### PR TITLE
feat(PROD-59): auth system — signup, API keys, auth middleware

### DIFF
--- a/migrations/0002_add_auth_columns.sql
+++ b/migrations/0002_add_auth_columns.sql
@@ -1,0 +1,5 @@
+-- Migration: Add email and password_hash to workspaces
+-- For PROD-59: Auth system
+
+ALTER TABLE workspaces ADD COLUMN email TEXT NOT NULL UNIQUE;
+ALTER TABLE workspaces ADD COLUMN password_hash TEXT NOT NULL;

--- a/packages/api/src/__tests__/auth.test.ts
+++ b/packages/api/src/__tests__/auth.test.ts
@@ -1,0 +1,64 @@
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+import authRoutes from '../routes/auth';
+
+describe('POST /v1/auth/signup', () => {
+  it('should return 400 for invalid email', async () => {
+    const app = new Hono().route('/v1/auth', authRoutes);
+    const res = await app.request('/v1/auth/signup', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'invalid', password: 'password123' }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toHaveProperty('error');
+  });
+
+  it('should return 400 for short password', async () => {
+    const app = new Hono().route('/v1/auth', authRoutes);
+    const res = await app.request('/v1/auth/signup', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'test@example.com', password: 'short' }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('should return 400 for missing email', async () => {
+    const app = new Hono().route('/v1/auth', authRoutes);
+    const res = await app.request('/v1/auth/signup', {
+      method: 'POST',
+      body: JSON.stringify({ password: 'password123' }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('GET /v1/auth/keys', () => {
+  it('should return 401 without auth', async () => {
+    const app = new Hono().route('/v1/auth', authRoutes);
+    const res = await app.request('/v1/auth/keys');
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('POST /v1/auth/keys', () => {
+  it('should return 401 without auth', async () => {
+    const app = new Hono().route('/v1/auth', authRoutes);
+    const res = await app.request('/v1/auth/keys', {
+      method: 'POST',
+      body: JSON.stringify({ name: 'Test Key' }),
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('DELETE /v1/auth/keys/:id', () => {
+  it('should return 401 without auth', async () => {
+    const app = new Hono().route('/v1/auth', authRoutes);
+    const res = await app.request('/v1/auth/keys/key_123', { method: 'DELETE' });
+    expect(res.status).toBe(401);
+  });
+});

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_TIERS, getTierBySlug } from '@hookwing/shared';
 import { Hono } from 'hono';
+import authRoutes from './routes/auth';
 
 type Bindings = {
   DB?: D1Database;
@@ -43,6 +44,9 @@ app.get('/tiers/:slug', (c) => {
 
   return c.json(tier);
 });
+
+// Mount auth routes at /v1/auth/*
+app.route('/v1/auth', authRoutes);
 
 app.notFound((c) => {
   return c.json({ error: 'Not found', status: 404 }, 404);

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -1,0 +1,137 @@
+import { type Workspace, apiKeys, workspaces } from '@hookwing/shared';
+import { verifyApiKey } from '@hookwing/shared';
+import type { Context, MiddlewareHandler } from 'hono';
+import { createDb } from '../db';
+
+/**
+ * Extended context with auth info
+ */
+export interface AuthContext {
+  workspace: Workspace;
+  apiKey: {
+    id: string;
+    name: string;
+    keyPrefix: string;
+    scopes: string[] | null;
+  };
+}
+
+/**
+ * Extract and verify API key from Authorization header
+ *
+ * Sets on context:
+ * - c.set('workspace', workspace)
+ * - c.set('apiKey', apiKey info)
+ */
+export const authMiddleware: MiddlewareHandler<{ Bindings: { DB: D1Database } }> = async (
+  c,
+  next,
+) => {
+  const authHeader = c.req.header('Authorization');
+
+  if (!authHeader) {
+    return c.json({ error: 'Unauthorized', message: 'Missing Authorization header' }, 401);
+  }
+
+  // Expect "Bearer hk_live_..."
+  const [scheme, key] = authHeader.split(' ');
+  if (scheme !== 'Bearer' || !key) {
+    return c.json({ error: 'Unauthorized', message: 'Invalid Authorization header format' }, 401);
+  }
+
+  // Extract prefix (first 12 chars: hk_live_xxx)
+  if (key.length < 12) {
+    return c.json({ error: 'Unauthorized', message: 'Invalid API key format' }, 401);
+  }
+
+  const prefix = key.substring(0, 12);
+
+  // Look up key in DB
+  const db = createDb(c.env.DB);
+  const keyRecord = await db
+    .select()
+    .from(apiKeys)
+    .where(apiKeys.keyPrefix.equals(prefix))
+    .limit(1)
+    .then((rows) => rows[0]);
+
+  if (!keyRecord) {
+    return c.json({ error: 'Unauthorized', message: 'Invalid API key' }, 401);
+  }
+
+  // Check if key is active
+  if (!keyRecord.isActive) {
+    return c.json({ error: 'Unauthorized', message: 'API key has been revoked' }, 401);
+  }
+
+  // Check expiration
+  if (keyRecord.expiresAt && keyRecord.expiresAt < Date.now()) {
+    return c.json({ error: 'Unauthorized', message: 'API key has expired' }, 401);
+  }
+
+  // Verify key hash
+  const isValid = await verifyApiKey(key, keyRecord.keyHash);
+  if (!isValid) {
+    return c.json({ error: 'Unauthorized', message: 'Invalid API key' }, 401);
+  }
+
+  // Look up workspace
+  const workspace = await db
+    .select()
+    .from(workspaces)
+    .where(workspaces.id.equals(keyRecord.workspaceId))
+    .limit(1)
+    .then((rows) => rows[0]);
+
+  if (!workspace) {
+    return c.json({ error: 'Unauthorized', message: 'Workspace not found' }, 401);
+  }
+
+  // Update last used timestamp
+  await db.update(apiKeys).set({ lastUsedAt: Date.now() }).where(apiKeys.id.equals(keyRecord.id));
+
+  // Parse scopes
+  let scopes: string[] | null = null;
+  if (keyRecord.scopes) {
+    try {
+      scopes = JSON.parse(keyRecord.scopes);
+    } catch {
+      scopes = null;
+    }
+  }
+
+  // Set on context
+  c.set('workspace', workspace);
+  c.set('apiKey', {
+    id: keyRecord.id,
+    name: keyRecord.name,
+    keyPrefix: keyRecord.keyPrefix,
+    scopes,
+  });
+
+  await next();
+};
+
+/**
+ * Helper to get the authenticated workspace from context
+ * @throws Error if workspace is not set (should only happen if auth middleware was not applied)
+ */
+export function getWorkspace(c: Context): Workspace {
+  const workspace = c.get('workspace');
+  if (!workspace) {
+    throw new Error('Workspace not found in context - auth middleware may not have run');
+  }
+  return workspace;
+}
+
+/**
+ * Helper to get the authenticated API key info from context
+ * @throws Error if apiKey is not set (should only happen if auth middleware was not applied)
+ */
+export function getApiKey(c: Context): AuthContext['apiKey'] {
+  const apiKey = c.get('apiKey');
+  if (!apiKey) {
+    throw new Error('API key not found in context - auth middleware may not have run');
+  }
+  return apiKey;
+}

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -1,0 +1,228 @@
+import {
+  apiKeys,
+  generateApiKey,
+  generateId,
+  getTierBySlug,
+  hashPassword,
+  workspaces,
+} from '@hookwing/shared';
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { createDb } from '../db';
+import { authMiddleware, getApiKey, getWorkspace } from '../middleware/auth';
+
+const auth = new Hono<{ Bindings: { DB?: D1Database } }>();
+
+// ============================================================================
+// Validation schemas
+// ============================================================================
+
+const signupSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8),
+  workspaceName: z.string().min(1).optional(),
+});
+
+const createKeySchema = z.object({
+  name: z.string().min(1),
+  scopes: z.array(z.string()).optional(),
+});
+
+// ============================================================================
+// POST /v1/auth/signup - Create workspace + first API key
+// ============================================================================
+
+auth.post('/signup', async (c) => {
+  const body = await c.req.json();
+
+  // Validate input FIRST (before touching DB)
+  const parsed = signupSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: 'Invalid input', details: parsed.error.flatten() }, 400);
+  }
+
+  const { email, password, workspaceName } = parsed.data;
+
+  // Now we can safely access DB
+  const db = createDb(c.env.DB);
+
+  // Check for duplicate email
+  const existing = await db
+    .select()
+    .from(workspaces)
+    .where(workspaces.email.equals(email.toLowerCase()))
+    .limit(1);
+
+  if (existing.length > 0) {
+    return c.json({ error: 'Email already registered' }, 409);
+  }
+
+  // Generate workspace slug from email prefix
+  const emailPrefix = email
+    .split('@')[0]
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '');
+  const slug = `${emailPrefix}-${generateId('ws').substring(3, 8)}`;
+
+  // Hash password
+  const passwordHash = await hashPassword(password);
+
+  // Create workspace
+  const workspaceId = generateId('ws');
+  const now = Date.now();
+
+  await db.insert(workspaces).values({
+    id: workspaceId,
+    email: email.toLowerCase(),
+    passwordHash,
+    name: workspaceName || `${email.split('@')[0]}'s Workspace`,
+    slug,
+    tierSlug: 'paper-plane',
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  // Generate first API key
+  const keyData = await generateApiKey();
+  const keyId = generateId('key');
+
+  await db.insert(apiKeys).values({
+    id: keyId,
+    workspaceId,
+    name: 'Default',
+    keyHash: keyData.hash,
+    keyPrefix: keyData.prefix,
+    scopes: null,
+    isActive: 1,
+    createdAt: now,
+  });
+
+  // Get tier info
+  const tier = getTierBySlug('paper-plane');
+
+  return c.json(
+    {
+      workspace: {
+        id: workspaceId,
+        name: workspaceName || `${email.split('@')[0]}'s Workspace`,
+        slug,
+        tier: tier,
+      },
+      apiKey: keyData.key, // Raw key returned ONLY on creation
+    },
+    201,
+  );
+});
+
+// ============================================================================
+// POST /v1/auth/keys - Create additional API key (authenticated)
+// ============================================================================
+
+auth.post('/keys', authMiddleware, async (c) => {
+  const workspace = getWorkspace(c);
+  const db = createDb(c.env.DB);
+  const body = await c.req.json();
+
+  // Validate input
+  const parsed = createKeySchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: 'Invalid input', details: parsed.error.flatten() }, 400);
+  }
+
+  const { name, scopes } = parsed.data;
+
+  // Generate API key
+  const keyData = await generateApiKey();
+  const keyId = generateId('key');
+  const now = Date.now();
+
+  await db.insert(apiKeys).values({
+    id: keyId,
+    workspaceId: workspace.id,
+    name,
+    keyHash: keyData.hash,
+    keyPrefix: keyData.prefix,
+    scopes: scopes ? JSON.stringify(scopes) : null,
+    isActive: 1,
+    createdAt: now,
+  });
+
+  return c.json(
+    {
+      apiKey: {
+        id: keyId,
+        name,
+        prefix: keyData.prefix,
+        scopes,
+      },
+      key: keyData.key, // Raw key returned ONLY on creation
+    },
+    201,
+  );
+});
+
+// ============================================================================
+// GET /v1/auth/keys - List API keys for workspace (authenticated)
+// ============================================================================
+
+auth.get('/keys', authMiddleware, async (c) => {
+  const workspace = getWorkspace(c);
+  const db = createDb(c.env.DB);
+
+  const keys = await db.select().from(apiKeys).where(apiKeys.workspaceId.equals(workspace.id));
+
+  // Return keys WITHOUT raw key
+  return c.json({
+    keys: keys.map((key) => ({
+      id: key.id,
+      name: key.name,
+      prefix: key.keyPrefix,
+      scopes: key.scopes ? JSON.parse(key.scopes) : null,
+      lastUsedAt: key.lastUsedAt,
+      expiresAt: key.expiresAt,
+      isActive: Boolean(key.isActive),
+      createdAt: key.createdAt,
+    })),
+  });
+});
+
+// ============================================================================
+// DELETE /v1/auth/keys/:id - Revoke API key (authenticated)
+// ============================================================================
+
+auth.delete('/keys/:id', authMiddleware, async (c) => {
+  const workspace = getWorkspace(c);
+  const apiKey = getApiKey(c);
+  const keyId = c.req.param('id');
+  const db = createDb(c.env.DB);
+
+  // Find the key
+  const key = await db
+    .select()
+    .from(apiKeys)
+    .where(apiKeys.id.equals(keyId))
+    .limit(1)
+    .then((rows) => rows[0]);
+
+  if (!key || key.workspaceId !== workspace.id) {
+    return c.json({ error: 'API key not found' }, 404);
+  }
+
+  // Check if it's the last active key
+  const activeKeys = await db
+    .select()
+    .from(apiKeys)
+    .where(apiKeys.workspaceId.equals(workspace.id))
+    .and(apiKeys.isActive.equals(1));
+
+  if (activeKeys.length === 1 && activeKeys[0].id === keyId) {
+    return c.json({ error: 'Cannot delete the last active API key' }, 400);
+  }
+
+  // Soft delete
+  await db.update(apiKeys).set({ isActive: 0 }).where(apiKeys.id.equals(keyId));
+
+  return c.json({ success: true });
+});
+
+export default auth;

--- a/packages/shared/src/__tests__/auth.test.ts
+++ b/packages/shared/src/__tests__/auth.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+import {
+  generateApiKey,
+  generateId,
+  hashApiKey,
+  hashPassword,
+  verifyApiKey,
+  verifyPassword,
+} from '../auth';
+
+describe('generateApiKey', () => {
+  it('should generate key with hk_live_ prefix', async () => {
+    const { key } = await generateApiKey();
+    expect(key).toMatch(/^hk_live_[a-zA-Z0-9]{32}$/);
+  });
+
+  it('should generate unique keys', async () => {
+    const keys = new Set<string>();
+    for (let i = 0; i < 100; i++) {
+      const { key } = await generateApiKey();
+      keys.add(key);
+    }
+    expect(keys.size).toBe(100); // All unique
+  });
+
+  it('should return prefix of 12 characters', async () => {
+    const { key, prefix } = await generateApiKey();
+    expect(prefix).toBe(key.substring(0, 12));
+    expect(prefix).toMatch(/^hk_live_[a-zA-Z0-9]{4}$/);
+  });
+
+  it('should return valid SHA-256 hash', async () => {
+    const { key, hash } = await generateApiKey();
+    const expectedHash = await hashApiKey(key);
+    expect(hash).toBe(expectedHash);
+    expect(hash).toMatch(/^[a-f0-9]{64}$/);
+  });
+});
+
+describe('hashApiKey', () => {
+  it('should return SHA-256 hash in hex format', async () => {
+    const hash = await hashApiKey('test-key');
+    expect(hash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('should produce consistent hashes for same input', async () => {
+    const key = 'test-key-123';
+    const hash1 = await hashApiKey(key);
+    const hash2 = await hashApiKey(key);
+    expect(hash1).toBe(hash2);
+  });
+
+  it('should produce different hashes for different inputs', async () => {
+    const hash1 = await hashApiKey('key-1');
+    const hash2 = await hashApiKey('key-2');
+    expect(hash1).not.toBe(hash2);
+  });
+});
+
+describe('verifyApiKey', () => {
+  it('should return true for matching key and hash', async () => {
+    const { key, hash } = await generateApiKey();
+    const isValid = await verifyApiKey(key, hash);
+    expect(isValid).toBe(true);
+  });
+
+  it('should return false for non-matching key and hash', async () => {
+    const { hash } = await generateApiKey();
+    const isValid = await verifyApiKey('wrong-key', hash as string);
+    expect(isValid).toBe(false);
+  });
+
+  it('should return false for tampered hash', async () => {
+    const { key, hash } = await generateApiKey();
+    const tamperedHash = `${(hash as string).slice(0, -2)}ff`;
+    const isValid = await verifyApiKey(key, tamperedHash);
+    expect(isValid).toBe(false);
+  });
+});
+
+describe('hashPassword', () => {
+  it('should return a hash in salt:hash format', async () => {
+    const hash = await hashPassword('testpassword');
+    // Base64 can include = for padding
+    expect(hash).toMatch(/^[A-Za-z0-9+/]+=*:[A-Za-z0-9+/]+=*$/);
+  });
+
+  it('should produce different hashes for same password (due to random salt)', async () => {
+    const hash1 = await hashPassword('testpassword');
+    const hash2 = await hashPassword('testpassword');
+    expect(hash1).not.toBe(hash2);
+  });
+
+  it('should produce different hashes for different passwords', async () => {
+    const hash1 = await hashPassword('password1');
+    const hash2 = await hashPassword('password2');
+    expect(hash1).not.toBe(hash2);
+  });
+});
+
+describe('verifyPassword', () => {
+  it('should return true for correct password', async () => {
+    const password = 'mysecurepassword';
+    const hash = await hashPassword(password);
+    const isValid = await verifyPassword(password, hash);
+    expect(isValid).toBe(true);
+  });
+
+  it('should return false for incorrect password', async () => {
+    const hash = await hashPassword('correctpassword');
+    const isValid = await verifyPassword('wrongpassword', hash);
+    expect(isValid).toBe(false);
+  });
+
+  it('should return false for tampered hash', async () => {
+    const password = 'testpassword';
+    const hash = await hashPassword(password);
+    const tamperedHash = `${hash.slice(0, -2)}==`;
+    const isValid = await verifyPassword(password, tamperedHash);
+    expect(isValid).toBe(false);
+  });
+
+  it('should return false for malformed hash', async () => {
+    const isValid = await verifyPassword('password', 'invalid-hash');
+    expect(isValid).toBe(false);
+  });
+});
+
+describe('generateId', () => {
+  it('should generate ID with correct prefix', () => {
+    const id = generateId('ws');
+    expect(id).toMatch(/^ws_[a-zA-Z0-9]{16}$/);
+  });
+
+  it('should generate unique IDs', () => {
+    const ids = new Set<string>();
+    for (let i = 0; i < 100; i++) {
+      ids.add(generateId('ws'));
+    }
+    expect(ids.size).toBe(100);
+  });
+
+  it('should work with different prefixes', () => {
+    expect(generateId('key')).toMatch(/^key_[a-zA-Z0-9]{16}$/);
+    expect(generateId('evt')).toMatch(/^evt_[a-zA-Z0-9]{16}$/);
+    expect(generateId('ep')).toMatch(/^ep_[a-zA-Z0-9]{16}$/);
+  });
+});

--- a/packages/shared/src/auth/ids.ts
+++ b/packages/shared/src/auth/ids.ts
@@ -1,0 +1,30 @@
+/**
+ * ID generation utilities
+ *
+ * Format: <prefix>_<random chars>
+ * Uses crypto.getRandomValues for secure random generation
+ */
+
+const ID_LENGTH = 16;
+const CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+
+/**
+ * Generate a cryptographically secure ID with a prefix
+ * @param prefix - The prefix for the ID (e.g., 'ws', 'key', 'evt')
+ * @returns A unique ID like 'ws_abc123...'
+ */
+export function generateId(prefix: string): string {
+  const bytes = new Uint8Array(ID_LENGTH);
+  crypto.getRandomValues(bytes);
+
+  const charsArray = CHARS.split('');
+  let randomPart = '';
+  for (let i = 0; i < ID_LENGTH; i++) {
+    const byte = bytes[i];
+    if (byte === undefined) continue;
+    const charIndex = byte % charsArray.length;
+    randomPart += charsArray[charIndex] as string;
+  }
+
+  return `${prefix}_${randomPart}`;
+}

--- a/packages/shared/src/auth/index.ts
+++ b/packages/shared/src/auth/index.ts
@@ -1,0 +1,3 @@
+export { generateApiKey, hashApiKey, verifyApiKey } from './keys';
+export { hashPassword, verifyPassword } from './passwords';
+export { generateId } from './ids';

--- a/packages/shared/src/auth/keys.ts
+++ b/packages/shared/src/auth/keys.ts
@@ -1,0 +1,70 @@
+/**
+ * API Key generation utilities
+ *
+ * Format: hk_live_<32 random chars>
+ * - prefix: first 12 chars (hk_live_abc...)
+ * - hash: SHA-256 of full key (stored in DB)
+ */
+
+const KEY_PREFIX = 'hk_live_';
+const KEY_LENGTH = 32;
+const PREFIX_LENGTH = 12; // hk_live_ + 4 random chars
+
+/**
+ * Generate a cryptographically secure API key
+ * Returns the raw key (for display once), prefix (for lookup), and hash (for storage)
+ */
+export async function generateApiKey(): Promise<{
+  key: string;
+  prefix: string;
+  hash: string;
+}> {
+  const randomBytes = new Uint8Array(KEY_LENGTH);
+  crypto.getRandomValues(randomBytes);
+
+  // Convert to base62-like string (alphanumeric, uppercase)
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  const charsArray = chars.split('');
+  let randomPart = '';
+  for (let i = 0; i < KEY_LENGTH; i++) {
+    const byte = randomBytes[i];
+    if (byte === undefined) continue;
+    const charIndex = byte % charsArray.length;
+    randomPart += charsArray[charIndex] as string;
+  }
+
+  const key = KEY_PREFIX + randomPart;
+  const prefix = key.substring(0, PREFIX_LENGTH); // hk_live_ + first 4 chars
+
+  const hash = await hashApiKey(key);
+
+  return {
+    key,
+    prefix,
+    hash,
+  };
+}
+
+/**
+ * Hash an API key using SHA-256
+ * @param key - The raw API key to hash
+ * @returns SHA-256 hash as a hex string
+ */
+export async function hashApiKey(key: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(key);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * Verify an API key against a stored hash
+ * @param key - The raw API key to verify
+ * @param storedHash - The stored SHA-256 hash
+ * @returns matches
+ */
+export async function verifyApiKey(key: string, storedHash: string): Promise<boolean> {
+  const hash = await hashApiKey(key);
+  return hash === storedHash;
+}

--- a/packages/shared/src/auth/passwords.ts
+++ b/packages/shared/src/auth/passwords.ts
@@ -1,0 +1,102 @@
+/**
+ * Password hashing utilities
+ *
+ * Uses PBKDF2 with SHA-256 and 100,000 iterations
+ * Compatible with Cloudflare Workers (Web Crypto API)
+ */
+
+const PBKDF2_ITERATIONS = 100_000;
+const SALT_LENGTH = 16;
+const HASH_LENGTH = 32;
+
+/**
+ * Hash a password using PBKDF2-SHA256
+ * @param password - The plain text password
+ * @returns Salted hash in format: base64(salt):base64(hash)
+ */
+export async function hashPassword(password: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const passwordBuffer = encoder.encode(password);
+
+  // Generate a random salt
+  const salt = new Uint8Array(SALT_LENGTH);
+  crypto.getRandomValues(salt);
+
+  // Derive the key using PBKDF2
+  const keyBuffer = await crypto.subtle.importKey('raw', passwordBuffer, 'PBKDF2', false, [
+    'deriveBits',
+  ]);
+
+  const derivedBits = await crypto.subtle.deriveBits(
+    {
+      name: 'PBKDF2',
+      salt,
+      iterations: PBKDF2_ITERATIONS,
+      hash: 'SHA-256',
+    },
+    keyBuffer,
+    HASH_LENGTH * 8,
+  );
+
+  const hash = new Uint8Array(derivedBits);
+
+  // Convert to base64 for storage
+  const saltBase64 = btoa(String.fromCharCode(...salt));
+  const hashBase64 = btoa(String.fromCharCode(...hash));
+
+  return `${saltBase64}:${hashBase64}`;
+}
+
+/**
+ * Verify a password against a stored hash
+ * @param password - The plain text password to verify
+ * @param storedHash - The stored hash (salt:hash format)
+ * @returns true if the password matches
+ */
+export async function verifyPassword(password: string, storedHash: string): Promise<boolean> {
+  const encoder = new TextEncoder();
+  const passwordBuffer = encoder.encode(password);
+
+  // Parse the stored hash
+  const [saltBase64, hashBase64] = storedHash.split(':');
+  if (!saltBase64 || !hashBase64) {
+    return false;
+  }
+
+  const salt = Uint8Array.from(atob(saltBase64), (c) => c.charCodeAt(0));
+  const expectedHash = Uint8Array.from(atob(hashBase64), (c) => c.charCodeAt(0));
+
+  // Derive the key using the same parameters
+  const keyBuffer = await crypto.subtle.importKey('raw', passwordBuffer, 'PBKDF2', false, [
+    'deriveBits',
+  ]);
+
+  const derivedBits = await crypto.subtle.deriveBits(
+    {
+      name: 'PBKDF2',
+      salt,
+      iterations: PBKDF2_ITERATIONS,
+      hash: 'SHA-256',
+    },
+    keyBuffer,
+    HASH_LENGTH * 8,
+  );
+
+  const derivedHash = new Uint8Array(derivedBits);
+
+  // Constant-time comparison
+  if (derivedHash.length !== expectedHash.length) {
+    return false;
+  }
+
+  let result = 0;
+  for (let i = 0; i < derivedHash.length; i++) {
+    const dh = derivedHash[i];
+    const eh = expectedHash[i];
+    if (dh !== undefined && eh !== undefined) {
+      result |= dh ^ eh;
+    }
+  }
+
+  return result === 0;
+}

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -6,6 +6,8 @@ import { index, integer, sqliteTable, text, uniqueIndex } from 'drizzle-orm/sqli
 
 export const workspaces = sqliteTable('workspaces', {
   id: text('id').primaryKey(),
+  email: text('email').notNull().unique(),
+  passwordHash: text('password_hash').notNull(),
   name: text('name').notNull(),
   slug: text('slug').notNull().unique(),
   tierSlug: text('tier_slug').notNull().default('paper-plane'),

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,4 @@
 export * from './types';
 export * from './config';
 export * from './db';
+export * from './auth';


### PR DESCRIPTION
## What

Full auth system for the Hookwing API. Agent-first: no 2FA, no CAPTCHA, no email verification.

### Auth utilities (`packages/shared/src/auth/`)
- **API key generation** — `hk_live_` prefix + 32 random chars, SHA-256 hashed for storage
- **Password hashing** — PBKDF2-SHA256, 100k iterations (CF Workers compatible, no bcrypt)
- **ID generation** — prefixed nanoid (`ws_`, `key_`, etc.)

### Auth middleware (`packages/api/src/middleware/auth.ts`)
- Bearer token extraction from `Authorization` header
- Key lookup by prefix, hash verification
- Sets `workspace` and `apiKey` on Hono context
- Updates `lastUsedAt` on each use

### Endpoints (`packages/api/src/routes/auth.ts`)
- `POST /v1/auth/signup` — create workspace + first API key (returns raw key only on creation)
- `POST /v1/auth/keys` — create additional API keys (authenticated)
- `GET /v1/auth/keys` — list keys for workspace (no raw keys exposed)
- `DELETE /v1/auth/keys/:id` — revoke key (soft delete, can't delete last active key)

### Schema update
- Added `email` (unique) and `passwordHash` columns to `workspaces` table
- Migration: `migrations/0002_add_auth_columns.sql`

### Tests
- 19 API tests passing (health + tiers + auth)
- Shared auth unit tests (key generation, password hashing, ID generation)
- All `npx turbo test` green

### Security
- Raw API keys never stored — only SHA-256 hash
- Passwords hashed with PBKDF2 (100k iterations)
- No secrets in code
- Scoped keys supported (JSON array of allowed scopes)