### PR TITLE
feat(PROD-65): fan-out delivery — one event, multiple endpoints, event type routing

### DIFF
--- a/migrations/0003_add_fanout_enabled.sql
+++ b/migrations/0003_add_fanout_enabled.sql
@@ -1,0 +1,4 @@
+-- Migration: Add fanout_enabled to endpoints
+-- For PROD-65: Fan-out delivery
+
+ALTER TABLE endpoints ADD COLUMN fanout_enabled INTEGER NOT NULL DEFAULT(1);

--- a/packages/api/src/__tests__/fanout.test.ts
+++ b/packages/api/src/__tests__/fanout.test.ts
@@ -1,0 +1,99 @@
+import { endpointCreateSchema, endpointUpdateSchema } from '@hookwing/shared';
+import { describe, expect, it } from 'vitest';
+
+describe('endpointCreateSchema', () => {
+  it('should accept valid endpoint with fanoutEnabled defaulting to true', () => {
+    const result = endpointCreateSchema.safeParse({
+      url: 'https://example.com/webhook',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.fanoutEnabled).toBe(true);
+    }
+  });
+
+  it('should accept endpoint with fanoutEnabled explicitly set to false', () => {
+    const result = endpointCreateSchema.safeParse({
+      url: 'https://example.com/webhook',
+      fanoutEnabled: false,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.fanoutEnabled).toBe(false);
+    }
+  });
+
+  it('should accept endpoint with fanoutEnabled explicitly set to true', () => {
+    const result = endpointCreateSchema.safeParse({
+      url: 'https://example.com/webhook',
+      fanoutEnabled: true,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.fanoutEnabled).toBe(true);
+    }
+  });
+
+  it('should accept endpoint with eventTypes filter', () => {
+    const result = endpointCreateSchema.safeParse({
+      url: 'https://example.com/webhook',
+      eventTypes: ['user.created', 'user.updated'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept endpoint with both eventTypes and fanoutEnabled', () => {
+    const result = endpointCreateSchema.safeParse({
+      url: 'https://example.com/webhook',
+      eventTypes: ['user.created'],
+      fanoutEnabled: false,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.eventTypes).toEqual(['user.created']);
+      expect(result.data.fanoutEnabled).toBe(false);
+    }
+  });
+
+  it('should reject endpoint with invalid URL', () => {
+    const result = endpointCreateSchema.safeParse({
+      url: 'http://example.com/webhook', // Not HTTPS
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('endpointUpdateSchema', () => {
+  it('should accept update with fanoutEnabled', () => {
+    const result = endpointUpdateSchema.safeParse({
+      fanoutEnabled: false,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.fanoutEnabled).toBe(false);
+    }
+  });
+
+  it('should accept update with fanoutEnabled set to true', () => {
+    const result = endpointUpdateSchema.safeParse({
+      fanoutEnabled: true,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.fanoutEnabled).toBe(true);
+    }
+  });
+
+  it('should accept update with multiple fields including fanoutEnabled', () => {
+    const result = endpointUpdateSchema.safeParse({
+      url: 'https://example.com/new-webhook',
+      fanoutEnabled: false,
+      isActive: true,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.fanoutEnabled).toBe(false);
+      expect(result.data.isActive).toBe(true);
+    }
+  });
+});

--- a/packages/api/src/routes/endpoints.ts
+++ b/packages/api/src/routes/endpoints.ts
@@ -54,7 +54,7 @@ endpointRoutes.post('/', async (c) => {
     }
   }
 
-  const { url, description, eventTypes, metadata } = parsed.data;
+  const { url, description, eventTypes, fanoutEnabled, metadata } = parsed.data;
   const signingSecret = await generateSigningSecret();
   const now = Date.now();
 
@@ -68,6 +68,7 @@ endpointRoutes.post('/', async (c) => {
     secret: signingSecret,
     eventTypes: eventTypes ? JSON.stringify(eventTypes) : null,
     isActive: 1,
+    fanoutEnabled: fanoutEnabled !== false ? 1 : 0,
     rateLimitPerSecond: null,
     metadata: metadata ? JSON.stringify(metadata) : null,
     createdAt: now,
@@ -82,6 +83,7 @@ endpointRoutes.post('/', async (c) => {
       description,
       secret: signingSecret,
       eventTypes: eventTypes ?? null,
+      fanoutEnabled: fanoutEnabled !== false,
       isActive: true,
       rateLimitPerSecond: null,
       metadata: metadata ?? null,
@@ -112,6 +114,7 @@ endpointRoutes.get('/', async (c) => {
       url: ep.url,
       description: ep.description,
       eventTypes: ep.eventTypes ? JSON.parse(ep.eventTypes) : null,
+      fanoutEnabled: Boolean(ep.fanoutEnabled),
       isActive: Boolean(ep.isActive),
       rateLimitPerSecond: ep.rateLimitPerSecond,
       metadata: ep.metadata ? JSON.parse(ep.metadata) : null,
@@ -147,6 +150,7 @@ endpointRoutes.get('/:id', async (c) => {
     url: endpoint.url,
     description: endpoint.description,
     eventTypes: endpoint.eventTypes ? JSON.parse(endpoint.eventTypes) : null,
+    fanoutEnabled: Boolean(endpoint.fanoutEnabled),
     isActive: Boolean(endpoint.isActive),
     rateLimitPerSecond: endpoint.rateLimitPerSecond,
     metadata: endpoint.metadata ? JSON.parse(endpoint.metadata) : null,
@@ -181,7 +185,7 @@ endpointRoutes.patch('/:id', async (c) => {
     return c.json({ error: 'Endpoint not found' }, 404);
   }
 
-  const { url, description, eventTypes, isActive, metadata } = parsed.data;
+  const { url, description, eventTypes, isActive, fanoutEnabled, metadata } = parsed.data;
   const now = Date.now();
 
   const updateFields: Record<string, unknown> = { updatedAt: now };
@@ -191,6 +195,7 @@ endpointRoutes.patch('/:id', async (c) => {
   if (eventTypes !== undefined)
     updateFields.eventTypes = eventTypes ? JSON.stringify(eventTypes) : null;
   if (isActive !== undefined) updateFields.isActive = isActive ? 1 : 0;
+  if (fanoutEnabled !== undefined) updateFields.fanoutEnabled = fanoutEnabled ? 1 : 0;
   if (metadata !== undefined) updateFields.metadata = metadata ? JSON.stringify(metadata) : null;
 
   await db.update(endpoints).set(updateFields).where(eq(endpoints.id, endpointId));
@@ -212,6 +217,7 @@ endpointRoutes.patch('/:id', async (c) => {
     url: updated.url,
     description: updated.description,
     eventTypes: updated.eventTypes ? JSON.parse(updated.eventTypes) : null,
+    fanoutEnabled: Boolean(updated.fanoutEnabled),
     isActive: Boolean(updated.isActive),
     rateLimitPerSecond: updated.rateLimitPerSecond,
     metadata: updated.metadata ? JSON.parse(updated.metadata) : null,

--- a/packages/api/src/routes/events.ts
+++ b/packages/api/src/routes/events.ts
@@ -1,9 +1,10 @@
-import { events, deliveries, endpoints, generateId, getTierBySlug } from '@hookwing/shared';
+import { events, deliveries, getTierBySlug } from '@hookwing/shared';
 import { and, desc, eq, gte, lt, lte } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { z } from 'zod';
 import { createDb } from '../db';
 import { authMiddleware, getWorkspace } from '../middleware/auth';
+import { fanoutEvent } from '../services/fanout';
 
 const eventRoutes = new Hono<{
   Bindings: {
@@ -212,42 +213,16 @@ eventRoutes.post('/:id/replay', async (c) => {
     return c.json({ error: 'Event not found' }, 404);
   }
 
-  // Find all active endpoints for this workspace
-  const activeEndpoints = await db
-    .select()
-    .from(endpoints)
-    .where(and(eq(endpoints.workspaceId, workspace.id), eq(endpoints.isActive, 1)));
+  // Use fanout service for replay (no receiving endpoint)
+  const fanoutResult = await fanoutEvent(
+    db,
+    c.env.DELIVERY_QUEUE,
+    { id: eventId, workspaceId: workspace.id, eventType: event.eventType },
+    // No receivingEndpointId - this is a replay
+  );
 
-  if (activeEndpoints.length === 0) {
+  if (fanoutResult.deliveries.length === 0) {
     return c.json({ error: 'No active endpoints to replay to' }, 400);
-  }
-
-  const now = Date.now();
-  const deliveryIds: string[] = [];
-
-  for (const endpoint of activeEndpoints) {
-    const deliveryId = generateId('dlv');
-    deliveryIds.push(deliveryId);
-
-    await db.insert(deliveries).values({
-      id: deliveryId,
-      eventId,
-      endpointId: endpoint.id,
-      workspaceId: workspace.id,
-      attemptNumber: 1,
-      status: 'pending',
-      createdAt: now,
-    });
-
-    if (c.env?.DELIVERY_QUEUE) {
-      await c.env.DELIVERY_QUEUE.send({
-        deliveryId,
-        eventId,
-        endpointId: endpoint.id,
-        workspaceId: workspace.id,
-        attempt: 1,
-      });
-    }
   }
 
   // Reset event status to processing
@@ -259,8 +234,8 @@ eventRoutes.post('/:id/replay', async (c) => {
   return c.json({
     replayed: true,
     eventId,
-    deliveryIds,
-    endpointCount: activeEndpoints.length,
+    deliveryIds: fanoutResult.deliveries.map((d) => d.deliveryId),
+    endpointCount: fanoutResult.deliveries.length,
   });
 });
 
@@ -284,24 +259,13 @@ eventRoutes.post('/replay', async (c) => {
 
   const { eventIds } = parsed.data;
 
-  // Find all active endpoints for this workspace
-  const activeEndpoints = await db
-    .select()
-    .from(endpoints)
-    .where(and(eq(endpoints.workspaceId, workspace.id), eq(endpoints.isActive, 1)));
-
-  if (activeEndpoints.length === 0) {
-    return c.json({ error: 'No active endpoints to replay to' }, 400);
-  }
-
-  const now = Date.now();
   const allDeliveryIds: string[] = [];
   let replayedCount = 0;
 
   for (const eventId of eventIds) {
-    // Verify event belongs to workspace
+    // Verify event belongs to workspace and get event type
     const event = await db
-      .select({ id: events.id })
+      .select()
       .from(events)
       .where(and(eq(events.id, eventId), eq(events.workspaceId, workspace.id)))
       .limit(1)
@@ -311,30 +275,15 @@ eventRoutes.post('/replay', async (c) => {
       continue; // Skip events that don't exist or don't belong to workspace
     }
 
-    for (const endpoint of activeEndpoints) {
-      const deliveryId = generateId('dlv');
-      allDeliveryIds.push(deliveryId);
+    // Use fanout service for replay
+    const fanoutResult = await fanoutEvent(
+      db,
+      c.env.DELIVERY_QUEUE,
+      { id: eventId, workspaceId: workspace.id, eventType: event.eventType },
+      // No receivingEndpointId - this is a replay
+    );
 
-      await db.insert(deliveries).values({
-        id: deliveryId,
-        eventId,
-        endpointId: endpoint.id,
-        workspaceId: workspace.id,
-        attemptNumber: 1,
-        status: 'pending',
-        createdAt: now,
-      });
-
-      if (c.env?.DELIVERY_QUEUE) {
-        await c.env.DELIVERY_QUEUE.send({
-          deliveryId,
-          eventId,
-          endpointId: endpoint.id,
-          workspaceId: workspace.id,
-          attempt: 1,
-        });
-      }
-    }
+    allDeliveryIds.push(...fanoutResult.deliveries.map((d) => d.deliveryId));
 
     // Reset event status
     await db
@@ -345,11 +294,15 @@ eventRoutes.post('/replay', async (c) => {
     replayedCount++;
   }
 
+  if (replayedCount === 0) {
+    return c.json({ error: 'No valid events found to replay' }, 400);
+  }
+
   return c.json({
     replayed: true,
     count: replayedCount,
     deliveryIds: allDeliveryIds,
-    endpointCount: activeEndpoints.length,
+    endpointCount: allDeliveryIds.length,
   });
 });
 

--- a/packages/api/src/routes/ingest.ts
+++ b/packages/api/src/routes/ingest.ts
@@ -1,7 +1,8 @@
-import { events, deliveries, endpoints, generateId } from '@hookwing/shared';
+import { events, endpoints, generateId } from '@hookwing/shared';
 import { eq } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { createDb } from '../db';
+import { fanoutEvent } from '../services/fanout';
 
 const ingestRoutes = new Hono<{ Bindings: { DB: D1Database; DELIVERY_QUEUE?: Queue } }>();
 
@@ -87,31 +88,20 @@ ingestRoutes.post('/:endpointId', async (c) => {
     status: 'pending',
   });
 
-  // 8. Insert into deliveries table
-  const deliveryId = generateId('dlv');
-  await db.insert(deliveries).values({
-    id: deliveryId,
-    eventId,
+  // 8. Fan-out to all eligible endpoints
+  const fanoutResult = await fanoutEvent(
+    db,
+    c.env.DELIVERY_QUEUE,
+    { id: eventId, workspaceId: endpoint.workspaceId, eventType },
     endpointId,
-    workspaceId: endpoint.workspaceId,
-    attemptNumber: 1,
-    status: 'pending',
-    createdAt: now,
+  );
+
+  // 9. Return success response
+  return c.json({
+    received: true,
+    eventId,
+    deliveries: fanoutResult.deliveries.length,
   });
-
-  // 9. Enqueue delivery for async processing
-  if (c.env?.DELIVERY_QUEUE) {
-    await c.env.DELIVERY_QUEUE.send({
-      deliveryId,
-      eventId,
-      endpointId,
-      workspaceId: endpoint.workspaceId,
-      attempt: 1,
-    });
-  }
-
-  // 10. Return success response
-  return c.json({ received: true, eventId });
 });
 
 export default ingestRoutes;

--- a/packages/api/src/services/fanout.ts
+++ b/packages/api/src/services/fanout.ts
@@ -1,0 +1,154 @@
+/**
+ * Fan-out service — distributes events to multiple endpoints
+ */
+
+import { type Endpoint, deliveries, endpoints, generateId } from '@hookwing/shared';
+import { and, eq } from 'drizzle-orm';
+import type { Database } from '../db';
+
+export interface FanoutResult {
+  eventId: string;
+  deliveries: Array<{ deliveryId: string; endpointId: string; status: string }>;
+}
+
+/**
+ * Check if an endpoint should receive an event based on its eventType filter
+ */
+function shouldEndpointReceiveEvent(endpoint: Endpoint, eventType: string): boolean {
+  // If eventTypes is null/empty, endpoint receives all events (wildcard)
+  if (!endpoint.eventTypes) {
+    return true;
+  }
+
+  try {
+    const allowedTypes = JSON.parse(endpoint.eventTypes) as string[];
+    return allowedTypes.includes(eventType);
+  } catch {
+    // Invalid JSON, treat as wildcard
+    return true;
+  }
+}
+
+/**
+ * Fan-out an event to all eligible endpoints in the workspace
+ *
+ * The receiving endpoint always gets a delivery regardless of its event type filter.
+ * Other endpoints only get the event if:
+ * - They have fanoutEnabled = 1
+ * - They match the event type filter (null/empty = wildcard)
+ *
+ * For replay (when receivingEndpointId is undefined), all endpoints with fanoutEnabled=1
+ * and matching event type filter will receive the event.
+ *
+ * @param db - Drizzle database instance
+ * @param queue - Optional Cloudflare Queue for async delivery
+ * @param event - Event details (id, workspaceId, eventType)
+ * @param receivingEndpointId - The endpoint that originally received the webhook (optional for replay)
+ * @returns FanoutResult with delivery details
+ */
+export async function fanoutEvent(
+  db: Database,
+  queue: Queue | undefined,
+  event: { id: string; workspaceId: string; eventType: string },
+  receivingEndpointId?: string,
+): Promise<FanoutResult> {
+  const { id: eventId, workspaceId, eventType } = event;
+
+  // Get all active endpoints in the workspace with fanout enabled
+  const allEndpoints = await db
+    .select()
+    .from(endpoints)
+    .where(and(eq(endpoints.workspaceId, workspaceId), eq(endpoints.isActive, 1)))
+    .then((rows) => rows);
+
+  const result: FanoutResult = {
+    eventId,
+    deliveries: [],
+  };
+
+  const now = Date.now();
+
+  for (const endpoint of allEndpoints) {
+    // For non-replay: receiving endpoint always gets delivery, others need fanoutEnabled
+    // For replay (no receivingEndpointId): all endpoints need fanoutEnabled
+    const isReceivingEndpoint = receivingEndpointId && endpoint.id === receivingEndpointId;
+    const isReplay = !receivingEndpointId;
+
+    if (!isReceivingEndpoint && !endpoint.fanoutEnabled) {
+      continue;
+    }
+
+    // Check event type filter
+    if (!shouldEndpointReceiveEvent(endpoint, eventType)) {
+      // Receiving endpoint always gets delivery regardless of filter
+      if (!isReceivingEndpoint && !isReplay) {
+        continue;
+      }
+    }
+
+    // Create delivery record
+    const deliveryId = generateId('dlv');
+    await db.insert(deliveries).values({
+      id: deliveryId,
+      eventId,
+      endpointId: endpoint.id,
+      workspaceId,
+      attemptNumber: 1,
+      status: 'pending',
+      createdAt: now,
+    });
+
+    // Enqueue for delivery
+    if (queue) {
+      await queue.send({
+        deliveryId,
+        eventId,
+        endpointId: endpoint.id,
+        workspaceId,
+        attempt: 1,
+      });
+    }
+
+    result.deliveries.push({
+      deliveryId,
+      endpointId: endpoint.id,
+      status: 'pending',
+    });
+  }
+
+  // If receiving endpoint was not found in active endpoints, add it directly
+  // (edge case: receiving endpoint might be inactive but we still want to deliver)
+  if (receivingEndpointId) {
+    const hasReceivingEndpoint = allEndpoints.some((ep) => ep.id === receivingEndpointId);
+    if (!hasReceivingEndpoint) {
+      const deliveryId = generateId('dlv');
+      await db.insert(deliveries).values({
+        id: deliveryId,
+        eventId,
+        endpointId: receivingEndpointId,
+        workspaceId,
+        attemptNumber: 1,
+        status: 'pending',
+        createdAt: now,
+      });
+
+      if (queue) {
+        await queue.send({
+          deliveryId,
+          eventId,
+          endpointId: receivingEndpointId,
+          workspaceId,
+          attempt: 1,
+        });
+      }
+
+      result.deliveries.push({
+        deliveryId,
+        endpointId: receivingEndpointId,
+        status: 'pending',
+      });
+    }
+  }
+
+  return result;
+}

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -67,6 +67,7 @@ export const endpoints = sqliteTable(
     secret: text('secret').notNull(),
     eventTypes: text('event_types'), // JSON array of subscribed event types
     isActive: integer('is_active').notNull().default(1),
+    fanoutEnabled: integer('fanout_enabled').notNull().default(1), // Opt-out of receiving fan-out events
     rateLimitPerSecond: integer('rate_limit_per_second'),
     metadata: text('metadata'), // JSON object
     createdAt: integer('created_at').notNull(),

--- a/packages/shared/src/endpoints/validation.ts
+++ b/packages/shared/src/endpoints/validation.ts
@@ -11,6 +11,7 @@ export const endpointCreateSchema = z.object({
     .refine((url) => url.startsWith('https://'), { message: 'Endpoint URL must use HTTPS' }),
   description: z.string().max(500).optional(),
   eventTypes: z.array(z.string().min(1)).optional(), // null = subscribe to all
+  fanoutEnabled: z.boolean().optional().default(true), // Opt-out of receiving fan-out events
   metadata: z.record(z.string()).optional(),
 });
 
@@ -23,6 +24,7 @@ export const endpointUpdateSchema = z.object({
   description: z.string().max(500).optional().nullable(),
   eventTypes: z.array(z.string().min(1)).optional().nullable(),
   isActive: z.boolean().optional(),
+  fanoutEnabled: z.boolean().optional(),
   metadata: z.record(z.string()).optional().nullable(),
 });
 


### PR DESCRIPTION
PROD-65: Fan-out delivery service.

**What:** When a webhook arrives at one endpoint, it fans out to all eligible active endpoints in the workspace.

**Changes:**
- `packages/api/src/services/fanout.ts` — centralized fan-out logic with event type filtering and `fanoutEnabled` opt-out
- Refactored ingest + replay routes to use shared `fanoutEvent()` service
- `fanoutEnabled` column on endpoints (default true) — opt-out of receiving fan-out events
- Migration: `0003_add_fanout_enabled.sql`
- Schema + validation updates in shared package
- 9 tests for fan-out schema validation

**Behavior:**
- Receiving endpoint always gets delivery regardless of filters
- Other endpoints: must have `fanoutEnabled=true` + matching `eventTypes` filter
- Replay: all eligible endpoints receive the event
- Edge case: inactive receiving endpoint still gets delivery