### PR TITLE
feat(PROD-68): CLI package — hookwing command-line tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1173,6 +1173,10 @@
       "resolved": "packages/api",
       "link": true
     },
+    "node_modules/@hookwing/cli": {
+      "resolved": "packages/cli",
+      "link": true
+    },
     "node_modules/@hookwing/mcp": {
       "resolved": "packages/mcp",
       "link": true
@@ -1842,6 +1846,18 @@
         }
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1983,6 +1999,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/check-error": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
@@ -2007,6 +2035,42 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/confbox": {
@@ -2753,6 +2817,12 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -3135,6 +3205,18 @@
         "node": ">= 18.0.0"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -3324,11 +3406,35 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/isexe": {
       "version": "3.1.5",
@@ -3387,6 +3493,34 @@
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/log-symbols": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/loupe": {
       "version": "3.2.1",
@@ -3471,6 +3605,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mlly": {
@@ -3593,6 +3739,44 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/parseurl": {
@@ -3825,6 +4009,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/rollup": {
@@ -4152,6 +4352,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -4225,6 +4437,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/stoppable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
@@ -4234,6 +4458,38 @@
       "engines": {
         "node": ">=4",
         "npm": ">=6"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/strip-literal": {
@@ -5834,6 +6090,22 @@
         "@cloudflare/workers-types": {
           "optional": true
         }
+      }
+    },
+    "packages/cli": {
+      "name": "@hookwing/cli",
+      "version": "0.0.1",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.0.0",
+        "ora": "^8.0.0"
+      },
+      "bin": {
+        "hookwing": "dist/index.js"
+      },
+      "devDependencies": {
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0"
       }
     },
     "packages/mcp": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@hookwing/cli",
+  "version": "0.0.1",
+  "type": "module",
+  "bin": {
+    "hookwing": "./dist/index.js"
+  },
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "chalk": "^5.3.0",
+    "commander": "^12.0.0",
+    "ora": "^8.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/cli/src/__tests__/client.test.ts
+++ b/packages/cli/src/__tests__/client.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { HookwingClient } from '../client.js';
+
+describe('HookwingClient', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe('constructor', () => {
+    it('creates client with api key and base url', () => {
+      const client = new HookwingClient('test-key', 'https://api.example.com');
+      expect(client).toBeDefined();
+    });
+
+    it('strips trailing slash from base url', () => {
+      const client = new HookwingClient('test-key', 'https://api.example.com/');
+      expect(client).toBeDefined();
+    });
+  });
+
+  describe('listEndpoints', () => {
+    it('calls API and returns endpoints', async () => {
+      const mockEndpoints = [
+        {
+          id: 'ep1',
+          url: 'https://example.com/hook',
+          active: true,
+          eventTypes: ['test'],
+          description: '',
+          createdAt: '',
+          updatedAt: '',
+        },
+      ];
+
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockEndpoints),
+      });
+
+      const client = new HookwingClient('test-key', 'https://api.hookwing.com');
+      const result = await client.listEndpoints();
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.hookwing.com/v1/endpoints',
+        expect.objectContaining({
+          method: 'GET',
+          headers: expect.objectContaining({
+            Authorization: 'Bearer test-key',
+          }),
+        }),
+      );
+      expect(result).toEqual(mockEndpoints);
+    });
+
+    it('throws on non-2xx response', async () => {
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        text: () => Promise.resolve('Invalid API key'),
+      });
+
+      const client = new HookwingClient('invalid-key', 'https://api.hookwing.com');
+
+      await expect(client.listEndpoints()).rejects.toThrow('API error (401): Invalid API key');
+    });
+
+    it('throws on network error', async () => {
+      fetchMock.mockRejectedValue(new Error('Connection refused'));
+
+      const client = new HookwingClient('test-key', 'https://api.hookwing.com');
+
+      await expect(client.listEndpoints()).rejects.toThrow('Connection refused');
+    });
+  });
+
+  describe('createEndpoint', () => {
+    it('sends POST request with endpoint data', async () => {
+      const mockEndpoint = {
+        id: 'ep-new',
+        url: 'https://example.com/new',
+        active: true,
+        eventTypes: ['order.created'],
+        description: 'New endpoint',
+        createdAt: '2024-01-01',
+        updatedAt: '2024-01-01',
+      };
+
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockEndpoint),
+      });
+
+      const client = new HookwingClient('test-key', 'https://api.hookwing.com');
+      const result = await client.createEndpoint({
+        url: 'https://example.com/new',
+        description: 'New endpoint',
+        eventTypes: ['order.created'],
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.hookwing.com/v1/endpoints',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            url: 'https://example.com/new',
+            description: 'New endpoint',
+            eventTypes: ['order.created'],
+          }),
+        }),
+      );
+      expect(result).toEqual(mockEndpoint);
+    });
+  });
+
+  describe('deleteEndpoint', () => {
+    it('sends DELETE request', async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(undefined),
+      });
+
+      const client = new HookwingClient('test-key', 'https://api.hookwing.com');
+      await client.deleteEndpoint('ep-123');
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.hookwing.com/v1/endpoints/ep-123',
+        expect.objectContaining({
+          method: 'DELETE',
+        }),
+      );
+    });
+  });
+
+  describe('replayEvent', () => {
+    it('sends POST request to replay endpoint', async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ success: true }),
+      });
+
+      const client = new HookwingClient('test-key', 'https://api.hookwing.com');
+      const result = await client.replayEvent('evt-123');
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.hookwing.com/v1/events/evt-123/replay',
+        expect.objectContaining({
+          method: 'POST',
+        }),
+      );
+      expect(result).toEqual({ success: true });
+    });
+  });
+
+  describe('listDeliveries', () => {
+    it('passes query parameters correctly', async () => {
+      const mockDeliveries = [
+        {
+          id: 'del1',
+          endpointId: 'ep1',
+          endpointUrl: 'https://example.com',
+          status: 'success',
+          statusCode: 200,
+          attempts: 1,
+          response: null,
+          sentAt: null,
+          completedAt: null,
+        },
+      ];
+
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockDeliveries),
+      });
+
+      const client = new HookwingClient('test-key', 'https://api.hookwing.com');
+      await client.listDeliveries({ limit: 10, status: 'failed', endpointId: 'ep1' });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.hookwing.com/v1/deliveries?limit=10&status=failed&endpointId=ep1',
+        expect.any(Object),
+      );
+    });
+  });
+});

--- a/packages/cli/src/__tests__/config.test.ts
+++ b/packages/cli/src/__tests__/config.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+import { type Config, getApiKey } from '../config.js';
+
+describe('getApiKey', () => {
+  it('prefers env var over config', () => {
+    vi.stubEnv('HOOKWING_API_KEY', 'env-key-123');
+    const config: Config = {
+      apiKey: 'config-key-456',
+      baseUrl: 'https://api.hookwing.com',
+      format: 'table',
+    };
+    expect(getApiKey(config)).toBe('env-key-123');
+    vi.unstubAllEnvs();
+  });
+
+  it('falls back to config apiKey when env not set', () => {
+    vi.stubEnv('HOOKWING_API_KEY', '');
+    const config: Config = {
+      apiKey: 'config-key-789',
+      baseUrl: 'https://api.hookwing.com',
+      format: 'table',
+    };
+    expect(getApiKey(config)).toBe('config-key-789');
+    vi.unstubAllEnvs();
+  });
+
+  it('returns undefined when no key available', () => {
+    vi.stubEnv('HOOKWING_API_KEY', '');
+    const config: Config = {
+      apiKey: '',
+      baseUrl: 'https://api.hookwing.com',
+      format: 'table',
+    };
+    expect(getApiKey(config)).toBeUndefined();
+    vi.unstubAllEnvs();
+  });
+
+  it('handles missing env var gracefully', () => {
+    vi.stubEnv('HOOKWING_API_KEY', '');
+    const config: Config = {
+      apiKey: 'fallback-key',
+      baseUrl: 'https://api.hookwing.com',
+      format: 'table',
+    };
+    expect(getApiKey(config)).toBe('fallback-key');
+  });
+});

--- a/packages/cli/src/__tests__/output.test.ts
+++ b/packages/cli/src/__tests__/output.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { formatJson, formatTable } from '../output.js';
+
+describe('formatTable', () => {
+  it('produces aligned columns with separator', () => {
+    const headers = ['ID', 'Name', 'Status'];
+    const rows = [
+      ['abc123', 'Test One', 'active'],
+      ['def456', 'Longer Name Here', 'inactive'],
+    ];
+
+    const result = formatTable(headers, rows);
+    const lines = result.split('\n');
+
+    expect(lines.length).toBe(4); // header + separator + 2 data rows
+    expect(lines[0]).toContain('ID');
+    expect(lines[0]).toContain('Name');
+    expect(lines[0]).toContain('Status');
+    expect(lines[1]).toContain('-');
+    expect(lines[2]).toContain('abc123');
+    expect(lines[3]).toContain('Longer Name Here');
+  });
+
+  it('handles empty rows', () => {
+    const result = formatTable(['ID', 'Name'], []);
+    const lines = result.split('\n');
+    expect(lines.length).toBe(2); // header + separator only
+    expect(lines[0]).toContain('ID');
+    expect(lines[0]).toContain('Name');
+  });
+
+  it('handles missing values gracefully', () => {
+    const result = formatTable(['ID', 'Description'], [['abc123', '']]);
+    const lines = result.split('\n');
+    expect(lines.length).toBe(3);
+    expect(lines[2]).toContain('abc123');
+  });
+});
+
+describe('formatJson', () => {
+  it('produces valid JSON string', () => {
+    const data = { name: 'test', count: 42, active: true };
+    const result = formatJson(data);
+    const parsed = JSON.parse(result);
+    expect(parsed).toEqual(data);
+  });
+
+  it('formats with indentation', () => {
+    const data = { user: { id: '123' } };
+    const result = formatJson(data);
+    expect(result).toContain('\n');
+    expect(result).toContain('  ');
+  });
+
+  it('handles arrays', () => {
+    const data = ['one', 'two', 'three'];
+    const result = formatJson(data);
+    expect(JSON.parse(result)).toEqual(data);
+  });
+
+  it('handles null values', () => {
+    const data = { a: null };
+    const result = formatJson(data);
+    expect(JSON.parse(result).a).toBeNull();
+  });
+});

--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -1,0 +1,136 @@
+export interface Endpoint {
+  id: string;
+  url: string;
+  description: string;
+  active: boolean;
+  eventTypes: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Event {
+  id: string;
+  type: string;
+  payload: Record<string, unknown>;
+  receivedAt: string;
+  status: 'pending' | 'processed' | 'failed';
+  deliveries: Delivery[];
+}
+
+export interface Delivery {
+  id: string;
+  endpointId: string;
+  endpointUrl: string;
+  status: 'pending' | 'success' | 'failed';
+  statusCode: number | null;
+  attempts: number;
+  response: string | null;
+  sentAt: string | null;
+  completedAt: string | null;
+}
+
+export class HookwingClient {
+  private apiKey: string;
+  private baseUrl: string;
+
+  constructor(apiKey: string, baseUrl: string) {
+    this.apiKey = apiKey;
+    this.baseUrl = baseUrl.replace(/\/$/, '');
+  }
+
+  private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${this.apiKey}`,
+      'Content-Type': 'application/json',
+    };
+
+    const init: RequestInit = { method, headers };
+    if (body !== undefined) {
+      init.body = JSON.stringify(body);
+    }
+    const response = await fetch(url, init);
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`API error (${response.status}): ${errorText || response.statusText}`);
+    }
+
+    return response.json() as Promise<T>;
+  }
+
+  async listEndpoints(): Promise<Endpoint[]> {
+    return this.request<Endpoint[]>('GET', '/v1/endpoints');
+  }
+
+  async createEndpoint(data: {
+    url: string;
+    description?: string;
+    eventTypes?: string[];
+  }): Promise<Endpoint> {
+    return this.request<Endpoint>('POST', '/v1/endpoints', data);
+  }
+
+  async getEndpoint(id: string): Promise<Endpoint> {
+    return this.request<Endpoint>('GET', `/v1/endpoints/${id}`);
+  }
+
+  async updateEndpoint(
+    id: string,
+    data: {
+      url?: string;
+      description?: string;
+      active?: boolean;
+    },
+  ): Promise<Endpoint> {
+    return this.request<Endpoint>('PATCH', `/v1/endpoints/${id}`, data);
+  }
+
+  async deleteEndpoint(id: string): Promise<void> {
+    await this.request<void>('DELETE', `/v1/endpoints/${id}`);
+  }
+
+  async listEvents(options?: {
+    limit?: number;
+    status?: string;
+    type?: string;
+  }): Promise<Event[]> {
+    const params = new URLSearchParams();
+    if (options?.limit) params.set('limit', String(options.limit));
+    if (options?.status) params.set('status', options.status);
+    if (options?.type) params.set('type', options.type);
+    const query = params.toString();
+    return this.request<Event[]>('GET', `/v1/events${query ? `?${query}` : ''}`);
+  }
+
+  async getEvent(id: string): Promise<Event> {
+    return this.request<Event>('GET', `/v1/events/${id}`);
+  }
+
+  async replayEvent(id: string): Promise<{ success: boolean }> {
+    return this.request<{ success: boolean }>('POST', `/v1/events/${id}/replay`);
+  }
+
+  async replayEvents(ids: string[]): Promise<{ success: boolean }> {
+    return this.request<{ success: boolean }>('POST', '/v1/events/replay-bulk', {
+      eventIds: ids,
+    });
+  }
+
+  async listDeliveries(options?: {
+    limit?: number;
+    status?: string;
+    endpointId?: string;
+  }): Promise<Delivery[]> {
+    const params = new URLSearchParams();
+    if (options?.limit) params.set('limit', String(options.limit));
+    if (options?.status) params.set('status', options.status);
+    if (options?.endpointId) params.set('endpointId', options.endpointId);
+    const query = params.toString();
+    return this.request<Delivery[]>('GET', `/v1/deliveries${query ? `?${query}` : ''}`);
+  }
+
+  async getDelivery(id: string): Promise<Delivery> {
+    return this.request<Delivery>('GET', `/v1/deliveries/${id}`);
+  }
+}

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -1,0 +1,66 @@
+import chalk from 'chalk';
+import type { Command } from 'commander';
+import { getApiKey, loadConfig, saveConfig } from '../config.js';
+
+export function createAuthCommands(program: Command): void {
+  const auth = program.command('auth').description('Manage authentication');
+
+  auth
+    .command('login')
+    .description('Login with your API key')
+    .action(async () => {
+      const config = await loadConfig();
+
+      // Prompt for API key (using simple approach since no inquirer)
+      const readline = await import('node:readline');
+      const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+      });
+
+      const question = (query: string): Promise<string> =>
+        new Promise((resolve) => rl.question(query, resolve));
+
+      const apiKey = await question('Enter your API key: ');
+      rl.close();
+
+      if (!apiKey.trim()) {
+        console.error(chalk.red('Error: API key is required'));
+        process.exit(1);
+      }
+
+      config.apiKey = apiKey.trim();
+      await saveConfig(config);
+
+      console.log(chalk.green('API key saved successfully'));
+    });
+
+  auth
+    .command('logout')
+    .description('Remove API key from config')
+    .action(async () => {
+      const config = await loadConfig();
+      config.apiKey = '';
+      await saveConfig(config);
+      console.log(chalk.green('Logged out successfully'));
+    });
+
+  auth
+    .command('status')
+    .description('Show current auth status')
+    .action(async () => {
+      const config = await loadConfig();
+      const apiKey = getApiKey(config);
+
+      if (apiKey) {
+        const masked = `${apiKey.substring(0, 7)}...${apiKey.substring(apiKey.length - 4)}`;
+        console.log(chalk.green('Authenticated'));
+        console.log(`API Key: ${chalk.cyan(masked)}`);
+      } else {
+        console.log(chalk.yellow('Not authenticated'));
+        console.log(`Run ${chalk.cyan('hookwing auth login')} to authenticate`);
+      }
+
+      console.log(`Base URL: ${chalk.cyan(config.baseUrl)}`);
+    });
+}

--- a/packages/cli/src/commands/deliveries.ts
+++ b/packages/cli/src/commands/deliveries.ts
@@ -1,0 +1,129 @@
+import chalk from 'chalk';
+import type { Command } from 'commander';
+import ora from 'ora';
+import { HookwingClient } from '../client.js';
+import { getApiKey, loadConfig } from '../config.js';
+import { formatJson, formatTable } from '../output.js';
+
+export function createDeliveriesCommands(
+  program: Command,
+  getFormat: () => 'json' | 'table',
+): void {
+  const deliveries = program.command('deliveries').description('Manage deliveries');
+
+  deliveries
+    .command('list')
+    .option('--limit <n>', 'Number of deliveries to fetch', '20')
+    .option('--status <status>', 'Filter by status (pending, success, failed)')
+    .option('--endpoint-id <id>', 'Filter by endpoint ID')
+    .action(async (options) => {
+      const config = await loadConfig();
+      const apiKey = getApiKey(config);
+      if (!apiKey) {
+        console.error(chalk.red("Error: Not authenticated. Run 'hookwing auth login'"));
+        process.exit(1);
+      }
+
+      const client = new HookwingClient(apiKey, config.baseUrl);
+      const spinner = ora('Loading deliveries...').start();
+
+      try {
+        const list = await client.listDeliveries({
+          limit: Number.parseInt(options.limit, 10),
+          status: options.status,
+          endpointId: options.endpointId,
+        });
+        spinner.stop();
+
+        const format = getFormat();
+        if (format === 'json') {
+          console.log(formatJson(list));
+        } else {
+          if (list.length === 0) {
+            console.log(chalk.yellow('No deliveries found'));
+            return;
+          }
+
+          const headers = ['ID', 'Endpoint', 'Status', 'Code', 'Attempts', 'Sent'];
+          const rows = list.map((d) => [
+            d.id,
+            d.endpointUrl,
+            d.status === 'pending'
+              ? chalk.yellow('pending')
+              : d.status === 'success'
+                ? chalk.green('success')
+                : chalk.red('failed'),
+            d.statusCode !== null ? String(d.statusCode) : '-',
+            String(d.attempts),
+            d.sentAt || '-',
+          ]);
+
+          console.log(formatTable(headers, rows));
+        }
+      } catch (err) {
+        spinner.fail('Failed to load deliveries');
+        console.error(chalk.red((err as Error).message));
+        process.exit(1);
+      }
+    });
+
+  deliveries.command('get <id>').action(async (id: string) => {
+    const config = await loadConfig();
+    const apiKey = getApiKey(config);
+    if (!apiKey) {
+      console.error(chalk.red("Error: Not authenticated. Run 'hookwing auth login'"));
+      process.exit(1);
+    }
+
+    const client = new HookwingClient(apiKey, config.baseUrl);
+    const spinner = ora('Loading delivery...').start();
+
+    try {
+      const delivery = await client.getDelivery(id);
+      spinner.stop();
+
+      const format = getFormat();
+      if (format === 'json') {
+        console.log(formatJson(delivery));
+      } else {
+        console.log(chalk.bold('Delivery Details\n'));
+        console.log(
+          formatTable(
+            ['ID', 'Endpoint ID', 'Endpoint URL', 'Status', 'Code', 'Attempts'],
+            [
+              [
+                delivery.id,
+                delivery.endpointId,
+                delivery.endpointUrl,
+                delivery.status === 'pending'
+                  ? chalk.yellow('pending')
+                  : delivery.status === 'success'
+                    ? chalk.green('success')
+                    : chalk.red('failed'),
+                delivery.statusCode !== null ? String(delivery.statusCode) : '-',
+                String(delivery.attempts),
+              ],
+            ],
+          ),
+        );
+
+        console.log(chalk.bold('\nTimestamps'));
+        console.log(
+          formatTable(
+            ['Sent', 'Completed'],
+            [[delivery.sentAt || '-', delivery.completedAt || '-']],
+          ),
+        );
+
+        if (delivery.response) {
+          console.log(chalk.bold('\nResponse'));
+          console.log(delivery.response);
+        }
+      }
+    } catch (err) {
+      spinner.fail('Failed to load delivery');
+      console.error(chalk.red((err as Error).message));
+      process.exit(1);
+    }
+  });
+}

--- a/packages/cli/src/commands/endpoints.ts
+++ b/packages/cli/src/commands/endpoints.ts
@@ -1,0 +1,231 @@
+import chalk from 'chalk';
+import type { Command } from 'commander';
+import ora from 'ora';
+import { HookwingClient } from '../client.js';
+import { getApiKey, loadConfig } from '../config.js';
+import { formatJson, formatTable } from '../output.js';
+
+export function createEndpointsCommands(program: Command, getFormat: () => 'json' | 'table'): void {
+  const endpoints = program.command('endpoints').description('Manage webhook endpoints');
+
+  endpoints.command('list').action(async () => {
+    const config = await loadConfig();
+    const apiKey = getApiKey(config);
+    if (!apiKey) {
+      console.error(chalk.red("Error: Not authenticated. Run 'hookwing auth login'"));
+      process.exit(1);
+    }
+
+    const client = new HookwingClient(apiKey, config.baseUrl);
+    const spinner = ora('Loading endpoints...').start();
+
+    try {
+      const list = await client.listEndpoints();
+      spinner.stop();
+
+      const format = getFormat();
+      if (format === 'json') {
+        console.log(formatJson(list));
+      } else {
+        if (list.length === 0) {
+          console.log(chalk.yellow('No endpoints found'));
+          return;
+        }
+
+        const headers = ['ID', 'URL', 'Status', 'Event Types'];
+        const rows = list.map((ep) => [
+          ep.id,
+          ep.url,
+          ep.active ? chalk.green('active') : chalk.red('inactive'),
+          ep.eventTypes.join(', ') || '-',
+        ]);
+
+        console.log(formatTable(headers, rows));
+      }
+    } catch (err) {
+      spinner.fail('Failed to load endpoints');
+      console.error(chalk.red((err as Error).message));
+      process.exit(1);
+    }
+  });
+
+  endpoints
+    .command('create')
+    .requiredOption('--url <url>', 'Endpoint URL')
+    .option('--description <desc>', 'Endpoint description')
+    .option('--event-types <types...>', 'Event types to receive')
+    .action(async (options) => {
+      const config = await loadConfig();
+      const apiKey = getApiKey(config);
+      if (!apiKey) {
+        console.error(chalk.red("Error: Not authenticated. Run 'hookwing auth login'"));
+        process.exit(1);
+      }
+
+      const client = new HookwingClient(apiKey, config.baseUrl);
+      const spinner = ora('Creating endpoint...').start();
+
+      try {
+        const endpoint = await client.createEndpoint({
+          url: options.url,
+          description: options.description,
+          eventTypes: options.eventTypes,
+        });
+        spinner.succeed('Endpoint created');
+
+        const format = getFormat();
+        if (format === 'json') {
+          console.log(formatJson(endpoint));
+        } else {
+          console.log(formatTable(['ID', 'URL'], [[endpoint.id, endpoint.url]]));
+        }
+      } catch (err) {
+        spinner.fail('Failed to create endpoint');
+        console.error(chalk.red((err as Error).message));
+        process.exit(1);
+      }
+    });
+
+  endpoints.command('get <id>').action(async (id: string) => {
+    const config = await loadConfig();
+    const apiKey = getApiKey(config);
+    if (!apiKey) {
+      console.error(chalk.red("Error: Not authenticated. Run 'hookwing auth login'"));
+      process.exit(1);
+    }
+
+    const client = new HookwingClient(apiKey, config.baseUrl);
+    const spinner = ora('Loading endpoint...').start();
+
+    try {
+      const endpoint = await client.getEndpoint(id);
+      spinner.stop();
+
+      const format = getFormat();
+      if (format === 'json') {
+        console.log(formatJson(endpoint));
+      } else {
+        console.log(
+          formatTable(
+            ['ID', 'URL', 'Description', 'Active', 'Event Types', 'Created'],
+            [
+              [
+                endpoint.id,
+                endpoint.url,
+                endpoint.description || '-',
+                endpoint.active ? chalk.green('yes') : chalk.red('no'),
+                endpoint.eventTypes.join(', ') || '-',
+                endpoint.createdAt,
+              ],
+            ],
+          ),
+        );
+      }
+    } catch (err) {
+      spinner.fail('Failed to load endpoint');
+      console.error(chalk.red((err as Error).message));
+      process.exit(1);
+    }
+  });
+
+  endpoints
+    .command('delete <id>')
+    .option('--yes', 'Skip confirmation prompt')
+    .action(async (id: string, options) => {
+      const config = await loadConfig();
+      const apiKey = getApiKey(config);
+      if (!apiKey) {
+        console.error(chalk.red("Error: Not authenticated. Run 'hookwing auth login'"));
+        process.exit(1);
+      }
+
+      if (!options.yes) {
+        const readline = await import('node:readline');
+        const rl = readline.createInterface({
+          input: process.stdin,
+          output: process.stdout,
+        });
+
+        const question = (q: string): Promise<string> =>
+          new Promise((resolve) => rl.question(q, resolve));
+
+        const answer = await question(
+          chalk.yellow(`Are you sure you want to delete endpoint ${id}? (y/N): `),
+        );
+        rl.close();
+
+        if (answer.toLowerCase() !== 'y') {
+          console.log(chalk.yellow('Cancelled'));
+          process.exit(0);
+        }
+      }
+
+      const client = new HookwingClient(apiKey, config.baseUrl);
+      const spinner = ora('Deleting endpoint...').start();
+
+      try {
+        await client.deleteEndpoint(id);
+        spinner.succeed('Endpoint deleted');
+      } catch (err) {
+        spinner.fail('Failed to delete endpoint');
+        console.error(chalk.red((err as Error).message));
+        process.exit(1);
+      }
+    });
+
+  endpoints
+    .command('update <id>')
+    .option('--url <url>', 'New endpoint URL')
+    .option('--description <desc>', 'New endpoint description')
+    .option('--active <true|false>', 'Set active status', (val) => {
+      if (val === 'true' || val === 'false') return val === 'true';
+      return undefined;
+    })
+    .action(async (id: string, options) => {
+      const config = await loadConfig();
+      const apiKey = getApiKey(config);
+      if (!apiKey) {
+        console.error(chalk.red("Error: Not authenticated. Run 'hookwing auth login'"));
+        process.exit(1);
+      }
+
+      const updateData: {
+        url?: string;
+        description?: string;
+        active?: boolean;
+      } = {};
+
+      if (options.url) updateData.url = options.url;
+      if (options.description !== undefined) updateData.description = options.description;
+      if (options.active !== undefined) updateData.active = options.active;
+
+      if (Object.keys(updateData).length === 0) {
+        console.error(chalk.red('Error: No options provided'));
+        process.exit(1);
+      }
+
+      const client = new HookwingClient(apiKey, config.baseUrl);
+      const spinner = ora('Updating endpoint...').start();
+
+      try {
+        const endpoint = await client.updateEndpoint(id, updateData);
+        spinner.succeed('Endpoint updated');
+
+        const format = getFormat();
+        if (format === 'json') {
+          console.log(formatJson(endpoint));
+        } else {
+          console.log(
+            formatTable(
+              ['ID', 'URL', 'Active'],
+              [[endpoint.id, endpoint.url, endpoint.active ? chalk.green('yes') : chalk.red('no')]],
+            ),
+          );
+        }
+      } catch (err) {
+        spinner.fail('Failed to update endpoint');
+        console.error(chalk.red((err as Error).message));
+        process.exit(1);
+      }
+    });
+}

--- a/packages/cli/src/commands/events.ts
+++ b/packages/cli/src/commands/events.ts
@@ -1,0 +1,180 @@
+import chalk from 'chalk';
+import type { Command } from 'commander';
+import ora from 'ora';
+import { HookwingClient } from '../client.js';
+import { getApiKey, loadConfig } from '../config.js';
+import { formatJson, formatTable } from '../output.js';
+
+export function createEventsCommands(program: Command, getFormat: () => 'json' | 'table'): void {
+  const events = program.command('events').description('Manage events');
+
+  events
+    .command('list')
+    .option('--limit <n>', 'Number of events to fetch', '20')
+    .option('--status <status>', 'Filter by status (pending, processed, failed)')
+    .option('--type <type>', 'Filter by event type')
+    .action(async (options) => {
+      const config = await loadConfig();
+      const apiKey = getApiKey(config);
+      if (!apiKey) {
+        console.error(chalk.red("Error: Not authenticated. Run 'hookwing auth login'"));
+        process.exit(1);
+      }
+
+      const client = new HookwingClient(apiKey, config.baseUrl);
+      const spinner = ora('Loading events...').start();
+
+      try {
+        const list = await client.listEvents({
+          limit: Number.parseInt(options.limit, 10),
+          status: options.status,
+          type: options.type,
+        });
+        spinner.stop();
+
+        const format = getFormat();
+        if (format === 'json') {
+          console.log(formatJson(list));
+        } else {
+          if (list.length === 0) {
+            console.log(chalk.yellow('No events found'));
+            return;
+          }
+
+          const headers = ['ID', 'Type', 'Status', 'Received'];
+          const rows = list.map((ev) => [
+            ev.id,
+            ev.type,
+            ev.status === 'pending'
+              ? chalk.yellow('pending')
+              : ev.status === 'processed'
+                ? chalk.green('processed')
+                : chalk.red('failed'),
+            ev.receivedAt,
+          ]);
+
+          console.log(formatTable(headers, rows));
+        }
+      } catch (err) {
+        spinner.fail('Failed to load events');
+        console.error(chalk.red((err as Error).message));
+        process.exit(1);
+      }
+    });
+
+  events.command('get <id>').action(async (id: string) => {
+    const config = await loadConfig();
+    const apiKey = getApiKey(config);
+    if (!apiKey) {
+      console.error(chalk.red("Error: Not authenticated. Run 'hookwing auth login'"));
+      process.exit(1);
+    }
+
+    const client = new HookwingClient(apiKey, config.baseUrl);
+    const spinner = ora('Loading event...').start();
+
+    try {
+      const event = await client.getEvent(id);
+      spinner.stop();
+
+      const format = getFormat();
+      if (format === 'json') {
+        console.log(formatJson(event));
+      } else {
+        console.log(chalk.bold('Event Details\n'));
+        console.log(
+          formatTable(
+            ['ID', 'Type', 'Status', 'Received'],
+            [
+              [
+                event.id,
+                event.type,
+                event.status === 'pending'
+                  ? chalk.yellow('pending')
+                  : event.status === 'processed'
+                    ? chalk.green('processed')
+                    : chalk.red('failed'),
+                event.receivedAt,
+              ],
+            ],
+          ),
+        );
+
+        console.log(chalk.bold('\nPayload'));
+        console.log(formatJson(event.payload));
+
+        if (event.deliveries.length > 0) {
+          console.log(chalk.bold('\nDeliveries'));
+          const headers = ['ID', 'Endpoint', 'Status', 'Code', 'Attempts'];
+          const rows = event.deliveries.map((d) => [
+            d.id,
+            d.endpointUrl,
+            d.status === 'pending'
+              ? chalk.yellow('pending')
+              : d.status === 'success'
+                ? chalk.green('success')
+                : chalk.red('failed'),
+            d.statusCode !== null ? String(d.statusCode) : '-',
+            String(d.attempts),
+          ]);
+          console.log(formatTable(headers, rows));
+        }
+      }
+    } catch (err) {
+      spinner.fail('Failed to load event');
+      console.error(chalk.red((err as Error).message));
+      process.exit(1);
+    }
+  });
+
+  events.command('replay <id>').action(async (id: string) => {
+    const config = await loadConfig();
+    const apiKey = getApiKey(config);
+    if (!apiKey) {
+      console.error(chalk.red("Error: Not authenticated. Run 'hookwing auth login'"));
+      process.exit(1);
+    }
+
+    const client = new HookwingClient(apiKey, config.baseUrl);
+    const spinner = ora('Replaying event...').start();
+
+    try {
+      await client.replayEvent(id);
+      spinner.succeed('Event replayed successfully');
+    } catch (err) {
+      spinner.fail('Failed to replay event');
+      console.error(chalk.red((err as Error).message));
+      process.exit(1);
+    }
+  });
+
+  events
+    .command('replay')
+    .option('--bulk <ids>', 'Comma-separated list of event IDs')
+    .action(async (options) => {
+      if (!options.bulk) {
+        console.error(chalk.red('Error: --bulk is required'));
+        process.exit(1);
+      }
+
+      const config = await loadConfig();
+      const apiKey = getApiKey(config);
+      if (!apiKey) {
+        console.error(chalk.red("Error: Not authenticated. Run 'hookwing auth login'"));
+        process.exit(1);
+      }
+
+      const ids = options.bulk.split(',').map((id: string) => id.trim());
+      const client = new HookwingClient(apiKey, config.baseUrl);
+      const spinner = ora(`Replaying ${ids.length} events...`).start();
+
+      try {
+        await client.replayEvents(ids);
+        spinner.succeed(`Replayed ${ids.length} events successfully`);
+      } catch (err) {
+        spinner.fail('Failed to replay events');
+        console.error(chalk.red((err as Error).message));
+        process.exit(1);
+      }
+    });
+}

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,0 +1,63 @@
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export interface Config {
+  apiKey: string;
+  baseUrl: string;
+  format: 'json' | 'table';
+}
+
+const DEFAULT_CONFIG: Config = {
+  apiKey: '',
+  baseUrl: 'https://api.hookwing.com',
+  format: 'table',
+};
+
+function getConfigPath(): string {
+  return join(homedir(), '.hookwing', 'config.json');
+}
+
+function getConfigDir(): string {
+  return join(homedir(), '.hookwing');
+}
+
+export async function loadConfig(): Promise<Config> {
+  const configPath = getConfigPath();
+
+  if (!existsSync(configPath)) {
+    return { ...DEFAULT_CONFIG };
+  }
+
+  try {
+    const content = await readFile(configPath, 'utf-8');
+    const parsed = JSON.parse(content);
+    return {
+      ...DEFAULT_CONFIG,
+      ...parsed,
+    };
+  } catch {
+    return { ...DEFAULT_CONFIG };
+  }
+}
+
+export async function saveConfig(config: Config): Promise<void> {
+  const configDir = getConfigDir();
+  const configPath = getConfigPath();
+
+  if (!existsSync(configDir)) {
+    await mkdir(configDir, { recursive: true });
+  }
+
+  const content = JSON.stringify(config, null, 2);
+  await writeFile(configPath, content, 'utf-8');
+}
+
+export function getApiKey(config: Config): string | undefined {
+  const envApiKey = process.env.HOOKWING_API_KEY;
+  if (envApiKey) {
+    return envApiKey;
+  }
+  return config.apiKey || undefined;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+import { Command } from 'commander';
+import { createAuthCommands } from './commands/auth.js';
+import { createDeliveriesCommands } from './commands/deliveries.js';
+import { createEndpointsCommands } from './commands/endpoints.js';
+import { createEventsCommands } from './commands/events.js';
+import { loadConfig } from './config.js';
+
+const program = new Command();
+let outputFormat: 'json' | 'table' = 'table';
+
+function getFormat(): 'json' | 'table' {
+  return outputFormat;
+}
+
+program
+  .name('hookwing')
+  .version('0.0.1')
+  .description('Hookwing CLI - Manage webhooks from the terminal')
+  .option('--json', 'Output in JSON format')
+  .hook('preAction', async () => {
+    const config = await loadConfig();
+    outputFormat = config.format;
+  });
+
+// Global --json flag
+program.on('option:json', () => {
+  outputFormat = 'json';
+});
+
+createAuthCommands(program);
+createEndpointsCommands(program, getFormat);
+createEventsCommands(program, getFormat);
+createDeliveriesCommands(program, getFormat);
+
+program.parse();

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -1,0 +1,19 @@
+export function formatTable(headers: string[], rows: string[][]): string {
+  const columnWidths = headers.map((header, colIndex) => {
+    const dataWidths = rows.map((row) => (row[colIndex] ?? '').length);
+    return Math.max(header.length, ...dataWidths);
+  });
+
+  const headerRow = headers.map((header, i) => header.padEnd(columnWidths[i] ?? 0)).join(' | ');
+  const separator = columnWidths.map((w) => '-'.repeat(w)).join('-+-');
+
+  const dataRows = rows.map((row) =>
+    row.map((cell, i) => (cell ?? '').padEnd(columnWidths[i] ?? 0)).join(' | '),
+  );
+
+  return [headerRow, separator, ...dataRows].join('\n');
+}
+
+export function formatJson(data: unknown): string {
+  return JSON.stringify(data, null, 2);
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16"
+  },
+  "include": ["src"]
+}

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  globals: true,
+  environment: 'node',
+});


### PR DESCRIPTION
New `@hookwing/cli` package — `hookwing` command-line tool for managing webhooks.

**Commands:**
- `hookwing auth login|logout|status` — API key management via `~/.hookwing/config.json`
- `hookwing endpoints list|create|get|update|delete` — full endpoint CRUD
- `hookwing events list|get|replay` — event browsing + single/bulk replay
- `hookwing deliveries list|get` — delivery attempt tracking

**Features:**
- Table + JSON output formats (`--json` flag or config)
- Spinner feedback (ora) + colored output (chalk)
- API key from config file or `HOOKWING_API_KEY` env var
- Commander-based with subcommand groups

**20 tests passing**, typecheck clean, biome clean, 12/12 turbo tasks green.