### PR TITLE
feat(PROD-70): usage analytics — daily tracking, usage + summary endpoints

### DIFF
--- a/packages/api/openapi.yaml
+++ b/packages/api/openapi.yaml
@@ -32,6 +32,8 @@ tags:
     description: Event history, filtering, and replay
   - name: Deliveries
     description: Delivery attempt tracking
+  - name: Analytics
+    description: Usage metrics and delivery statistics
   - name: Ingest
     description: Public webhook ingestion
 
@@ -586,6 +588,102 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
+
+  # ==========================================================================
+  # ==========================================================================
+  # Analytics
+  # ==========================================================================
+  /v1/analytics/usage:
+    get:
+      operationId: getUsage
+      tags: [Analytics]
+      summary: Daily usage breakdown for the workspace
+      parameters:
+        - name: days
+          in: query
+          description: Number of days to include (max 90, default 30)
+          schema:
+            type: integer
+            default: 30
+            minimum: 1
+            maximum: 90
+      responses:
+        "200":
+          description: Daily usage stats
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  workspace:
+                    type: object
+                    properties:
+                      id: { type: string }
+                      tier: { type: string }
+                  period:
+                    type: object
+                    properties:
+                      days: { type: integer }
+                      since: { type: string, format: date }
+                  totals:
+                    type: object
+                    properties:
+                      eventsReceived: { type: integer }
+                      deliveriesAttempted: { type: integer }
+                      deliveriesSucceeded: { type: integer }
+                      deliveriesFailed: { type: integer }
+                      deliverySuccessRate: { type: number, nullable: true }
+                  daily:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        date: { type: string, format: date }
+                        eventsReceived: { type: integer }
+                        deliveriesAttempted: { type: integer }
+                        deliveriesSucceeded: { type: integer }
+                        deliveriesFailed: { type: integer }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+
+  /v1/analytics/summary:
+    get:
+      operationId: getAnalyticsSummary
+      tags: [Analytics]
+      summary: Quick usage snapshot (today + current month vs tier limit)
+      responses:
+        "200":
+          description: Usage summary
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  today:
+                    type: object
+                    properties:
+                      eventsReceived: { type: integer }
+                      deliveriesAttempted: { type: integer }
+                      deliveriesSucceeded: { type: integer }
+                      deliveriesFailed: { type: integer }
+                  month:
+                    type: object
+                    properties:
+                      eventsReceived: { type: integer }
+                      limit: { type: integer, nullable: true }
+                      percentUsed: { type: number, nullable: true }
+                  tier:
+                    type: object
+                    properties:
+                      slug: { type: string }
+                      name: { type: string }
+                      limits: { $ref: "#/components/schemas/TierLimits" }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "429":
+          $ref: "#/components/responses/RateLimited"
 
   # ==========================================================================
   # Ingest (public)

--- a/packages/api/src/__tests__/analytics.test.ts
+++ b/packages/api/src/__tests__/analytics.test.ts
@@ -1,0 +1,82 @@
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+import analyticsRoutes from '../routes/analytics';
+
+const makeApp = () => new Hono().route('/v1/analytics', analyticsRoutes);
+
+describe('GET /v1/analytics/usage', () => {
+  it('should return 401 without auth', async () => {
+    const res = await makeApp().request('/v1/analytics/usage');
+    expect(res.status).toBe(401);
+  });
+
+  it('should return 401 with invalid API key', async () => {
+    const res = await makeApp().request('/v1/analytics/usage', {
+      headers: { Authorization: 'Bearer invalid_key' },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('should not accept requests without Authorization header', async () => {
+    const res = await makeApp().request('/v1/analytics/usage', {
+      method: 'GET',
+    });
+    expect(res.status).not.toBe(200);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /v1/analytics/summary', () => {
+  it('should return 401 without auth', async () => {
+    const res = await makeApp().request('/v1/analytics/summary');
+    expect(res.status).toBe(401);
+  });
+
+  it('should return 401 with malformed auth', async () => {
+    const res = await makeApp().request('/v1/analytics/summary', {
+      headers: { Authorization: 'Basic dXNlcjpwYXNz' },
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('analytics service contract', () => {
+  it('should export trackEventReceived', async () => {
+    const { trackEventReceived } = await import('../services/analytics.js');
+    expect(typeof trackEventReceived).toBe('function');
+  });
+
+  it('should export trackDeliveryAttempted', async () => {
+    const { trackDeliveryAttempted } = await import('../services/analytics.js');
+    expect(typeof trackDeliveryAttempted).toBe('function');
+  });
+
+  it('should export trackDeliverySucceeded', async () => {
+    const { trackDeliverySucceeded } = await import('../services/analytics.js');
+    expect(typeof trackDeliverySucceeded).toBe('function');
+  });
+
+  it('should export trackDeliveryFailed', async () => {
+    const { trackDeliveryFailed } = await import('../services/analytics.js');
+    expect(typeof trackDeliveryFailed).toBe('function');
+  });
+
+  it('should calculate today date in YYYY-MM-DD format', () => {
+    const today = new Date().toISOString().slice(0, 10);
+    expect(today).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('should calculate success rate correctly', () => {
+    const attempted = 100;
+    const succeeded = 95;
+    const rate = Math.round((succeeded / attempted) * 10000) / 100;
+    expect(rate).toBe(95);
+  });
+
+  it('should handle zero deliveries gracefully', () => {
+    const attempted = 0;
+    const succeeded = 0;
+    const rate = attempted > 0 ? Math.round((succeeded / attempted) * 10000) / 100 : null;
+    expect(rate).toBeNull();
+  });
+});

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_TIERS, getTierBySlug } from '@hookwing/shared';
 import { Hono } from 'hono';
+import analyticsRoutes from './routes/analytics';
 import authRoutes from './routes/auth';
 import deliveryRoutes from './routes/deliveries';
 import endpointRoutes from './routes/endpoints';
@@ -62,6 +63,7 @@ app.route('/v1/ingest', ingestRoutes);
 
 // Mount event routes at /v1/events/* (authenticated)
 app.route('/v1/events', eventRoutes);
+app.route('/v1/analytics', analyticsRoutes);
 
 // Mount delivery routes at /v1/deliveries/* (authenticated)
 app.route('/v1/deliveries', deliveryRoutes);

--- a/packages/api/src/routes/analytics.ts
+++ b/packages/api/src/routes/analytics.ts
@@ -1,0 +1,137 @@
+import { getTierBySlug, usageDaily } from '@hookwing/shared';
+import { and, desc, eq, gte } from 'drizzle-orm';
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { createDb } from '../db';
+import { authMiddleware, getWorkspace } from '../middleware/auth';
+import { createRateLimitMiddleware } from '../middleware/rateLimit';
+
+const analyticsRoutes = new Hono<{ Bindings: { DB: D1Database } }>();
+
+analyticsRoutes.use('/*', authMiddleware);
+analyticsRoutes.use(
+  '/*',
+  createRateLimitMiddleware({
+    windowMs: 1000,
+    keyFn: (c) => {
+      const ws = c.get('workspace') as { id: string } | undefined;
+      return `api:${ws?.id ?? 'unknown'}`;
+    },
+    getLimit: (c) => {
+      const ws = c.get('workspace') as { tierSlug: string } | undefined;
+      const tier = ws ? getTierBySlug(ws.tierSlug) : undefined;
+      return tier?.limits.rate_limit_per_second ?? 10;
+    },
+  }),
+);
+
+// ============================================================================
+// GET /v1/analytics/usage — Daily usage stats for workspace
+// ============================================================================
+
+const usageQuerySchema = z.object({
+  days: z
+    .string()
+    .optional()
+    .transform((v) => (v ? Math.min(Number.parseInt(v, 10), 90) : 30))
+    .pipe(z.number().int().min(1).max(90)),
+});
+
+analyticsRoutes.get('/usage', async (c) => {
+  const workspace = getWorkspace(c);
+  const db = createDb(c.env.DB);
+
+  const query = usageQuerySchema.safeParse({ days: c.req.query('days') });
+  const days = query.success ? query.data.days : 30;
+
+  // Calculate date N days ago (YYYY-MM-DD)
+  const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+
+  const rows = await db
+    .select()
+    .from(usageDaily)
+    .where(and(eq(usageDaily.workspaceId, workspace.id), gte(usageDaily.date, since)))
+    .orderBy(desc(usageDaily.date));
+
+  // Aggregate totals
+  const totals = rows.reduce(
+    (acc, row) => ({
+      eventsReceived: acc.eventsReceived + row.eventsReceived,
+      deliveriesAttempted: acc.deliveriesAttempted + row.deliveriesAttempted,
+      deliveriesSucceeded: acc.deliveriesSucceeded + row.deliveriesSucceeded,
+      deliveriesFailed: acc.deliveriesFailed + row.deliveriesFailed,
+    }),
+    { eventsReceived: 0, deliveriesAttempted: 0, deliveriesSucceeded: 0, deliveriesFailed: 0 },
+  );
+
+  const deliverySuccessRate =
+    totals.deliveriesAttempted > 0
+      ? Math.round((totals.deliveriesSucceeded / totals.deliveriesAttempted) * 10000) / 100
+      : null;
+
+  return c.json({
+    workspace: { id: workspace.id, tier: workspace.tierSlug },
+    period: { days, since },
+    totals: { ...totals, deliverySuccessRate },
+    daily: rows.map((r) => ({
+      date: r.date,
+      eventsReceived: r.eventsReceived,
+      deliveriesAttempted: r.deliveriesAttempted,
+      deliveriesSucceeded: r.deliveriesSucceeded,
+      deliveriesFailed: r.deliveriesFailed,
+    })),
+  });
+});
+
+// ============================================================================
+// GET /v1/analytics/summary — Quick stats snapshot
+// ============================================================================
+
+analyticsRoutes.get('/summary', async (c) => {
+  const workspace = getWorkspace(c);
+  const db = createDb(c.env.DB);
+
+  const tier = getTierBySlug(workspace.tierSlug);
+
+  // Today's usage
+  const today = new Date().toISOString().slice(0, 10);
+  const todayRow = await db
+    .select()
+    .from(usageDaily)
+    .where(and(eq(usageDaily.workspaceId, workspace.id), eq(usageDaily.date, today)))
+    .limit(1)
+    .then((rows) => rows[0]);
+
+  // This month's usage
+  const monthStart = `${new Date().toISOString().slice(0, 7)}-01`; // YYYY-MM-01
+  const monthRows = await db
+    .select()
+    .from(usageDaily)
+    .where(and(eq(usageDaily.workspaceId, workspace.id), gte(usageDaily.date, monthStart)));
+
+  const monthlyEvents = monthRows.reduce((sum, r) => sum + r.eventsReceived, 0);
+
+  return c.json({
+    today: {
+      eventsReceived: todayRow?.eventsReceived ?? 0,
+      deliveriesAttempted: todayRow?.deliveriesAttempted ?? 0,
+      deliveriesSucceeded: todayRow?.deliveriesSucceeded ?? 0,
+      deliveriesFailed: todayRow?.deliveriesFailed ?? 0,
+    },
+    month: {
+      eventsReceived: monthlyEvents,
+      limit: tier?.limits.max_events_per_month ?? null,
+      percentUsed:
+        tier != null
+          ? Math.round((monthlyEvents / tier.limits.max_events_per_month) * 10000) / 100
+          : null,
+    },
+    tier: {
+      slug: workspace.tierSlug,
+      name: tier?.name ?? workspace.tierSlug,
+      limits: tier?.limits ?? null,
+    },
+  });
+});
+
+export default analyticsRoutes;

--- a/packages/api/src/routes/ingest.ts
+++ b/packages/api/src/routes/ingest.ts
@@ -3,6 +3,7 @@ import { eq } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { createDb } from '../db';
 import { applyRateLimit } from '../middleware/rateLimit';
+import { trackEventReceived } from '../services/analytics';
 import { fanoutEvent } from '../services/fanout';
 
 const ingestRoutes = new Hono<{ Bindings: { DB: D1Database; DELIVERY_QUEUE?: Queue } }>();
@@ -128,7 +129,10 @@ ingestRoutes.post('/:endpointId', async (c) => {
     endpointId,
   );
 
-  // 9. Return success response
+  // 9. Track usage (fire-and-forget, don't fail the request)
+  trackEventReceived(db, endpoint.workspaceId).catch(() => {});
+
+  // 10. Return success response
   return c.json({
     received: true,
     eventId,

--- a/packages/api/src/services/analytics.ts
+++ b/packages/api/src/services/analytics.ts
@@ -1,0 +1,69 @@
+/**
+ * Analytics service — tracks usage counts in the usage_daily table.
+ * Increments counters on ingest, delivery success/failure.
+ */
+
+import { generateId, usageDaily } from '@hookwing/shared';
+import { and, eq } from 'drizzle-orm';
+import type { Database } from '../db';
+
+function todayDate(): string {
+  return new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+}
+
+async function upsertDaily(
+  db: Database,
+  workspaceId: string,
+  date: string,
+  increments: {
+    eventsReceived?: number;
+    deliveriesAttempted?: number;
+    deliveriesSucceeded?: number;
+    deliveriesFailed?: number;
+  },
+): Promise<void> {
+  const existing = await db
+    .select()
+    .from(usageDaily)
+    .where(and(eq(usageDaily.workspaceId, workspaceId), eq(usageDaily.date, date)))
+    .limit(1)
+    .then((rows) => rows[0]);
+
+  if (existing) {
+    await db
+      .update(usageDaily)
+      .set({
+        eventsReceived: existing.eventsReceived + (increments.eventsReceived ?? 0),
+        deliveriesAttempted: existing.deliveriesAttempted + (increments.deliveriesAttempted ?? 0),
+        deliveriesSucceeded: existing.deliveriesSucceeded + (increments.deliveriesSucceeded ?? 0),
+        deliveriesFailed: existing.deliveriesFailed + (increments.deliveriesFailed ?? 0),
+      })
+      .where(and(eq(usageDaily.workspaceId, workspaceId), eq(usageDaily.date, date)));
+  } else {
+    await db.insert(usageDaily).values({
+      id: generateId('usg'),
+      workspaceId,
+      date,
+      eventsReceived: increments.eventsReceived ?? 0,
+      deliveriesAttempted: increments.deliveriesAttempted ?? 0,
+      deliveriesSucceeded: increments.deliveriesSucceeded ?? 0,
+      deliveriesFailed: increments.deliveriesFailed ?? 0,
+    });
+  }
+}
+
+export async function trackEventReceived(db: Database, workspaceId: string): Promise<void> {
+  await upsertDaily(db, workspaceId, todayDate(), { eventsReceived: 1 });
+}
+
+export async function trackDeliveryAttempted(db: Database, workspaceId: string): Promise<void> {
+  await upsertDaily(db, workspaceId, todayDate(), { deliveriesAttempted: 1 });
+}
+
+export async function trackDeliverySucceeded(db: Database, workspaceId: string): Promise<void> {
+  await upsertDaily(db, workspaceId, todayDate(), { deliveriesSucceeded: 1 });
+}
+
+export async function trackDeliveryFailed(db: Database, workspaceId: string): Promise<void> {
+  await upsertDaily(db, workspaceId, todayDate(), { deliveriesFailed: 1 });
+}

--- a/packages/api/src/worker/deliver.ts
+++ b/packages/api/src/worker/deliver.ts
@@ -8,6 +8,11 @@ import {
 } from '@hookwing/shared';
 import { eq } from 'drizzle-orm';
 import { createDb } from '../db';
+import {
+  trackDeliveryAttempted,
+  trackDeliveryFailed,
+  trackDeliverySucceeded,
+} from '../services/analytics';
 import { calculateBackoff, shouldRetry } from './retry';
 
 export interface DeliveryMessage {
@@ -155,6 +160,8 @@ export async function processDelivery(message: DeliveryMessage, env: Env): Promi
       .where(eq(events.id, eventId));
 
     console.log(`Delivery ${deliveryId} succeeded on attempt ${attempt}`);
+    trackDeliveryAttempted(db, workspaceId).catch(() => {});
+    trackDeliverySucceeded(db, workspaceId).catch(() => {});
     return;
   }
 
@@ -229,6 +236,8 @@ export async function processDelivery(message: DeliveryMessage, env: Env): Promi
       .where(eq(events.id, eventId));
 
     console.log(`Delivery ${deliveryId} failed after ${attempt} attempts (max: ${maxAttempts})`);
+    trackDeliveryAttempted(db, workspaceId).catch(() => {});
+    trackDeliveryFailed(db, workspaceId).catch(() => {});
   }
 }
 


### PR DESCRIPTION
PROD-70: Usage analytics service + API endpoints.

**New endpoints:**
- `GET /v1/analytics/usage?days=30` — daily breakdown (events received, deliveries attempted/succeeded/failed, success rate %)
- `GET /v1/analytics/summary` — quick snapshot: today's stats + monthly usage vs tier limit

**Tracking wired into:**
- Ingest route — `trackEventReceived()` after event stored
- Delivery worker — `trackDeliveryAttempted/Succeeded/Failed()` after outcome

**Analytics service** (`services/analytics.ts`): fire-and-forget upsert pattern — never blocks request path.

OpenAPI spec updated with Analytics tag + 2 new paths. 10 tests, 12/12 turbo green.