### PR TITLE
feat(PROD-71): SDK package — @hookwing/sdk webhook verifier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1181,6 +1181,10 @@
       "resolved": "packages/mcp",
       "link": true
     },
+    "node_modules/@hookwing/sdk": {
+      "resolved": "packages/sdk",
+      "link": true
+    },
     "node_modules/@hookwing/shared": {
       "resolved": "packages/shared",
       "link": true
@@ -6118,6 +6122,15 @@
       "bin": {
         "hookwing-mcp": "dist/index.js"
       },
+      "devDependencies": {
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "packages/sdk": {
+      "name": "@hookwing/sdk",
+      "version": "0.0.1",
+      "license": "MIT",
       "devDependencies": {
         "typescript": "^5.7.0",
         "vitest": "^3.0.0"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@hookwing/sdk",
+  "version": "0.0.1",
+  "description": "Hookwing JavaScript/TypeScript SDK — webhook signature verification and client utilities",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "keywords": ["hookwing", "webhooks", "sdk", "signature-verification"],
+  "license": "MIT",
+  "devDependencies": {
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/sdk/src/__tests__/webhook.test.ts
+++ b/packages/sdk/src/__tests__/webhook.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import { SIGNATURE_HEADER, TIMESTAMP_HEADER, Webhook, WebhookVerificationError } from '../webhook.js';
+
+const SECRET = 'whsec_testSecretForUnitTests1234567890';
+const PAYLOAD = JSON.stringify({ id: 'evt_01', type: 'order.created', data: { orderId: 'ord_123' } });
+
+async function sign(payload: string, secret: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const raw = secret.startsWith('whsec_') ? secret.slice(6) : secret;
+  const key = await crypto.subtle.importKey('raw', encoder.encode(raw), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+  const sig = await crypto.subtle.sign('HMAC', key, encoder.encode(payload));
+  const hex = Array.from(new Uint8Array(sig)).map((b) => b.toString(16).padStart(2, '0')).join('');
+  return `sha256=${hex}`;
+}
+
+describe('Webhook constructor', () => {
+  it('should throw if secret is empty', () => {
+    expect(() => new Webhook('')).toThrow('Webhook secret is required');
+  });
+
+  it('should accept secret with whsec_ prefix', () => {
+    expect(() => new Webhook('whsec_abc123')).not.toThrow();
+  });
+
+  it('should accept secret without prefix', () => {
+    expect(() => new Webhook('rawsecret123')).not.toThrow();
+  });
+
+  it('should accept custom tolerance', () => {
+    expect(() => new Webhook(SECRET, { toleranceMs: 60000 })).not.toThrow();
+  });
+});
+
+describe('Webhook.verifySignature', () => {
+  it('should return true for a valid signature', async () => {
+    const wh = new Webhook(SECRET);
+    const sig = await sign(PAYLOAD, SECRET);
+    expect(await wh.verifySignature(PAYLOAD, sig)).toBe(true);
+  });
+
+  it('should return false for an invalid signature', async () => {
+    const wh = new Webhook(SECRET);
+    expect(await wh.verifySignature(PAYLOAD, 'sha256=deadbeef')).toBe(false);
+  });
+
+  it('should return false for missing sha256= prefix', async () => {
+    const wh = new Webhook(SECRET);
+    const sig = await sign(PAYLOAD, SECRET);
+    expect(await wh.verifySignature(PAYLOAD, sig.slice(7))).toBe(false); // Remove sha256=
+  });
+
+  it('should return false if payload is modified', async () => {
+    const wh = new Webhook(SECRET);
+    const sig = await sign(PAYLOAD, SECRET);
+    expect(await wh.verifySignature(PAYLOAD + ' ', sig)).toBe(false);
+  });
+
+  it('should return false for wrong secret', async () => {
+    const wh = new Webhook('whsec_wrongSecret12345678901234567890');
+    const sig = await sign(PAYLOAD, SECRET);
+    expect(await wh.verifySignature(PAYLOAD, sig)).toBe(false);
+  });
+});
+
+describe('Webhook.verify', () => {
+  it('should throw on missing signature header', async () => {
+    const wh = new Webhook(SECRET, { toleranceMs: 999999999 });
+    await expect(wh.verify(PAYLOAD, { signature: null, timestamp: String(Date.now()) })).rejects.toThrow(
+      WebhookVerificationError,
+    );
+  });
+
+  it('should throw on missing timestamp header', async () => {
+    const wh = new Webhook(SECRET, { toleranceMs: 999999999 });
+    const sig = await sign(PAYLOAD, SECRET);
+    await expect(wh.verify(PAYLOAD, { signature: sig, timestamp: null })).rejects.toThrow(
+      WebhookVerificationError,
+    );
+  });
+
+  it('should throw on stale timestamp', async () => {
+    const wh = new Webhook(SECRET, { toleranceMs: 1000 });
+    const sig = await sign(PAYLOAD, SECRET);
+    const oldTs = String(Date.now() - 10000); // 10s ago, tolerance is 1s
+    await expect(wh.verify(PAYLOAD, { signature: sig, timestamp: oldTs })).rejects.toThrow(
+      'timestamp too old',
+    );
+  });
+
+  it('should succeed with valid signature and fresh timestamp', async () => {
+    const wh = new Webhook(SECRET, { toleranceMs: 999999999 });
+    const sig = await sign(PAYLOAD, SECRET);
+    const ts = String(Date.now());
+    const event = await wh.verify(PAYLOAD, { signature: sig, timestamp: ts });
+    expect(event.type).toBe('order.created');
+    expect(event.id).toBe('evt_01');
+  });
+
+  it('should throw WebhookVerificationError on bad signature', async () => {
+    const wh = new Webhook(SECRET, { toleranceMs: 999999999 });
+    await expect(
+      wh.verify(PAYLOAD, { signature: 'sha256=badbad', timestamp: String(Date.now()) }),
+    ).rejects.toThrow(WebhookVerificationError);
+  });
+
+  it('should throw on invalid JSON payload', async () => {
+    const wh = new Webhook(SECRET, { toleranceMs: 999999999 });
+    const badPayload = 'not json';
+    const sig = await sign(badPayload, SECRET);
+    await expect(wh.verify(badPayload, { signature: sig, timestamp: String(Date.now()) })).rejects.toThrow(
+      'not valid JSON',
+    );
+  });
+});
+
+describe('header constants', () => {
+  it('should export correct header names', () => {
+    expect(SIGNATURE_HEADER).toBe('x-hookwing-signature');
+    expect(TIMESTAMP_HEADER).toBe('x-hookwing-timestamp');
+  });
+});

--- a/packages/sdk/src/__tests__/webhook.test.ts
+++ b/packages/sdk/src/__tests__/webhook.test.ts
@@ -1,15 +1,32 @@
 import { describe, expect, it } from 'vitest';
-import { SIGNATURE_HEADER, TIMESTAMP_HEADER, Webhook, WebhookVerificationError } from '../webhook.js';
+import {
+  SIGNATURE_HEADER,
+  TIMESTAMP_HEADER,
+  Webhook,
+  WebhookVerificationError,
+} from '../webhook.js';
 
 const SECRET = 'whsec_testSecretForUnitTests1234567890';
-const PAYLOAD = JSON.stringify({ id: 'evt_01', type: 'order.created', data: { orderId: 'ord_123' } });
+const PAYLOAD = JSON.stringify({
+  id: 'evt_01',
+  type: 'order.created',
+  data: { orderId: 'ord_123' },
+});
 
 async function sign(payload: string, secret: string): Promise<string> {
   const encoder = new TextEncoder();
   const raw = secret.startsWith('whsec_') ? secret.slice(6) : secret;
-  const key = await crypto.subtle.importKey('raw', encoder.encode(raw), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(raw),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
   const sig = await crypto.subtle.sign('HMAC', key, encoder.encode(payload));
-  const hex = Array.from(new Uint8Array(sig)).map((b) => b.toString(16).padStart(2, '0')).join('');
+  const hex = Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
   return `sha256=${hex}`;
 }
 
@@ -52,7 +69,7 @@ describe('Webhook.verifySignature', () => {
   it('should return false if payload is modified', async () => {
     const wh = new Webhook(SECRET);
     const sig = await sign(PAYLOAD, SECRET);
-    expect(await wh.verifySignature(PAYLOAD + ' ', sig)).toBe(false);
+    expect(await wh.verifySignature(`${PAYLOAD} `, sig)).toBe(false);
   });
 
   it('should return false for wrong secret', async () => {
@@ -65,9 +82,9 @@ describe('Webhook.verifySignature', () => {
 describe('Webhook.verify', () => {
   it('should throw on missing signature header', async () => {
     const wh = new Webhook(SECRET, { toleranceMs: 999999999 });
-    await expect(wh.verify(PAYLOAD, { signature: null, timestamp: String(Date.now()) })).rejects.toThrow(
-      WebhookVerificationError,
-    );
+    await expect(
+      wh.verify(PAYLOAD, { signature: null, timestamp: String(Date.now()) }),
+    ).rejects.toThrow(WebhookVerificationError);
   });
 
   it('should throw on missing timestamp header', async () => {
@@ -107,9 +124,9 @@ describe('Webhook.verify', () => {
     const wh = new Webhook(SECRET, { toleranceMs: 999999999 });
     const badPayload = 'not json';
     const sig = await sign(badPayload, SECRET);
-    await expect(wh.verify(badPayload, { signature: sig, timestamp: String(Date.now()) })).rejects.toThrow(
-      'not valid JSON',
-    );
+    await expect(
+      wh.verify(badPayload, { signature: sig, timestamp: String(Date.now()) }),
+    ).rejects.toThrow('not valid JSON');
   });
 });
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,0 +1,9 @@
+export {
+  Webhook,
+  WebhookVerificationError,
+  SIGNATURE_HEADER,
+  TIMESTAMP_HEADER,
+  EVENT_TYPE_HEADER,
+  type WebhookEvent,
+  type VerifyHeaders,
+} from './webhook.js';

--- a/packages/sdk/src/webhook.ts
+++ b/packages/sdk/src/webhook.ts
@@ -1,0 +1,147 @@
+/**
+ * Hookwing Webhook verifier
+ *
+ * Verifies HMAC-SHA256 signatures on incoming Hookwing webhook deliveries.
+ * Works in Node.js (v18+), browsers, and edge runtimes (Cloudflare Workers, etc.)
+ *
+ * @example
+ * ```ts
+ * import { Webhook } from '@hookwing/sdk';
+ *
+ * const wh = new Webhook('whsec_your_signing_secret');
+ *
+ * // In your webhook handler:
+ * const payload = await request.text();
+ * const signature = request.headers.get('X-Hookwing-Signature');
+ * const timestamp = request.headers.get('X-Hookwing-Timestamp');
+ *
+ * const event = await wh.verify(payload, { signature, timestamp });
+ * // event is typed as WebhookEvent
+ * ```
+ */
+
+export const SIGNATURE_HEADER = 'x-hookwing-signature';
+export const TIMESTAMP_HEADER = 'x-hookwing-timestamp';
+export const EVENT_TYPE_HEADER = 'x-event-type';
+
+/** Default tolerance window for timestamp verification (5 minutes) */
+const DEFAULT_TOLERANCE_MS = 5 * 60 * 1000;
+
+export interface WebhookEvent {
+  id: string;
+  type: string;
+  timestamp: number;
+  payload: unknown;
+}
+
+export interface VerifyHeaders {
+  signature: string | null;
+  timestamp: string | null;
+}
+
+export class WebhookVerificationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'WebhookVerificationError';
+  }
+}
+
+export class Webhook {
+  private readonly secret: string;
+  private readonly toleranceMs: number;
+
+  constructor(secret: string, options?: { toleranceMs?: number }) {
+    if (!secret) {
+      throw new Error('Webhook secret is required');
+    }
+    this.secret = secret.startsWith('whsec_') ? secret.slice(6) : secret;
+    this.toleranceMs = options?.toleranceMs ?? DEFAULT_TOLERANCE_MS;
+  }
+
+  /**
+   * Verify a webhook payload and return the parsed event.
+   * Throws WebhookVerificationError if the signature is invalid or the timestamp is stale.
+   */
+  async verify(payload: string, headers: VerifyHeaders): Promise<WebhookEvent> {
+    const { signature, timestamp } = headers;
+
+    if (!signature) {
+      throw new WebhookVerificationError('Missing X-Hookwing-Signature header');
+    }
+    if (!timestamp) {
+      throw new WebhookVerificationError('Missing X-Hookwing-Timestamp header');
+    }
+
+    // Validate timestamp format and staleness
+    const ts = Number(timestamp);
+    if (Number.isNaN(ts)) {
+      throw new WebhookVerificationError('Invalid X-Hookwing-Timestamp header');
+    }
+
+    const now = Date.now();
+    const age = Math.abs(now - ts);
+    if (age > this.toleranceMs) {
+      throw new WebhookVerificationError(
+        `Webhook timestamp too old (${Math.round(age / 1000)}s ago, tolerance: ${Math.round(this.toleranceMs / 1000)}s)`,
+      );
+    }
+
+    // Verify HMAC signature
+    const isValid = await this.verifySignature(payload, signature);
+    if (!isValid) {
+      throw new WebhookVerificationError('Webhook signature verification failed');
+    }
+
+    // Parse payload
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(payload);
+    } catch {
+      throw new WebhookVerificationError('Webhook payload is not valid JSON');
+    }
+
+    const event = parsed as Record<string, unknown>;
+
+    return {
+      id: typeof event['id'] === 'string' ? event['id'] : '',
+      type: typeof event['type'] === 'string' ? event['type'] : 'unknown',
+      timestamp: ts,
+      payload: event,
+    };
+  }
+
+  /**
+   * Verify signature only (without timestamp check).
+   * Use `verify()` in production — this is for testing.
+   */
+  async verifySignature(payload: string, signatureHeader: string): Promise<boolean> {
+    if (!signatureHeader.startsWith('sha256=')) {
+      return false;
+    }
+
+    const expectedSig = signatureHeader.slice(7);
+    const actualSig = await this.computeHmac(payload);
+
+    // Constant-time comparison
+    if (expectedSig.length !== actualSig.length) {
+      return false;
+    }
+
+    let result = 0;
+    for (let i = 0; i < expectedSig.length; i++) {
+      result |= (expectedSig.codePointAt(i) ?? 0) ^ (actualSig.codePointAt(i) ?? 0);
+    }
+    return result === 0;
+  }
+
+  private async computeHmac(payload: string): Promise<string> {
+    const encoder = new TextEncoder();
+    const keyData = encoder.encode(this.secret);
+    const messageData = encoder.encode(payload);
+
+    const key = await crypto.subtle.importKey('raw', keyData, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+    const signature = await crypto.subtle.sign('HMAC', key, messageData);
+    const hashArray = Array.from(new Uint8Array(signature));
+    return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+  }
+}

--- a/packages/sdk/src/webhook.ts
+++ b/packages/sdk/src/webhook.ts
@@ -103,8 +103,8 @@ export class Webhook {
     const event = parsed as Record<string, unknown>;
 
     return {
-      id: typeof event['id'] === 'string' ? event['id'] : '',
-      type: typeof event['type'] === 'string' ? event['type'] : 'unknown',
+      id: typeof event.id === 'string' ? event.id : '',
+      type: typeof event.type === 'string' ? event.type : 'unknown',
       timestamp: ts,
       payload: event,
     };
@@ -139,7 +139,13 @@ export class Webhook {
     const keyData = encoder.encode(this.secret);
     const messageData = encoder.encode(payload);
 
-    const key = await crypto.subtle.importKey('raw', keyData, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+    const key = await crypto.subtle.importKey(
+      'raw',
+      keyData,
+      { name: 'HMAC', hash: 'SHA-256' },
+      false,
+      ['sign'],
+    );
     const signature = await crypto.subtle.sign('HMAC', key, messageData);
     const hashArray = Array.from(new Uint8Array(signature));
     return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "lib": ["ES2022", "DOM"]
+  },
+  "include": ["src"]
+}

--- a/packages/sdk/vitest.config.ts
+++ b/packages/sdk/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
PROD-71: New `@hookwing/sdk` package for customer-side webhook signature verification.

**`Webhook` class:**
- `verify(payload, headers)` — verifies HMAC-SHA256 signature + timestamp freshness, returns typed `WebhookEvent`
- `verifySignature(payload, sig)` — raw signature check (no timestamp), for testing
- Configurable `toleranceMs` (default 5 min) to reject stale replays
- Constant-time comparison to prevent timing attacks
- Works in Node.js v18+, browsers, Cloudflare Workers, Deno

**16 tests** covering: constructor validation, signature verification, tampered payloads, stale timestamps, invalid JSON, missing headers.

15/15 turbo tasks green, biome clean.