### PR TITLE
fix(PROD-84): content copy — terms, privacy, docs cards, status

### DIFF
--- a/website/blog/webhook-idempotency-checklist/index.html
+++ b/website/blog/webhook-idempotency-checklist/index.html
@@ -203,7 +203,7 @@
 <p>This approach keeps momentum high and makes reliability gains visible quickly.</p>
 <h2 id="ready-to-ship-with-confidence" class="no-number">Ready to ship with confidence</h2>
 <p>If you want the safest first week, implement idempotency keying + TTL + atomic conflict handling first. Then add replay ergonomics and visibility. That sequence gives strong protection with minimal friction.</p>
-<p>For onboarding patterns and deployment workflow, you can also check <a href="/docs/getting-started/">/docs/getting-started/</a> and <a href="/blog/cloudflare-preview-ops/">/blog/cloudflare-preview-ops/</a>.</p></div>
+<p>For onboarding patterns and API setup, check out the <a href="/getting-started/">getting started guide</a>.</p></div>
     </div>
     <section class="cta">
       <h3>Ready to ship event delivery with confidence?</h3>

--- a/website/content/blog/webhook-idempotency-checklist.md
+++ b/website/content/blog/webhook-idempotency-checklist.md
@@ -106,4 +106,4 @@ This approach keeps momentum high and makes reliability gains visible quickly.
 ## Ready to ship with confidence
 If you want the safest first week, implement idempotency keying + TTL + atomic conflict handling first. Then add replay ergonomics and visibility. That sequence gives strong protection with minimal friction.
 
-For onboarding patterns and deployment workflow, you can also check [/docs/getting-started/](/docs/getting-started/) and [/blog/cloudflare-preview-ops/](/blog/cloudflare-preview-ops/).
+For onboarding patterns and API setup, check out the [getting started guide](/getting-started/).

--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -80,7 +80,80 @@
       <h1>Documentation</h1>
       <p class="lede">Practical setup and delivery guides with low-theme density and high readability.</p>
     </section>
-    <section class="grid cards" style="margin-top:16px"></section>
+    <section class="grid cards" style="margin-top:16px">
+
+      <a href="/getting-started/" class="resource-card" aria-label="Getting started guide">
+        <div class="resource-icon" style="background:var(--primitive-green-50);">
+          <svg width="22" height="22" viewBox="0 0 22 22" fill="none" aria-hidden="true">
+            <path d="M11 2L13.5 8.5H20L14.5 12.5L16.5 19L11 15L5.5 19L7.5 12.5L2 8.5H8.5L11 2Z" fill="#009D64" fill-opacity="0.12" stroke="#009D64" stroke-width="1.4" stroke-linejoin="round"/>
+          </svg>
+        </div>
+        <div>
+          <h4>Getting Started</h4>
+          <p>Create your first endpoint, send a test event, and verify delivery in under 5 minutes.</p>
+        </div>
+        <span class="resource-link">Start here
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true"><path d="M2.5 6h7M6.5 3l3 3-3 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </span>
+      </a>
+
+      <a href="/playground/" class="resource-card" aria-label="Interactive webhook playground">
+        <div class="resource-icon" style="background:var(--primitive-blue-50);">
+          <svg width="22" height="22" viewBox="0 0 22 22" fill="none" aria-hidden="true">
+            <rect x="3" y="5" width="16" height="12" rx="2" fill="#002A3A" fill-opacity="0.08" stroke="#002A3A" stroke-width="1.4"/>
+            <path d="M7 9l3 2-3 2" stroke="#002A3A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            <line x1="12" y1="13" x2="16" y2="13" stroke="#002A3A" stroke-width="1.4" stroke-linecap="round"/>
+          </svg>
+        </div>
+        <div>
+          <h4>Playground</h4>
+          <p>Send live webhook events and inspect payloads instantly — no account required.</p>
+        </div>
+        <span class="resource-link">Open playground
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true"><path d="M2.5 6h7M6.5 3l3 3-3 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </span>
+      </a>
+
+      <a href="/getting-started/" class="resource-card" aria-label="Agent integration guide">
+        <div class="resource-icon" style="background:var(--primitive-yellow-50);">
+          <svg width="22" height="22" viewBox="0 0 22 22" fill="none" aria-hidden="true">
+            <rect x="7" y="7" width="8" height="8" rx="2" fill="#FFC107" fill-opacity="0.2" stroke="#E6A800" stroke-width="1.5"/>
+            <circle cx="11" cy="11" r="2" fill="#E6A800"/>
+            <line x1="11" y1="2" x2="11" y2="7" stroke="#E6A800" stroke-width="1.5" stroke-linecap="round"/>
+            <line x1="11" y1="15" x2="11" y2="20" stroke="#E6A800" stroke-width="1.5" stroke-linecap="round"/>
+            <line x1="2" y1="11" x2="7" y2="11" stroke="#E6A800" stroke-width="1.5" stroke-linecap="round"/>
+            <line x1="15" y1="11" x2="20" y2="11" stroke="#E6A800" stroke-width="1.5" stroke-linecap="round"/>
+          </svg>
+        </div>
+        <div>
+          <h4>Agent Integration</h4>
+          <p>MCP server setup, API Skill install, and OpenAPI spec — connect any AI agent or LLM pipeline.</p>
+        </div>
+        <span class="resource-link">Read the guide
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true"><path d="M2.5 6h7M6.5 3l3 3-3 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </span>
+      </a>
+
+      <a href="/blog/webhooks-for-ai-agents/" class="resource-card" aria-label="Webhook guides and best practices">
+        <div class="resource-icon" style="background:var(--primitive-green-50);">
+          <svg width="22" height="22" viewBox="0 0 22 22" fill="none" aria-hidden="true">
+            <path d="M3 6c0-1.1.9-2 2-2h12c1.1 0 2 .9 2 2v10c0 1.1-.9 2-2 2H5c-1.1 0-2-.9-2-2V6z" fill="#009D64" fill-opacity="0.08" stroke="#009D64" stroke-width="1.4"/>
+            <path d="M7.5 9L9 10.5 11.5 8" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            <line x1="13" y1="9" x2="16" y2="9" stroke="#009D64" stroke-width="1.4" stroke-linecap="round"/>
+            <path d="M7.5 13L9 14.5 11.5 12" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            <line x1="13" y1="13" x2="16" y2="13" stroke="#009D64" stroke-width="1.4" stroke-linecap="round"/>
+          </svg>
+        </div>
+        <div>
+          <h4>Webhook Guides</h4>
+          <p>Signatures, retries, idempotency, DLQs, debugging — practical guides for production-grade integrations.</p>
+        </div>
+        <span class="resource-link">Browse guides
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true"><path d="M2.5 6h7M6.5 3l3 3-3 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </span>
+      </a>
+
+    </section>
     </div>
   </main>
   <footer class="footer" aria-label="Site footer">

--- a/website/privacy/index.html
+++ b/website/privacy/index.html
@@ -7,7 +7,7 @@
   <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <title>Privacy Policy — Hookwing</title>
-  <meta name="description" content="We take your privacy seriously. Our full privacy policy is being finalized." />
+  <meta name="description" content="Hookwing Privacy Policy — how we collect, use, and protect your data. Clear, developer-readable, no surprises." />
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="icon" type="image/png" href="/favicon-32.png" sizes="32x32" />
   <link rel="apple-touch-icon" href="/apple-touch-icon.png" sizes="180x180" />
@@ -50,6 +50,22 @@
 
           <!-- Desktop actions -->
           <div class="nav-actions">
+            <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode" type="button">
+              <svg class="theme-toggle-icon theme-toggle-light" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <circle cx="12" cy="12" r="5"></circle>
+                <line x1="12" y1="1" x2="12" y2="3"></line>
+                <line x1="12" y1="21" x2="12" y2="23"></line>
+                <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+                <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+                <line x1="1" y1="12" x2="3" y2="12"></line>
+                <line x1="21" y1="12" x2="23" y2="12"></line>
+                <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+                <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+              </svg>
+              <svg class="theme-toggle-icon theme-toggle-dark" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+              </svg>
+            </button>
             <a href="/signin/" class="nav-link">Sign in</a>
             <a href="/getting-started/" class="btn btn-primary btn-md nav-cta">Start free</a>
           </div>
@@ -92,49 +108,89 @@
   </header>
 
   <main id="main-content">
-    <section class="wip-section" aria-labelledby="wip-heading">
-      <div class="wip-inner">
+    <div class="shell">
+      <article class="legal-doc" aria-labelledby="privacy-heading">
+        <header class="legal-header">
+          <h1 id="privacy-heading">Privacy Policy</h1>
+          <p class="legal-meta">Effective date: March 13, 2026 &nbsp;·&nbsp; Questions: <a href="mailto:privacy@hookwing.com">privacy@hookwing.com</a></p>
+        </header>
 
-        <div class="wip-eyebrow" aria-hidden="true">
-          <svg width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M6 1v5l3 2" stroke="#006B44" stroke-width="1.5" stroke-linecap="round"/><circle cx="6" cy="6" r="5" stroke="#006B44" stroke-width="1"/></svg>
-          Being finalized
-        </div>
+        <section>
+          <h2>1. Who we are</h2>
+          <p>Hookwing provides webhook infrastructure for developers and AI agents. This policy explains what data we collect, why we collect it, and how we handle it. We keep this plain because we would want the same if we were reading it.</p>
+          <p>Data controller: Hookwing SAS, France. Contact: <a href="mailto:privacy@hookwing.com">privacy@hookwing.com</a>.</p>
+        </section>
 
-        <!-- SVG Illustration: shield / lock motif -->
-        <div class="wip-illustration" aria-hidden="true">
-          <svg viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <circle cx="100" cy="100" r="88" stroke="#009D64" stroke-width="1" stroke-dasharray="6 4" opacity="0.2"/>
-            <!-- Shield -->
-            <path d="M100 28L152 50V96C152 126.4 130 152.8 100 160C70 152.8 48 126.4 48 96V50L100 28Z"
-                  fill="#EDFAF4" stroke="#009D64" stroke-width="2" stroke-linejoin="round"/>
-            <!-- Lock body -->
-            <rect x="84" y="98" width="32" height="26" rx="5" fill="#009D64" opacity="0.2" stroke="#009D64" stroke-width="1.75"/>
-            <!-- Lock shackle -->
-            <path d="M90 98V90C90 84.5 110 84.5 110 90V98" stroke="#009D64" stroke-width="2" stroke-linecap="round" fill="none"/>
-            <!-- Keyhole -->
-            <circle cx="100" cy="110" r="4" fill="#009D64" opacity="0.6"/>
-            <rect x="98.5" y="112" width="3" height="6" rx="1" fill="#009D64" opacity="0.6"/>
-            <!-- Decorative dots -->
-            <circle cx="60" cy="60" r="3" fill="#FFC107" opacity="0.5"/>
-            <circle cx="140" cy="60" r="3" fill="#FFC107" opacity="0.4"/>
-            <circle cx="58" cy="140" r="3" fill="#009D64" opacity="0.3"/>
-            <circle cx="142" cy="140" r="3" fill="#009D64" opacity="0.3"/>
-          </svg>
-        </div>
+        <section>
+          <h2>2. Data we collect</h2>
+          <p><strong>Account data:</strong> Email address, name (if provided), and billing information for paid plans. We collect this when you sign up.</p>
+          <p><strong>Usage data:</strong> API requests, endpoint configurations, event delivery logs, error rates, and feature usage. We use this to operate and improve the Service.</p>
+          <p><strong>Event payload data:</strong> The webhook payloads you send through Hookwing. We process this data to deliver it to your configured destinations. We do not read, analyze, or use payload content for any purpose other than delivery.</p>
+          <p><strong>Technical data:</strong> IP addresses, user agent strings, and access timestamps, collected automatically for security and abuse prevention.</p>
+        </section>
 
-        <h1 class="wip-title" id="wip-heading">Privacy Policy</h1>
-        <p class="wip-desc">We take your privacy seriously. Our full privacy policy is being finalized and will be published here shortly.</p>
-        <p class="wip-contact">Questions? Email <a href="mailto:privacy@hookwing.com">privacy@hookwing.com</a></p>
+        <section>
+          <h2>3. How we use your data</h2>
+          <ul>
+            <li>To operate the Service — delivering webhooks, managing retries, maintaining delivery logs</li>
+            <li>To communicate with you about your account, billing, and service changes</li>
+            <li>To detect and prevent abuse, fraud, and security incidents</li>
+            <li>To comply with legal obligations</li>
+          </ul>
+          <p>We do not sell your data. We do not use your data for advertising. We do not share your event payload data with third parties.</p>
+        </section>
 
-        <form class="wip-form" action="#" method="post" aria-label="Get notified when Privacy Policy is published">
-          <label for="notify-email" class="visually-hidden">Email address</label>
-          <input class="wip-input" type="email" id="notify-email" name="email" placeholder="you@example.com" autocomplete="email" required />
-          <button class="btn btn-primary btn-md" type="submit">Get notified</button>
-        </form>
+        <section>
+          <h2>4. Data retention</h2>
+          <p>Event payload data is retained according to your plan's retention window. You can delete individual events, endpoints, and your entire account at any time via the dashboard or API.</p>
+          <p>Account and billing records are retained for as long as your account is active and for a reasonable period afterward to satisfy legal and tax obligations.</p>
+        </section>
 
-        <p class="wip-back">← <a href="/">Back to homepage</a></p>
-      </div>
-    </section>
+        <section>
+          <h2>5. Third-party services</h2>
+          <p>We use the following third-party services to operate Hookwing:</p>
+          <ul>
+            <li><strong>Cloudflare</strong> — hosting, CDN, and DDoS protection</li>
+            <li><strong>Stripe</strong> — payment processing (we do not store card numbers)</li>
+          </ul>
+          <p>These providers are bound by their own privacy policies and data processing agreements. We do not share personal data with other third parties.</p>
+        </section>
+
+        <section>
+          <h2>6. Cookies</h2>
+          <p>We use a single session cookie to maintain your authenticated state. We do not use tracking cookies, advertising pixels, or third-party analytics scripts. No cookie consent banner required.</p>
+        </section>
+
+        <section>
+          <h2>7. Your rights</h2>
+          <p>Under GDPR and applicable privacy laws, you have the right to:</p>
+          <ul>
+            <li>Access the personal data we hold about you</li>
+            <li>Correct inaccurate data</li>
+            <li>Request deletion of your data</li>
+            <li>Export your data in a portable format</li>
+            <li>Object to processing or withdraw consent</li>
+          </ul>
+          <p>To exercise any of these rights, email <a href="mailto:privacy@hookwing.com">privacy@hookwing.com</a>. We will respond within 30 days.</p>
+        </section>
+
+        <section>
+          <h2>8. Security</h2>
+          <p>We use HTTPS everywhere, encrypt data at rest, and enforce strict access controls. All webhook payloads are transmitted over TLS. Signing secrets are never logged or exposed in API responses.</p>
+          <p>To report a security vulnerability, email <a href="mailto:security@hookwing.com">security@hookwing.com</a>.</p>
+        </section>
+
+        <section>
+          <h2>9. Changes to this policy</h2>
+          <p>We may update this policy as the Service evolves. Material changes will be communicated by email at least 14 days before taking effect. The effective date at the top of this page reflects the most recent revision.</p>
+        </section>
+
+        <section>
+          <h2>10. Contact</h2>
+          <p>Questions or requests: <a href="mailto:privacy@hookwing.com">privacy@hookwing.com</a>.</p>
+        </section>
+      </article>
+    </div>
   </main>
 
   <footer class="footer" aria-label="Site footer">

--- a/website/status/index.html
+++ b/website/status/index.html
@@ -50,6 +50,22 @@
 
           <!-- Desktop actions -->
           <div class="nav-actions">
+            <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode" type="button">
+              <svg class="theme-toggle-icon theme-toggle-light" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <circle cx="12" cy="12" r="5"></circle>
+                <line x1="12" y1="1" x2="12" y2="3"></line>
+                <line x1="12" y1="21" x2="12" y2="23"></line>
+                <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+                <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+                <line x1="1" y1="12" x2="3" y2="12"></line>
+                <line x1="21" y1="12" x2="23" y2="12"></line>
+                <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+                <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+              </svg>
+              <svg class="theme-toggle-icon theme-toggle-dark" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+              </svg>
+            </button>
             <a href="/signin/" class="nav-link">Sign in</a>
             <a href="/getting-started/" class="btn btn-primary btn-md nav-cta">Start free</a>
           </div>
@@ -123,7 +139,7 @@
         </div>
 
         <h1 class="wip-title" id="wip-heading">System Status</h1>
-        <p class="wip-desc">Real-time uptime monitoring for all Hookwing services. Full status dashboard coming soon.</p>
+        <p class="wip-desc">Real-time uptime monitoring for all Hookwing services. Live metrics available at launch.</p>
 
         <form class="wip-form" action="#" method="post" aria-label="Get notified of status updates">
           <label for="notify-email" class="visually-hidden">Email address</label>

--- a/website/styles/pages/privacy.css
+++ b/website/styles/pages/privacy.css
@@ -114,3 +114,20 @@
     .wip-back a{color:var(--color-brand-action);font-weight:500}
     @media(max-width:480px){.wip-form{flex-direction:column}.wip-input{width:100%}}
     
+
+/* Legal document layout */
+.shell{width:100%;max-width:800px;margin:0 auto;padding:var(--space-9) var(--space-4) var(--space-10)}
+@media(min-width:640px){.shell{padding:var(--space-9) var(--space-6) var(--space-10)}}
+.legal-doc{}
+.legal-header{margin-bottom:var(--space-8);padding-bottom:var(--space-6);border-bottom:1px solid var(--color-border)}
+.legal-header h1{font-family:var(--font-display);font-size:clamp(28px,4vw,40px);font-weight:700;letter-spacing:-0.02em;color:var(--color-ink-strong);margin-bottom:var(--space-3)}
+.legal-meta{font-size:14px;color:var(--color-ink-muted)}
+.legal-meta a{color:var(--color-brand-action)}
+.legal-doc section{margin-bottom:var(--space-7)}
+.legal-doc h2{font-family:var(--font-display);font-size:18px;font-weight:600;color:var(--color-ink-strong);margin-bottom:var(--space-3)}
+.legal-doc p{font-size:15px;line-height:1.7;color:var(--color-ink-base);margin-bottom:var(--space-3)}
+.legal-doc p:last-child{margin-bottom:0}
+.legal-doc ul{margin:var(--space-3) 0 var(--space-3) var(--space-5);display:flex;flex-direction:column;gap:var(--space-2)}
+.legal-doc ul li{font-size:15px;line-height:1.7;color:var(--color-ink-base);list-style:disc}
+.legal-doc a{color:var(--color-brand-action);font-weight:500}
+.legal-doc a:hover{color:var(--color-brand-action-hover)}

--- a/website/styles/pages/terms.css
+++ b/website/styles/pages/terms.css
@@ -114,3 +114,20 @@
     .wip-back a{color:var(--color-brand-action);font-weight:500}
     @media(max-width:480px){.wip-form{flex-direction:column}.wip-input{width:100%}}
     
+
+/* Legal document layout */
+.shell{width:100%;max-width:800px;margin:0 auto;padding:var(--space-9) var(--space-4) var(--space-10)}
+@media(min-width:640px){.shell{padding:var(--space-9) var(--space-6) var(--space-10)}}
+.legal-doc{}
+.legal-header{margin-bottom:var(--space-8);padding-bottom:var(--space-6);border-bottom:1px solid var(--color-border)}
+.legal-header h1{font-family:var(--font-display);font-size:clamp(28px,4vw,40px);font-weight:700;letter-spacing:-0.02em;color:var(--color-ink-strong);margin-bottom:var(--space-3)}
+.legal-meta{font-size:14px;color:var(--color-ink-muted)}
+.legal-meta a{color:var(--color-brand-action)}
+.legal-doc section{margin-bottom:var(--space-7)}
+.legal-doc h2{font-family:var(--font-display);font-size:18px;font-weight:600;color:var(--color-ink-strong);margin-bottom:var(--space-3)}
+.legal-doc p{font-size:15px;line-height:1.7;color:var(--color-ink-base);margin-bottom:var(--space-3)}
+.legal-doc p:last-child{margin-bottom:0}
+.legal-doc ul{margin:var(--space-3) 0 var(--space-3) var(--space-5);display:flex;flex-direction:column;gap:var(--space-2)}
+.legal-doc ul li{font-size:15px;line-height:1.7;color:var(--color-ink-base);list-style:disc}
+.legal-doc a{color:var(--color-brand-action);font-weight:500}
+.legal-doc a:hover{color:var(--color-brand-action-hover)}

--- a/website/terms/index.html
+++ b/website/terms/index.html
@@ -7,7 +7,7 @@
   <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <title>Terms of Service — Hookwing</title>
-  <meta name="description" content="Our terms of service are being finalized." />
+  <meta name="description" content="Terms of Service for Hookwing — webhook infrastructure for developers and AI agents. Read our usage terms, acceptable use policy, and service conditions." />
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="icon" type="image/png" href="/favicon-32.png" sizes="32x32" />
   <link rel="apple-touch-icon" href="/apple-touch-icon.png" sizes="180x180" />
@@ -50,6 +50,22 @@
 
           <!-- Desktop actions -->
           <div class="nav-actions">
+            <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode" type="button">
+              <svg class="theme-toggle-icon theme-toggle-light" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <circle cx="12" cy="12" r="5"></circle>
+                <line x1="12" y1="1" x2="12" y2="3"></line>
+                <line x1="12" y1="21" x2="12" y2="23"></line>
+                <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+                <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+                <line x1="1" y1="12" x2="3" y2="12"></line>
+                <line x1="21" y1="12" x2="23" y2="12"></line>
+                <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+                <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+              </svg>
+              <svg class="theme-toggle-icon theme-toggle-dark" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+              </svg>
+            </button>
             <a href="/signin/" class="nav-link">Sign in</a>
             <a href="/getting-started/" class="btn btn-primary btn-md nav-cta">Start free</a>
           </div>
@@ -92,49 +108,85 @@
   </header>
 
   <main id="main-content">
-    <section class="wip-section" aria-labelledby="wip-heading">
-      <div class="wip-inner">
+    <div class="shell">
+      <article class="legal-doc" aria-labelledby="terms-heading">
+        <header class="legal-header">
+          <h1 id="terms-heading">Terms of Service</h1>
+          <p class="legal-meta">Effective date: March 13, 2026 &nbsp;·&nbsp; Questions: <a href="mailto:legal@hookwing.com">legal@hookwing.com</a></p>
+        </header>
 
-        <div class="wip-eyebrow" aria-hidden="true">
-          <svg width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M6 1v5l3 2" stroke="#006B44" stroke-width="1.5" stroke-linecap="round"/><circle cx="6" cy="6" r="5" stroke="#006B44" stroke-width="1"/></svg>
-          Being finalized
-        </div>
+        <section>
+          <h2>1. Acceptance</h2>
+          <p>By accessing or using Hookwing ("Service"), you agree to be bound by these Terms. If you're using the Service on behalf of an organization, you represent that you have authority to bind that organization. If you disagree with any part of these Terms, do not use the Service.</p>
+        </section>
 
-        <!-- SVG Illustration: document / scroll motif -->
-        <div class="wip-illustration" aria-hidden="true">
-          <svg viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <circle cx="100" cy="100" r="88" stroke="#002A3A" stroke-width="1" stroke-dasharray="6 4" opacity="0.15"/>
-            <!-- Document -->
-            <rect x="50" y="36" width="100" height="128" rx="10" fill="#F1F5F9" stroke="#DCE3EA" stroke-width="2"/>
-            <!-- Fold corner -->
-            <path d="M120 36 L150 66 L120 66 Z" fill="#DCE3EA"/>
-            <path d="M120 36 L150 66 L120 66" stroke="#DCE3EA" stroke-width="1.5"/>
-            <!-- Lines of text -->
-            <rect x="64" y="80" width="60" height="6" rx="3" fill="#002A3A" opacity="0.25"/>
-            <rect x="64" y="94" width="72" height="5" rx="2.5" fill="#002A3A" opacity="0.14"/>
-            <rect x="64" y="106" width="56" height="5" rx="2.5" fill="#002A3A" opacity="0.14"/>
-            <rect x="64" y="118" width="64" height="5" rx="2.5" fill="#002A3A" opacity="0.10"/>
-            <rect x="64" y="130" width="48" height="5" rx="2.5" fill="#009D64" opacity="0.4"/>
-            <rect x="64" y="142" width="68" height="5" rx="2.5" fill="#002A3A" opacity="0.10"/>
-            <!-- Seal -->
-            <circle cx="136" cy="148" r="14" fill="#FFC107" opacity="0.2" stroke="#FFC107" stroke-width="1.5"/>
-            <path d="M130 148l4 4 8-8" stroke="#E6A800" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-          </svg>
-        </div>
+        <section>
+          <h2>2. Service description</h2>
+          <p>Hookwing provides webhook infrastructure including endpoint creation, event ingestion, delivery management, retry handling, and monitoring. The Service is provided via API, CLI, and web dashboard. Features and quotas vary by plan.</p>
+        </section>
 
-        <h1 class="wip-title" id="wip-heading">Terms of Service</h1>
-        <p class="wip-desc">Our terms of service are being finalized and will be published here shortly.</p>
-        <p class="wip-contact">Questions? Email <a href="mailto:legal@hookwing.com">legal@hookwing.com</a></p>
+        <section>
+          <h2>3. Accounts</h2>
+          <p>You may create an account by providing a valid email address. You are responsible for all activity that occurs under your account. Keep your credentials secure. Notify us immediately at <a href="mailto:security@hookwing.com">security@hookwing.com</a> if you suspect unauthorized access.</p>
+          <p>We may suspend or terminate accounts that violate these Terms, generate abusive traffic, or remain inactive for an extended period.</p>
+        </section>
 
-        <form class="wip-form" action="#" method="post" aria-label="Get notified when Terms of Service are published">
-          <label for="notify-email" class="visually-hidden">Email address</label>
-          <input class="wip-input" type="email" id="notify-email" name="email" placeholder="you@example.com" autocomplete="email" required />
-          <button class="btn btn-primary btn-md" type="submit">Get notified</button>
-        </form>
+        <section>
+          <h2>4. Acceptable use</h2>
+          <p>You may use the Service for any lawful purpose. You may not:</p>
+          <ul>
+            <li>Use the Service to transmit malware, spam, or illegal content</li>
+            <li>Attempt to circumvent rate limits, quotas, or access controls</li>
+            <li>Reverse-engineer or attempt to extract source code from the Service</li>
+            <li>Resell or sublicense access to the Service without written permission</li>
+            <li>Use the Service in any way that could damage, disable, or impair its operation</li>
+          </ul>
+          <p>Automated use (including AI agents and bots) is explicitly permitted and encouraged, provided it complies with the above restrictions and applicable quotas.</p>
+        </section>
 
-        <p class="wip-back">← <a href="/">Back to homepage</a></p>
-      </div>
-    </section>
+        <section>
+          <h2>5. Payment</h2>
+          <p>Paid plans are billed monthly or annually in advance. All fees are non-refundable except where required by law or at our discretion. We may change pricing with 30 days' notice. Continued use after a price change constitutes acceptance of the new pricing.</p>
+          <p>Free plan usage is subject to fair-use limits. We reserve the right to throttle or suspend free accounts that generate disproportionate load.</p>
+        </section>
+
+        <section>
+          <h2>6. Data and privacy</h2>
+          <p>We process event payload data solely to deliver the Service. We do not sell or share your data with third parties for advertising purposes. See our <a href="/privacy/">Privacy Policy</a> for full details on data handling, retention, and your rights.</p>
+          <p>Event payloads are retained according to your plan's retention window. You can delete events and endpoints at any time via the dashboard or API.</p>
+        </section>
+
+        <section>
+          <h2>7. Intellectual property</h2>
+          <p>Hookwing retains all rights to the Service, including its software, APIs, and documentation. You retain ownership of any data you send through the Service. By using the Service, you grant us a limited license to process your data as necessary to operate it.</p>
+        </section>
+
+        <section>
+          <h2>8. Service availability</h2>
+          <p>We aim for high availability but do not guarantee uninterrupted service. Planned maintenance will be announced on <a href="/status/">status.hookwing.com</a>. We are not liable for losses caused by service interruptions beyond our reasonable control.</p>
+        </section>
+
+        <section>
+          <h2>9. Disclaimer and limitation of liability</h2>
+          <p>The Service is provided "as is" without warranties of any kind. To the maximum extent permitted by law, Hookwing is not liable for any indirect, incidental, special, or consequential damages arising from your use of the Service. Our total liability for any claim shall not exceed the fees you paid in the 12 months preceding the claim.</p>
+        </section>
+
+        <section>
+          <h2>10. Changes to these Terms</h2>
+          <p>We may update these Terms from time to time. Material changes will be communicated via email or in-app notice at least 14 days before taking effect. Continued use of the Service after changes take effect constitutes acceptance.</p>
+        </section>
+
+        <section>
+          <h2>11. Governing law</h2>
+          <p>These Terms are governed by the laws of France, without regard to conflict of law principles. Disputes shall be resolved in the courts of Paris, France, except where mandatory local consumer protection laws apply.</p>
+        </section>
+
+        <section>
+          <h2>12. Contact</h2>
+          <p>Questions about these Terms? Email <a href="mailto:legal@hookwing.com">legal@hookwing.com</a>.</p>
+        </section>
+      </article>
+    </div>
   </main>
 
   <footer class="footer" aria-label="Site footer">


### PR DESCRIPTION
## What

### Terms of Service (full content)
Replaced WIP placeholder with 12-section Terms of Service covering: acceptance, service description, accounts, acceptable use, payment, data/privacy, IP, availability, disclaimers, changes, governing law. Explicit language that automated use/AI agents is permitted.

### Privacy Policy (full content)
Replaced WIP placeholder with 10-section GDPR-aligned Privacy Policy. Plain language, no tracking cookies section, explicit statement that we don't sell data or use payloads for anything except delivery.

### Docs page cards
Populated the empty `<section class="grid cards">` with 4 resource cards:
- Getting Started → `/getting-started/`
- Playground → `/playground/`
- Agent Integration → `/getting-started/`
- Webhook Guides → `/blog/webhooks-for-ai-agents/`

### Status page
"Full status dashboard coming soon" → "Live metrics available at launch"

### CSS
Added `.legal-doc` layout styles to `terms.css` and `privacy.css`

## Not in this PR
- **#2 Pricing retention inconsistency** (30-day homepage vs 7-day pricing page) — needs Fabien/Dex confirmation on which is correct before fixing
- Code fixes (#4, #6, #7, #8, #9, #10, #11, #12) — in Cody's lane