### PR TITLE
fix(PROD-88): cross-browser & mobile responsive fixes

### DIFF
--- a/website/styles/base.css
+++ b/website/styles/base.css
@@ -40,6 +40,11 @@ h1, h2, h3, h4, h5 {
 h1 { font-size: 52px; line-height: 60px; letter-spacing: -0.02em; }
 h2 { font-size: 38px; line-height: 48px; font-weight: 600; }
 h3 { font-size: 28px; line-height: 36px; font-weight: 600; }
+
+@media (max-width: 480px) {
+  h1 { font-size: 36px; line-height: 44px; }
+  h2 { font-size: 28px; line-height: 36px; }
+}
 h4 { font-size: 22px; line-height: 30px; font-weight: 600; }
 h5 { font-size: 18px; line-height: 26px; font-weight: 600; }
 

--- a/website/styles/components.css
+++ b/website/styles/components.css
@@ -1,4 +1,23 @@
 /* ============================================================
+   SKIP LINK — visually hidden, shown on focus (a11y)
+============================================================ */
+.skip-link {
+  position: absolute;
+  top: -100%;
+  left: var(--space-4);
+  background: var(--color-brand-primary);
+  color: #fff;
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-sm);
+  font-size: 14px;
+  font-weight: 600;
+  z-index: 9999;
+  text-decoration: none;
+  transition: top var(--dur-fast) var(--ease);
+}
+.skip-link:focus { top: var(--space-2); }
+
+/* ============================================================
    BUTTONS
 ============================================================ */
 .btn {

--- a/website/styles/pages/signin.css
+++ b/website/styles/pages/signin.css
@@ -71,7 +71,7 @@
     .nav-mobile-link{font-family:var(--font-body);font-size:16px;font-weight:500;color:var(--color-ink-base);text-decoration:none;padding:var(--space-3) var(--space-2);border-radius:var(--radius-sm);border-bottom:1px solid var(--color-border)}
     .nav-mobile-link:last-child{border-bottom:none}.nav-mobile-link:hover{color:var(--color-brand-action)}
     .nav-mobile-actions{display:flex;flex-direction:column;gap:var(--space-3)}
-    @media(max-width:768px){.nav-links{display:none}.nav-signin{display:none}.nav-hamburger{display:flex}}
+    @media(max-width:768px){.nav-links{display:none}.nav-signin{display:none}.nav-cta{display:none}.nav-hamburger{display:flex}}
     .footer{background:#001A24;color:rgba(255,255,255,.75);padding:var(--space-10) 0 var(--space-6)}
     .footer-grid{display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:var(--space-8);padding-bottom:var(--space-8);border-bottom:1px solid rgba(255,255,255,.08)}
     .footer-brand-name{font-family:var(--font-display);font-size:18px;font-weight:700;color:#fff;text-decoration:none;display:inline-flex;align-items:center;gap:var(--space-2);margin-bottom:var(--space-3)}
@@ -120,5 +120,6 @@
     .signin-register a{color:var(--color-brand-action);font-weight:600}
     .wip-notice{display:flex;align-items:center;gap:var(--space-2);background:var(--color-success-bg);border:1px solid var(--primitive-green-100);border-radius:var(--radius-md);padding:var(--space-3) var(--space-4);margin-bottom:var(--space-6);font-size:14px;color:var(--primitive-green-700)}
 .error-message{display:flex;align-items:center;gap:var(--space-2);background:var(--color-error-bg,#FEE2E2);border:1px solid rgba(220,38,38,.3);border-radius:var(--radius-md);padding:var(--space-3) var(--space-4);margin-bottom:var(--space-6);font-size:14px;color:var(--color-error,#DC2626)}
+.error-message[hidden]{display:none}
     
     

--- a/website/styles/pages/signup.css
+++ b/website/styles/pages/signup.css
@@ -71,7 +71,7 @@
     .nav-mobile-link{font-family:var(--font-body);font-size:16px;font-weight:500;color:var(--color-ink-base);text-decoration:none;padding:var(--space-3) var(--space-2);border-radius:var(--radius-sm);border-bottom:1px solid var(--color-border)}
     .nav-mobile-link:last-child{border-bottom:none}.nav-mobile-link:hover{color:var(--color-brand-action)}
     .nav-mobile-actions{display:flex;flex-direction:column;gap:var(--space-3)}
-    @media(max-width:768px){.nav-links{display:none}.nav-signin{display:none}.nav-hamburger{display:flex}}
+    @media(max-width:768px){.nav-links{display:none}.nav-signin{display:none}.nav-cta{display:none}.nav-hamburger{display:flex}}
     .footer{background:#001A24;color:rgba(255,255,255,.75);padding:var(--space-10) 0 var(--space-6)}
     .footer-grid{display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:var(--space-8);padding-bottom:var(--space-8);border-bottom:1px solid rgba(255,255,255,.08)}
     .footer-brand-name{font-family:var(--font-display);font-size:18px;font-weight:700;color:#fff;text-decoration:none;display:inline-flex;align-items:center;gap:var(--space-2);margin-bottom:var(--space-3)}
@@ -120,5 +120,6 @@
     .signup-signin a{color:var(--color-brand-action);font-weight:600}
     .wip-notice{display:flex;align-items:center;gap:var(--space-2);background:var(--color-success-bg);border:1px solid var(--primitive-green-100);border-radius:var(--radius-md);padding:var(--space-3) var(--space-4);margin-bottom:var(--space-6);font-size:14px;color:var(--primitive-green-700)}
 .error-message{display:flex;align-items:center;gap:var(--space-2);background:var(--color-error-bg,#FEE2E2);border:1px solid rgba(220,38,38,.3);border-radius:var(--radius-md);padding:var(--space-3) var(--space-4);margin-bottom:var(--space-6);font-size:14px;color:var(--color-error,#DC2626)}
+.error-message[hidden]{display:none}
     
     


### PR DESCRIPTION
PROD-88: Cross-browser and mobile responsive audit.

## Tested breakpoints
375px, 768px, 1024px, 1440px — across homepage, pricing, playground, docs, signin, signup, blog, use-cases, getting-started, app.

## Issues found & fixed

**1. Error message bar visible on signin/signup (all breakpoints)**
- `.error-message { display: flex }` overrode the HTML `hidden` attribute
- Fix: Added `.error-message[hidden] { display: none }` to both signin.css and signup.css

**2. "Start free" button clipped at 375px on signin/signup**
- Page-specific CSS media query at max-width:768px was missing `.nav-cta { display: none }`
- Fix: Added `.nav-cta{display:none}` to the mobile media query in both pages

**3. Docs h1 "Documentation" truncated at 375px**
- Base h1 at 52px overflows 343px content area on small phones
- Fix: Added responsive media query at ≤480px → h1: 36px, h2: 28px

**4. Skip-to-content link visible on playground at 375px**
- `.skip-link` styles only existed in page-specific CSS (home, why-hookwing, changelog)
- Fix: Added global `.skip-link` styles to components.css

## Escalated (design/brand)
- Dark mode toggle works but visual difference is minimal (site already dark-themed) — Brenda
- Fazier footer link only on homepage — Brenda (from PROD-83)

## Pages verified clean at all breakpoints
Homepage ✅ | Pricing ✅ | Playground ✅ | Docs ✅ | Signin ✅ | Signup ✅ | Blog ✅ | Use-cases ✅ | Getting-started ✅ | App ✅