### PR TITLE
fix(PROD-89): remove Fazier badge, confirm 7-day retention

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <!-- Security meta tags -->
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://hookwing.com https://fazier.com; connect-src 'self'; base-uri 'self'; form-action 'self';" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://hookwing.com; connect-src 'self'; base-uri 'self'; form-action 'self';" />
   <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <title>Hookwing - Webhook infrastructure built for agents</title>
@@ -850,7 +850,6 @@
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
           Built for developers and AI agents.
         </p>
-        <a href="https://fazier.com" target="_blank" rel="noopener" style="display:inline-block;margin-top:8px;opacity:.4;transition:opacity .2s;" onmouseover="this.style.opacity='.7'" onmouseout="this.style.opacity='.4'"><img src="https://fazier.com/images/launched-on-fazier-badge.svg" alt="Launched on Fazier" width="120" height="auto" loading="lazy" /></a>
       </div>
 
     </div>


### PR DESCRIPTION
Per Fabien's decisions:

1. **Fazier badge → removed** from homepage footer. Will add platform badges later with traction.
   - Removed `<a>` + `<img>` badge link
   - Cleaned `https://fazier.com` from CSP `img-src`

2. **Event retention → 7-day** already correct in homepage (fixed in PROD-84). Pricing page + comparison table also say 7-day. No change needed.