### PR TITLE
fix: remove node -e syntax error in deploy preCommands

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -103,32 +103,24 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: packages/api
           preCommands: |
-            # Create Queue (idempotent — fails silently if exists)
+            # Create Queue (idempotent — no-op if exists)
             wrangler queues create webhook-delivery-dev || true
 
-            # Create D1 database (idempotent)
+            # Create D1 database (idempotent — no-op if exists)
+            # NOTE: Requires CF token to have D1:Edit permission
             wrangler d1 create hookwing-dev || true
 
-            # Resolve D1 database ID and patch wrangler.toml
-            DB_ID=$(wrangler d1 list --json 2>/dev/null | node -e "
-              try {
-                const dbs = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
-                const db = dbs.find(d => d.name === 'hookwing-dev');
-                if (db) process.stdout.write(db.uuid);
-              } catch(e) {}
-            " || true)
-            if [ -z "$DB_ID" ]; then
-              DB_ID=$(wrangler d1 list 2>/dev/null | grep hookwing-dev | grep -oE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | head -1 || true)
-            fi
+            # Resolve D1 database ID using text parsing (no node required)
+            DB_ID=$(wrangler d1 list 2>/dev/null | grep -i "hookwing-dev" | grep -oE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | head -1 || true)
             if [ -n "$DB_ID" ]; then
-              echo "✅ D1 database ID: $DB_ID"
+              echo "D1 database ID resolved: $DB_ID"
               sed -i "s/database_id = \"placeholder-will-be-set-on-deploy\"/database_id = \"$DB_ID\"/" wrangler.toml
             else
-              echo "::warning::Could not resolve D1 database ID"
+              echo "::warning::Could not resolve D1 ID — token may be missing D1:Read permission"
             fi
 
             # Run migrations (idempotent — tables use IF NOT EXISTS)
             for f in ../../migrations/*.sql; do
-              [ -f "$f" ] && echo "Applying: $f" && wrangler d1 execute hookwing-dev --remote --file="$f" || true
+              [ -f "$f" ] && echo "Applying: $f" && wrangler d1 execute hookwing-dev --remote --file="$f" 2>&1 || true
             done
           command: deploy


### PR DESCRIPTION
Fixes 'Unterminated quoted string' error in preCommands — the `node -e` multiline heredoc inside YAML isn't valid sh.

Replaced with `grep -oE UUID-regex` which extracts the D1 ID from wrangler's text output without needing node.

**Status after this PR:**
- ✅ Queue creation: works (confirmed run 23060207270 — `✅ Created queue webhook-delivery-dev`)
- ⚠️ D1 creation: blocked by CF token missing `D1:Edit` permission — needs Fabien to add D1 permissions to the API token
- ⚠️ D1 ID resolution: will work once D1 permission is granted

**Action needed from Fabien:** Add `D1:Edit` (and `D1:Read`) to the `CLOUDFLARE_API_TOKEN` GitHub secret.