### PR TITLE
feat(PROD-95/99): 3-tier pricing — Paper Plane, Warbird ($9), Stealth Jet ($99)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -11,3 +11,4 @@
 | 2026-03-13 | All deploys through CI — no manual deploys | Fabien | SOC 2 principle: audit trail for all changes |
 | 2026-03-13 | Dev domain only (dev.hookwing.com) — never share .pages.dev URLs | Fabien | Cloudflare Access protects dev domains; .pages.dev is unprotected |
 | 2026-03-13 | Infrastructure separation: product infra ≠ operational tooling | Fabien | SOC 2 Type 2 compliance principle |
+| 2026-03-13 | 3-tier pricing: Paper Plane (free), Warbird ($9), Stealth Jet ($99) — Jet tier removed | Fabien | Simpler pricing, $9 entry point lowers barrier |

--- a/packages/api/src/__tests__/tiers.test.ts
+++ b/packages/api/src/__tests__/tiers.test.ts
@@ -4,22 +4,29 @@ import app from '../index';
 import { checkTierFeature } from '../middleware/tier';
 
 describe('GET /tiers', () => {
-  it('should return 200 with array of 4 tiers', async () => {
+  it('should return 200 with array of 3 tiers', async () => {
     const res = await app.request('/tiers');
     expect(res.status).toBe(200);
     const body = (await res.json()) as unknown[];
     expect(Array.isArray(body)).toBe(true);
-    expect(body).toHaveLength(4);
+    expect(body).toHaveLength(3);
   });
 
-  it('should include all 4 tier slugs', async () => {
+  it('should include all 3 tier slugs', async () => {
     const res = await app.request('/tiers');
     const body = (await res.json()) as Array<{ slug: string }>;
     const slugs = body.map((t) => t.slug);
     expect(slugs).toContain('paper-plane');
-    expect(slugs).toContain('biplane');
     expect(slugs).toContain('warbird');
-    expect(slugs).toContain('jet');
+    expect(slugs).toContain('stealth-jet');
+  });
+
+  it('should NOT include removed tiers', async () => {
+    const res = await app.request('/tiers');
+    const body = (await res.json()) as Array<{ slug: string }>;
+    const slugs = body.map((t) => t.slug);
+    expect(slugs).not.toContain('biplane');
+    expect(slugs).not.toContain('jet');
   });
 });
 
@@ -33,9 +40,16 @@ describe('GET /tiers/:slug', () => {
   });
 
   it('should return 200 for each valid tier slug', async () => {
-    for (const slug of ['paper-plane', 'biplane', 'warbird', 'jet']) {
+    for (const slug of ['paper-plane', 'warbird', 'stealth-jet']) {
       const res = await app.request(`/tiers/${slug}`);
       expect(res.status).toBe(200);
+    }
+  });
+
+  it('should return 404 for removed tier slugs', async () => {
+    for (const slug of ['biplane', 'jet']) {
+      const res = await app.request(`/tiers/${slug}`);
+      expect(res.status).toBe(404);
     }
   });
 
@@ -65,16 +79,9 @@ describe('checkTierFeature middleware', () => {
     expect(body.feature).toBe('analytics');
   });
 
-  it('should allow access (200) to features available on paper-plane', async () => {
-    // webhook_signing is NOT on paper-plane, but the health endpoint has no tier guard
-    // Test an unrestricted feature — paper-plane has no boolean-true features,
-    // so let's verify that a feature paper-plane DOES have passes through.
-    // Since all boolean features are false on paper-plane, test via team_members workaround:
-    // Instead, confirm the middleware works by testing with 'ip_whitelist' on a jet-level stub
+  it('should allow access to unguarded endpoints', async () => {
     const testApp = new Hono();
-    // Patch: override tier to jet by testing the pattern directly
     testApp.get('/open', (c) => c.json({ ok: true }));
-
     const res = await testApp.request('/open');
     expect(res.status).toBe(200);
   });

--- a/packages/shared/src/__tests__/tiers.test.ts
+++ b/packages/shared/src/__tests__/tiers.test.ts
@@ -9,21 +9,36 @@ import {
 } from '../config/tiers';
 
 describe('DEFAULT_TIERS', () => {
-  it('should have exactly 4 tiers', () => {
-    expect(DEFAULT_TIERS).toHaveLength(4);
+  it('should have exactly 3 tiers', () => {
+    expect(DEFAULT_TIERS).toHaveLength(3);
   });
 
   it('should contain all required tier slugs', () => {
     const slugs = DEFAULT_TIERS.map((t) => t.slug);
     expect(slugs).toContain('paper-plane');
-    expect(slugs).toContain('biplane');
     expect(slugs).toContain('warbird');
-    expect(slugs).toContain('jet');
+    expect(slugs).toContain('stealth-jet');
+  });
+
+  it('should NOT contain removed tiers', () => {
+    const slugs = DEFAULT_TIERS.map((t) => t.slug);
+    expect(slugs).not.toContain('biplane');
+    expect(slugs).not.toContain('jet');
   });
 
   it('should have price_monthly_usd = 0 for paper-plane (free tier)', () => {
     const tier = getTierBySlug('paper-plane');
     expect(tier?.price_monthly_usd).toBe(0);
+  });
+
+  it('should have warbird at $9/mo', () => {
+    const tier = getTierBySlug('warbird');
+    expect(tier?.price_monthly_usd).toBe(9);
+  });
+
+  it('should have stealth-jet at $99/mo', () => {
+    const tier = getTierBySlug('stealth-jet');
+    expect(tier?.price_monthly_usd).toBe(99);
   });
 
   it('should have increasing prices across tiers', () => {
@@ -47,10 +62,15 @@ describe('getTierBySlug', () => {
     expect(tier?.name).toBe('Paper Plane');
   });
 
-  it('should return jet tier by slug', () => {
-    const tier = getTierBySlug('jet');
+  it('should return stealth-jet tier by slug', () => {
+    const tier = getTierBySlug('stealth-jet');
     expect(tier).toBeDefined();
-    expect(tier?.name).toBe('Jet');
+    expect(tier?.name).toBe('Stealth Jet');
+  });
+
+  it('should return undefined for removed tiers', () => {
+    expect(getTierBySlug('biplane')).toBeUndefined();
+    expect(getTierBySlug('jet')).toBeUndefined();
   });
 
   it('should return undefined for unknown slug', () => {
@@ -69,14 +89,14 @@ describe('isFeatureEnabled', () => {
     expect(isFeatureEnabled(tier, 'analytics')).toBe(false);
   });
 
-  it('should return true for custom_headers on biplane', () => {
-    const tier = getTierBySlug('biplane')!;
+  it('should return true for custom_headers on warbird', () => {
+    const tier = getTierBySlug('warbird')!;
     expect(isFeatureEnabled(tier, 'custom_headers')).toBe(true);
     expect(isFeatureEnabled(tier, 'webhook_signing')).toBe(true);
   });
 
-  it('should return true for all features on jet', () => {
-    const tier = getTierBySlug('jet')!;
+  it('should return true for all features on stealth-jet', () => {
+    const tier = getTierBySlug('stealth-jet')!;
     expect(isFeatureEnabled(tier, 'custom_headers')).toBe(true);
     expect(isFeatureEnabled(tier, 'ip_whitelist')).toBe(true);
     expect(isFeatureEnabled(tier, 'transformations')).toBe(true);
@@ -99,9 +119,9 @@ describe('isWithinLimit', () => {
     expect(isWithinLimit(tier, 'max_destinations', tier.limits.max_destinations + 1)).toBe(false);
   });
 
-  it('should return true for any limit on jet tier (high limits)', () => {
-    const tier = getTierBySlug('jet')!;
-    expect(isWithinLimit(tier, 'max_destinations', 100)).toBe(true);
+  it('should return true for high limits on stealth-jet', () => {
+    const tier = getTierBySlug('stealth-jet')!;
+    expect(isWithinLimit(tier, 'max_destinations', 50)).toBe(true);
     expect(isWithinLimit(tier, 'max_events_per_month', 1_000_000)).toBe(true);
   });
 
@@ -112,13 +132,12 @@ describe('isWithinLimit', () => {
 });
 
 describe('getUpgradePath', () => {
-  it('should return 3 upgrade options for paper-plane', () => {
+  it('should return 2 upgrade options for paper-plane', () => {
     const upgrades = getUpgradePath('paper-plane');
-    expect(upgrades).toHaveLength(3);
+    expect(upgrades).toHaveLength(2);
     const slugs = upgrades.map((t) => t.slug);
-    expect(slugs).toContain('biplane');
     expect(slugs).toContain('warbird');
-    expect(slugs).toContain('jet');
+    expect(slugs).toContain('stealth-jet');
   });
 
   it('should return tiers in ascending price order', () => {
@@ -128,14 +147,14 @@ describe('getUpgradePath', () => {
     }
   });
 
-  it('should return empty array for jet (no upgrades)', () => {
-    expect(getUpgradePath('jet')).toHaveLength(0);
+  it('should return empty array for stealth-jet (no upgrades)', () => {
+    expect(getUpgradePath('stealth-jet')).toHaveLength(0);
   });
 
-  it('should return 1 upgrade for warbird (only jet above it)', () => {
+  it('should return 1 upgrade for warbird (only stealth-jet above it)', () => {
     const upgrades = getUpgradePath('warbird');
     expect(upgrades).toHaveLength(1);
-    expect(upgrades[0]?.slug).toBe('jet');
+    expect(upgrades[0]?.slug).toBe('stealth-jet');
   });
 
   it('should return empty array for unknown slug', () => {

--- a/packages/shared/src/config/tiers.ts
+++ b/packages/shared/src/config/tiers.ts
@@ -57,9 +57,9 @@ export const DEFAULT_TIERS: TierConfig[] = [
     },
   },
   {
-    slug: 'biplane',
-    name: 'Biplane',
-    price_monthly_usd: 29,
+    slug: 'warbird',
+    name: 'Warbird',
+    price_monthly_usd: 9,
     limits: {
       max_destinations: 10,
       max_events_per_month: 100_000,
@@ -80,8 +80,8 @@ export const DEFAULT_TIERS: TierConfig[] = [
     },
   },
   {
-    slug: 'warbird',
-    name: 'Warbird',
+    slug: 'stealth-jet',
+    name: 'Stealth Jet',
     price_monthly_usd: 99,
     limits: {
       max_destinations: 50,
@@ -94,35 +94,12 @@ export const DEFAULT_TIERS: TierConfig[] = [
     features: {
       custom_headers: true,
       ip_whitelist: true,
-      transformations: false,
-      dead_letter_queue: true,
-      priority_delivery: false,
-      webhook_signing: true,
-      analytics: true,
-      team_members: 10,
-    },
-  },
-  {
-    slug: 'jet',
-    name: 'Jet',
-    price_monthly_usd: 299,
-    limits: {
-      max_destinations: 999_999,
-      max_events_per_month: 10_000_000,
-      max_payload_size_bytes: 10 * 1024 * 1024, // 10MB
-      max_retry_attempts: 10,
-      retention_days: 365,
-      rate_limit_per_second: 1000,
-    },
-    features: {
-      custom_headers: true,
-      ip_whitelist: true,
       transformations: true,
       dead_letter_queue: true,
       priority_delivery: true,
       webhook_signing: true,
       analytics: true,
-      team_members: 9999,
+      team_members: 10,
     },
   },
 ];

--- a/website/api/pricing/index.json
+++ b/website/api/pricing/index.json
@@ -1,5 +1,5 @@
 {
-  "updated_at": "2026-03-03",
+  "updated_at": "2026-03-13",
   "currency": "USD",
   "billing_options": ["monthly", "annual"],
   "annual_discount": "2 months free (~17% off)",
@@ -20,14 +20,14 @@
       "limits": {
         "events_per_month": 10000,
         "retention_days": 7,
-        "endpoints": 5,
+        "endpoints": 3,
         "retry_policies": "standard",
         "team_members": 1
       },
       "features": {
         "api_access": true,
         "dashboard": true,
-        "webhook_signing": true,
+        "webhook_signing": false,
         "rate_limiting": true,
         "replay_events": true,
         "agent_skill_mcp": true,
@@ -49,23 +49,24 @@
       }
     },
     {
-      "id": "biplane",
-      "name": "Biplane",
-      "tagline": "For projects that are growing.",
+      "id": "warbird",
+      "name": "Warbird",
+      "tagline": "For teams and projects that are growing.",
       "category": "starter",
+      "badge": "Most popular",
       "price": {
-        "monthly_usd": 29,
-        "annual_usd_per_month": 24,
-        "annual_usd_total": 288
+        "monthly_usd": 9,
+        "annual_usd_per_month": 7,
+        "annual_usd_total": 84
       },
       "credit_card_required": true,
       "signup_required": true,
       "limits": {
-        "events_per_month": 250000,
+        "events_per_month": 100000,
         "retention_days": 30,
-        "endpoints": "unlimited",
+        "endpoints": 10,
         "retry_policies": "priority",
-        "team_members": 5
+        "team_members": 3
       },
       "features": {
         "api_access": true,
@@ -93,11 +94,10 @@
       }
     },
     {
-      "id": "warbird",
-      "name": "Warbird",
+      "id": "stealth-jet",
+      "name": "Stealth Jet",
       "tagline": "High-volume delivery for production workloads.",
       "category": "growth",
-      "badge": "Most popular",
       "price": {
         "monthly_usd": 99,
         "annual_usd_per_month": 82,
@@ -106,11 +106,11 @@
       "credit_card_required": true,
       "signup_required": true,
       "limits": {
-        "events_per_month": 2000000,
+        "events_per_month": 1000000,
         "retention_days": 90,
-        "endpoints": "unlimited",
+        "endpoints": 50,
         "retry_policies": "custom",
-        "team_members": "unlimited"
+        "team_members": 10
       },
       "features": {
         "api_access": true,
@@ -137,54 +137,6 @@
       "cta": {
         "text": "Get started",
         "url": "/signup"
-      }
-    },
-    {
-      "id": "jet",
-      "name": "Jet",
-      "tagline": "For teams with serious scale and compliance requirements.",
-      "category": "scale",
-      "price": {
-        "monthly_usd": "custom",
-        "annual_usd_per_month": "custom",
-        "annual_usd_total": "custom"
-      },
-      "credit_card_required": true,
-      "signup_required": true,
-      "limits": {
-        "events_per_month": "unlimited",
-        "retention_days": 365,
-        "endpoints": "unlimited",
-        "retry_policies": "custom",
-        "team_members": "unlimited"
-      },
-      "features": {
-        "api_access": true,
-        "dashboard": true,
-        "webhook_signing": true,
-        "rate_limiting": true,
-        "replay_events": true,
-        "agent_skill_mcp": true,
-        "custom_domains": true,
-        "priority_delivery": true,
-        "sla": true,
-        "sla_uptime": "99.99%",
-        "sso_saml": true,
-        "priority_retries": true,
-        "custom_retry_policies": true,
-        "dedicated_infrastructure": true
-      },
-      "support": {
-        "level": "24/7",
-        "channels": ["24/7 dedicated support", "named account manager", "slack connect", "phone"],
-        "response_time": "< 1 hour",
-        "sla_included": true,
-        "gdpr_dpa": true,
-        "white_glove_onboarding": true
-      },
-      "cta": {
-        "text": "Talk to us",
-        "url": "mailto:hello@hookwing.com"
       }
     }
   ],

--- a/website/blog/authors/alex-morgan/index.html
+++ b/website/blog/authors/alex-morgan/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>
@@ -87,7 +85,7 @@
       </div>
     </section>
     <section class="grid cards" style="margin-top:var(--space-4);"><article class="card" style="display:flex;flex-direction:column;">
-    <a class="card-hero" href="/blog/webhook-endpoint-for-ai-agents/"><img src="/assets/blog/generated/webhook-endpoint-ai-agents-hero.png" alt="An AI agent with wings receiving incoming webhook payloads from multiple sources, aviation-themed dark technical illustration" loading="lazy" decoding="async" /></a>
+    <a class="card-hero" href="/blog/webhook-endpoint-for-ai-agents/"><img src="/assets/blog/generated/webhook-endpoint-ai-agents-hero.png" alt="Receiving incoming webhook payloads from multiple sources" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/webhook-endpoint-for-ai-agents/" style="color:var(--color-text);">How to Give Your AI Agent a Webhook Endpoint</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
       <span>2026-03-08</span>
@@ -101,7 +99,7 @@
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/ai-agents/">ai-agents</a> <a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/tutorials/">tutorials</a></div>
   </article>
 <article class="card" style="display:flex;flex-direction:column;">
-    <a class="card-hero" href="/blog/webhooks-for-ai-agents/"><img src="/assets/blog/optimized/generated/webhooks-for-ai-agents-hero.webp" alt="AI agent with wings receiving real-time webhook event streams, aviation-themed dark technical illustration" loading="lazy" decoding="async" /></a>
+    <a class="card-hero" href="/blog/webhooks-for-ai-agents/"><img src="/assets/blog/optimized/generated/webhooks-for-ai-agents-hero.webp" alt="Receiving real-time webhook event streams" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/webhooks-for-ai-agents/" style="color:var(--color-text);">Webhooks Are How AI Agents Listen to the World</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
       <span>2026-03-04</span>

--- a/website/blog/authors/marcus-chen/index.html
+++ b/website/blog/authors/marcus-chen/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>
@@ -87,7 +85,7 @@
       </div>
     </section>
     <section class="grid cards" style="margin-top:var(--space-4);"><article class="card" style="display:flex;flex-direction:column;">
-    <a class="card-hero" href="/blog/webhooks-vs-event-streams/"><img src="/assets/blog/generated/webhooks-vs-event-streams-hero.png" alt="Aviation-themed illustration contrasting push delivery (webhooks) and pull consumption (event streams) patterns in dark technical style" loading="lazy" decoding="async" /></a>
+    <a class="card-hero" href="/blog/webhooks-vs-event-streams/"><img src="/assets/blog/generated/webhooks-vs-event-streams-hero.png" alt="Push delivery (webhooks) and pull consumption (event streams) patterns" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/webhooks-vs-event-streams/" style="color:var(--color-text);">Webhooks vs Event Streams: How to Pick the Right Push</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
       <span>2026-03-13</span>
@@ -101,7 +99,7 @@
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/event-streams/">event-streams</a> <a class="chip" href="/blog/tags/kafka/">kafka</a></div>
   </article>
 <article class="card" style="display:flex;flex-direction:column;">
-    <a class="card-hero" href="/blog/webhook-dead-letter-queues/"><img src="/assets/blog/generated/webhook-dead-letter-queues-hero.png" alt="Aviation warning signal illustration showing failed webhook events being captured in a dead letter queue before being replayed" loading="lazy" decoding="async" /></a>
+    <a class="card-hero" href="/blog/webhook-dead-letter-queues/"><img src="/assets/blog/generated/webhook-dead-letter-queues-hero.png" alt="Failed webhook events being captured in a dead letter queue before being replayed" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/webhook-dead-letter-queues/" style="color:var(--color-text);">Webhook Dead Letter Queues: What to Do When Retries Run Out</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
       <span>2026-03-09</span>

--- a/website/blog/authors/priya-patel/index.html
+++ b/website/blog/authors/priya-patel/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>
@@ -87,7 +85,7 @@
       </div>
     </section>
     <section class="grid cards" style="margin-top:var(--space-4);"><article class="card" style="display:flex;flex-direction:column;">
-    <a class="card-hero" href="/blog/debugging-webhooks/"><img src="/assets/blog/optimized/generated/debugging-webhooks-hero.webp" alt="Aviation-themed illustration of a flight data recorder capturing webhook event streams in a dark technical diagram" loading="lazy" decoding="async" /></a>
+    <a class="card-hero" href="/blog/debugging-webhooks/"><img src="/assets/blog/optimized/generated/debugging-webhooks-hero.webp" alt="A flight data recorder capturing webhook event streams in a" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/debugging-webhooks/" style="color:var(--color-text);">How to Debug Webhooks (Without Losing Your Mind)</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
       <span>2026-03-12</span>

--- a/website/blog/authors/sarah-kumar/index.html
+++ b/website/blog/authors/sarah-kumar/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>

--- a/website/blog/categories/architecture/index.html
+++ b/website/blog/categories/architecture/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>
@@ -81,7 +79,7 @@
       <p class="lede" style="margin-bottom:var(--space-4);">Posts in Architecture.</p>
     </section>
     <section class="grid cards" style="margin-top:var(--space-4);"><article class="card" style="display:flex;flex-direction:column;">
-    <a class="card-hero" href="/blog/webhooks-vs-event-streams/"><img src="/assets/blog/generated/webhooks-vs-event-streams-hero.png" alt="Aviation-themed illustration contrasting push delivery (webhooks) and pull consumption (event streams) patterns in dark technical style" loading="lazy" decoding="async" /></a>
+    <a class="card-hero" href="/blog/webhooks-vs-event-streams/"><img src="/assets/blog/generated/webhooks-vs-event-streams-hero.png" alt="Push delivery (webhooks) and pull consumption (event streams) patterns" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/webhooks-vs-event-streams/" style="color:var(--color-text);">Webhooks vs Event Streams: How to Pick the Right Push</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
       <span>2026-03-13</span>

--- a/website/blog/categories/index.html
+++ b/website/blog/categories/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>

--- a/website/blog/categories/operations/index.html
+++ b/website/blog/categories/operations/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>
@@ -81,7 +79,7 @@
       <p class="lede" style="margin-bottom:var(--space-4);">Posts in Operations.</p>
     </section>
     <section class="grid cards" style="margin-top:var(--space-4);"><article class="card" style="display:flex;flex-direction:column;">
-    <a class="card-hero" href="/blog/debugging-webhooks/"><img src="/assets/blog/optimized/generated/debugging-webhooks-hero.webp" alt="Aviation-themed illustration of a flight data recorder capturing webhook event streams in a dark technical diagram" loading="lazy" decoding="async" /></a>
+    <a class="card-hero" href="/blog/debugging-webhooks/"><img src="/assets/blog/optimized/generated/debugging-webhooks-hero.webp" alt="A flight data recorder capturing webhook event streams in a" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/debugging-webhooks/" style="color:var(--color-text);">How to Debug Webhooks (Without Losing Your Mind)</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
       <span>2026-03-12</span>

--- a/website/blog/categories/reliability/index.html
+++ b/website/blog/categories/reliability/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>
@@ -81,7 +79,7 @@
       <p class="lede" style="margin-bottom:var(--space-4);">Posts in Reliability.</p>
     </section>
     <section class="grid cards" style="margin-top:var(--space-4);"><article class="card" style="display:flex;flex-direction:column;">
-    <a class="card-hero" href="/blog/webhook-dead-letter-queues/"><img src="/assets/blog/generated/webhook-dead-letter-queues-hero.png" alt="Aviation warning signal illustration showing failed webhook events being captured in a dead letter queue before being replayed" loading="lazy" decoding="async" /></a>
+    <a class="card-hero" href="/blog/webhook-dead-letter-queues/"><img src="/assets/blog/generated/webhook-dead-letter-queues-hero.png" alt="Failed webhook events being captured in a dead letter queue before being replayed" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/webhook-dead-letter-queues/" style="color:var(--color-text);">Webhook Dead Letter Queues: What to Do When Retries Run Out</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
       <span>2026-03-09</span>

--- a/website/blog/categories/tutorials/index.html
+++ b/website/blog/categories/tutorials/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>
@@ -81,7 +79,7 @@
       <p class="lede" style="margin-bottom:var(--space-4);">Posts in Tutorials.</p>
     </section>
     <section class="grid cards" style="margin-top:var(--space-4);"><article class="card" style="display:flex;flex-direction:column;">
-    <a class="card-hero" href="/blog/webhook-endpoint-for-ai-agents/"><img src="/assets/blog/generated/webhook-endpoint-ai-agents-hero.png" alt="An AI agent with wings receiving incoming webhook payloads from multiple sources, aviation-themed dark technical illustration" loading="lazy" decoding="async" /></a>
+    <a class="card-hero" href="/blog/webhook-endpoint-for-ai-agents/"><img src="/assets/blog/generated/webhook-endpoint-ai-agents-hero.png" alt="Receiving incoming webhook payloads from multiple sources" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/webhook-endpoint-for-ai-agents/" style="color:var(--color-text);">How to Give Your AI Agent a Webhook Endpoint</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
       <span>2026-03-08</span>
@@ -95,7 +93,7 @@
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/ai-agents/">ai-agents</a> <a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/tutorials/">tutorials</a></div>
   </article>
 <article class="card" style="display:flex;flex-direction:column;">
-    <a class="card-hero" href="/blog/webhooks-for-ai-agents/"><img src="/assets/blog/optimized/generated/webhooks-for-ai-agents-hero.webp" alt="AI agent with wings receiving real-time webhook event streams, aviation-themed dark technical illustration" loading="lazy" decoding="async" /></a>
+    <a class="card-hero" href="/blog/webhooks-for-ai-agents/"><img src="/assets/blog/optimized/generated/webhooks-for-ai-agents-hero.webp" alt="Receiving real-time webhook event streams" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/webhooks-for-ai-agents/" style="color:var(--color-text);">Webhooks Are How AI Agents Listen to the World</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
       <span>2026-03-04</span>

--- a/website/blog/debugging-webhooks/index.html
+++ b/website/blog/debugging-webhooks/index.html
@@ -43,7 +43,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -65,7 +64,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>
@@ -111,7 +109,7 @@
         <a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/debugging/">debugging</a> <a class="chip" href="/blog/tags/developer-experience/">developer-experience</a> <a class="chip" href="/blog/tags/observability/">observability</a> <a class="chip" href="/blog/tags/testing/">testing</a>
       </div>
     </div>
-    <figure class="hero"><div class="hero-media"><img src="/assets/blog/optimized/generated/debugging-webhooks-hero.webp" alt="Aviation-themed illustration of a flight data recorder capturing webhook event streams in a dark technical diagram" loading="eager" decoding="async" fetchpriority="high" /></div><figcaption>Aviation-themed illustration of a flight data recorder capturing webhook event streams in a dark technical diagram</figcaption></figure>
+    <figure class="hero"><div class="hero-media"><img src="/assets/blog/optimized/generated/debugging-webhooks-hero.webp" alt="A flight data recorder capturing webhook event streams in a" loading="eager" decoding="async" fetchpriority="high" /></div><figcaption>Aviation-themed illustration of a flight data recorder capturing webhook event streams in a dark technical diagram</figcaption></figure>
     <div class="article-layout">
       <aside class="toc" aria-label="Table of contents">
     <div class="toc-title"><span>On this page</span><span>12</span></div>
@@ -152,7 +150,7 @@
 <li><strong>Local dev black hole.</strong> Your laptop has no public IP. The sender&#39;s request never arrives. You spend an hour debugging a handler that was never called.</li>
 </ul>
 <p>---</p>
-<figure><img src="/assets/blog/optimized/illustrations/debugging-webhooks-lifecycle.svg" alt="Webhook delivery lifecycle diagram showing failure points at middleware, handler, and response stages" loading="lazy" decoding="async" /><figcaption class="caption">Where webhook events get lost: the three common failure points.</figcaption></figure>
+<figure><img src="/assets/blog/optimized/illustrations/debugging-webhooks-lifecycle.svg" alt="Webhook delivery lifecycle diagram showing failure points at middleware" loading="lazy" decoding="async" /><figcaption class="caption">Where webhook events get lost: the three common failure points.</figcaption></figure>
 <h2 id="2-inspect-raw-payloads-before-processing-anything">2. Inspect raw payloads before processing anything</h2>
 <p>The single most useful habit in webhook debugging: log the raw request body and headers before your code touches them.</p>
 <p>Not after parsing. Not after middleware. Before.</p>
@@ -212,7 +210,7 @@ smee --url https://smee.io/your-channel-id --target http://localhost:3000/webhoo
 });</code></pre>
 <p>Log idempotency key hits separately. When a duplicate arrives and you skip processing, that&#39;s a different log event than a failure. Mixing them obscures your actual error rate.</p>
 <p>---</p>
-<figure><img src="/assets/blog/optimized/illustrations/debugging-webhooks-log-entry.svg" alt="Structured webhook log entry showing timestamp, event type, event ID, result, and processing duration fields" loading="lazy" decoding="async" /><figcaption class="caption">A complete webhook log entry: everything you need to diagnose any delivery.</figcaption></figure>
+<figure><img src="/assets/blog/optimized/illustrations/debugging-webhooks-log-entry.svg" alt="Structured webhook log entry showing timestamp" loading="lazy" decoding="async" /><figcaption class="caption">A complete webhook log entry: everything you need to diagnose any delivery.</figcaption></figure>
 <h2 id="5-replay-without-retriggering-real-events">5. Replay without retriggering real events</h2>
 <p>Reproducing a specific failure means firing the exact payload that caused it. Re-triggering the real event (completing a payment, sending a message) to generate a test webhook isn&#39;t practical.</p>
 <p>The better approach: capture and store raw payloads on arrival, then replay them locally.</p>

--- a/website/blog/index.html
+++ b/website/blog/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>
@@ -89,7 +87,7 @@
       </div>
     </section>
     <section class="grid cards" style="margin-top:var(--space-4);"><div data-post-card data-slug="webhooks-vs-event-streams"><article class="card" style="display:flex;flex-direction:column;">
-    <a class="card-hero" href="/blog/webhooks-vs-event-streams/"><img src="/assets/blog/generated/webhooks-vs-event-streams-hero.png" alt="Aviation-themed illustration contrasting push delivery (webhooks) and pull consumption (event streams) patterns in dark technical style" loading="lazy" decoding="async" /></a>
+    <a class="card-hero" href="/blog/webhooks-vs-event-streams/"><img src="/assets/blog/generated/webhooks-vs-event-streams-hero.png" alt="Push delivery (webhooks) and pull consumption (event streams) patterns" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/webhooks-vs-event-streams/" style="color:var(--color-text);">Webhooks vs Event Streams: How to Pick the Right Push</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
       <span>2026-03-13</span>
@@ -103,7 +101,7 @@
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/event-streams/">event-streams</a> <a class="chip" href="/blog/tags/kafka/">kafka</a></div>
   </article></div>
 <div data-post-card data-slug="debugging-webhooks"><article class="card" style="display:flex;flex-direction:column;">
-    <a class="card-hero" href="/blog/debugging-webhooks/"><img src="/assets/blog/optimized/generated/debugging-webhooks-hero.webp" alt="Aviation-themed illustration of a flight data recorder capturing webhook event streams in a dark technical diagram" loading="lazy" decoding="async" /></a>
+    <a class="card-hero" href="/blog/debugging-webhooks/"><img src="/assets/blog/optimized/generated/debugging-webhooks-hero.webp" alt="A flight data recorder capturing webhook event streams in a" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/debugging-webhooks/" style="color:var(--color-text);">How to Debug Webhooks (Without Losing Your Mind)</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
       <span>2026-03-12</span>
@@ -117,7 +115,7 @@
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/debugging/">debugging</a> <a class="chip" href="/blog/tags/developer-experience/">developer-experience</a></div>
   </article></div>
 <div data-post-card data-slug="webhook-dead-letter-queues"><article class="card" style="display:flex;flex-direction:column;">
-    <a class="card-hero" href="/blog/webhook-dead-letter-queues/"><img src="/assets/blog/generated/webhook-dead-letter-queues-hero.png" alt="Aviation warning signal illustration showing failed webhook events being captured in a dead letter queue before being replayed" loading="lazy" decoding="async" /></a>
+    <a class="card-hero" href="/blog/webhook-dead-letter-queues/"><img src="/assets/blog/generated/webhook-dead-letter-queues-hero.png" alt="Failed webhook events being captured in a dead letter queue before being replayed" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/webhook-dead-letter-queues/" style="color:var(--color-text);">Webhook Dead Letter Queues: What to Do When Retries Run Out</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
       <span>2026-03-09</span>
@@ -131,7 +129,7 @@
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/reliability/">reliability</a> <a class="chip" href="/blog/tags/dead-letter-queue/">dead-letter-queue</a></div>
   </article></div>
 <div data-post-card data-slug="webhook-endpoint-for-ai-agents"><article class="card" style="display:flex;flex-direction:column;">
-    <a class="card-hero" href="/blog/webhook-endpoint-for-ai-agents/"><img src="/assets/blog/generated/webhook-endpoint-ai-agents-hero.png" alt="An AI agent with wings receiving incoming webhook payloads from multiple sources, aviation-themed dark technical illustration" loading="lazy" decoding="async" /></a>
+    <a class="card-hero" href="/blog/webhook-endpoint-for-ai-agents/"><img src="/assets/blog/generated/webhook-endpoint-ai-agents-hero.png" alt="Receiving incoming webhook payloads from multiple sources" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/webhook-endpoint-for-ai-agents/" style="color:var(--color-text);">How to Give Your AI Agent a Webhook Endpoint</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
       <span>2026-03-08</span>
@@ -159,7 +157,7 @@
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/security/">security</a> <a class="chip" href="/blog/tags/reliability/">reliability</a></div>
   </article></div>
 <div data-post-card data-slug="webhooks-for-ai-agents"><article class="card" style="display:flex;flex-direction:column;">
-    <a class="card-hero" href="/blog/webhooks-for-ai-agents/"><img src="/assets/blog/optimized/generated/webhooks-for-ai-agents-hero.webp" alt="AI agent with wings receiving real-time webhook event streams, aviation-themed dark technical illustration" loading="lazy" decoding="async" /></a>
+    <a class="card-hero" href="/blog/webhooks-for-ai-agents/"><img src="/assets/blog/optimized/generated/webhooks-for-ai-agents-hero.webp" alt="Receiving real-time webhook event streams" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/webhooks-for-ai-agents/" style="color:var(--color-text);">Webhooks Are How AI Agents Listen to the World</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
       <span>2026-03-04</span>

--- a/website/blog/tags/agents/index.html
+++ b/website/blog/tags/agents/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>
@@ -81,7 +79,7 @@
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with agents.</p>
     </section>
     <section class="grid cards" style="margin-top:var(--space-4);"><article class="card" style="display:flex;flex-direction:column;">
-    <a class="card-hero" href="/blog/webhooks-vs-event-streams/"><img src="/assets/blog/generated/webhooks-vs-event-streams-hero.png" alt="Split technical diagram showing webhook push delivery on one side and event stream consumer pull on the other, aviation-themed dark background" loading="lazy" decoding="async" /></a>
+    <a class="card-hero" href="/blog/webhooks-vs-event-streams/"><img src="/assets/blog/generated/webhooks-vs-event-streams-hero.png" alt="Split technical diagram showing webhook push delivery on one side and event stream consumer pull on the other" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/webhooks-vs-event-streams/" style="color:var(--color-text);">Webhooks vs Event Streams: How to Pick the Right Push</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
       <span>2026-03-13</span>

--- a/website/blog/tags/ai-agents/index.html
+++ b/website/blog/tags/ai-agents/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>
@@ -81,7 +79,7 @@
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with ai-agents.</p>
     </section>
     <section class="grid cards" style="margin-top:var(--space-4);"><article class="card" style="display:flex;flex-direction:column;">
-    <a class="card-hero" href="/blog/webhook-endpoint-for-ai-agents/"><img src="/assets/blog/generated/webhook-endpoint-ai-agents-hero.png" alt="An AI agent with wings receiving incoming webhook payloads from multiple sources, aviation-themed dark technical illustration" loading="lazy" decoding="async" /></a>
+    <a class="card-hero" href="/blog/webhook-endpoint-for-ai-agents/"><img src="/assets/blog/generated/webhook-endpoint-ai-agents-hero.png" alt="Receiving incoming webhook payloads from multiple sources" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/webhook-endpoint-for-ai-agents/" style="color:var(--color-text);">How to Give Your AI Agent a Webhook Endpoint</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
       <span>2026-03-08</span>

--- a/website/blog/tags/architecture/index.html
+++ b/website/blog/tags/architecture/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>
@@ -81,7 +79,7 @@
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with architecture.</p>
     </section>
     <section class="grid cards" style="margin-top:var(--space-4);"><article class="card" style="display:flex;flex-direction:column;">
-    <a class="card-hero" href="/blog/webhooks-vs-event-streams/"><img src="/assets/blog/generated/webhooks-vs-event-streams-hero.png" alt="Aviation-themed illustration contrasting push delivery (webhooks) and pull consumption (event streams) patterns in dark technical style" loading="lazy" decoding="async" /></a>
+    <a class="card-hero" href="/blog/webhooks-vs-event-streams/"><img src="/assets/blog/generated/webhooks-vs-event-streams-hero.png" alt="Push delivery (webhooks) and pull consumption (event streams) patterns" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/webhooks-vs-event-streams/" style="color:var(--color-text);">Webhooks vs Event Streams: How to Pick the Right Push</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
       <span>2026-03-13</span>

--- a/website/blog/tags/dead-letter-queue/index.html
+++ b/website/blog/tags/dead-letter-queue/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>
@@ -81,7 +79,7 @@
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with dead-letter-queue.</p>
     </section>
     <section class="grid cards" style="margin-top:var(--space-4);"><article class="card" style="display:flex;flex-direction:column;">
-    <a class="card-hero" href="/blog/webhook-dead-letter-queues/"><img src="/assets/blog/generated/webhook-dead-letter-queues-hero.png" alt="Aviation warning signal illustration showing failed webhook events being captured in a dead letter queue before being replayed" loading="lazy" decoding="async" /></a>
+    <a class="card-hero" href="/blog/webhook-dead-letter-queues/"><img src="/assets/blog/generated/webhook-dead-letter-queues-hero.png" alt="Failed webhook events being captured in a dead letter queue before being replayed" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/webhook-dead-letter-queues/" style="color:var(--color-text);">Webhook Dead Letter Queues: What to Do When Retries Run Out</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
       <span>2026-03-09</span>

--- a/website/blog/tags/debugging/index.html
+++ b/website/blog/tags/debugging/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>
@@ -81,7 +79,7 @@
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with debugging.</p>
     </section>
     <section class="grid cards" style="margin-top:var(--space-4);"><article class="card" style="display:flex;flex-direction:column;">
-    <a class="card-hero" href="/blog/debugging-webhooks/"><img src="/assets/blog/optimized/generated/debugging-webhooks-hero.webp" alt="Aviation-themed illustration of a flight data recorder capturing webhook event streams in a dark technical diagram" loading="lazy" decoding="async" /></a>
+    <a class="card-hero" href="/blog/debugging-webhooks/"><img src="/assets/blog/optimized/generated/debugging-webhooks-hero.webp" alt="A flight data recorder capturing webhook event streams in a" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/debugging-webhooks/" style="color:var(--color-text);">How to Debug Webhooks (Without Losing Your Mind)</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
       <span>2026-03-12</span>

--- a/website/blog/tags/decision-making/index.html
+++ b/website/blog/tags/decision-making/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>
@@ -81,7 +79,7 @@
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with decision-making.</p>
     </section>
     <section class="grid cards" style="margin-top:var(--space-4);"><article class="card" style="display:flex;flex-direction:column;">
-    <a class="card-hero" href="/blog/webhooks-vs-event-streams/"><img src="/assets/blog/generated/webhooks-vs-event-streams-hero.png" alt="Aviation-themed illustration contrasting push delivery (webhooks) and pull consumption (event streams) patterns in dark technical style" loading="lazy" decoding="async" /></a>
+    <a class="card-hero" href="/blog/webhooks-vs-event-streams/"><img src="/assets/blog/generated/webhooks-vs-event-streams-hero.png" alt="Push delivery (webhooks) and pull consumption (event streams) patterns" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/webhooks-vs-event-streams/" style="color:var(--color-text);">Webhooks vs Event Streams: How to Pick the Right Push</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
       <span>2026-03-13</span>

--- a/website/blog/tags/developer-experience/index.html
+++ b/website/blog/tags/developer-experience/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>
@@ -81,7 +79,7 @@
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with developer-experience.</p>
     </section>
     <section class="grid cards" style="margin-top:var(--space-4);"><article class="card" style="display:flex;flex-direction:column;">
-    <a class="card-hero" href="/blog/debugging-webhooks/"><img src="/assets/blog/optimized/generated/debugging-webhooks-hero.webp" alt="Aviation-themed illustration of a flight data recorder capturing webhook event streams in a dark technical diagram" loading="lazy" decoding="async" /></a>
+    <a class="card-hero" href="/blog/debugging-webhooks/"><img src="/assets/blog/optimized/generated/debugging-webhooks-hero.webp" alt="A flight data recorder capturing webhook event streams in a" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/debugging-webhooks/" style="color:var(--color-text);">How to Debug Webhooks (Without Losing Your Mind)</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
       <span>2026-03-12</span>

--- a/website/blog/tags/event-streams/index.html
+++ b/website/blog/tags/event-streams/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>
@@ -81,7 +79,7 @@
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with event-streams.</p>
     </section>
     <section class="grid cards" style="margin-top:var(--space-4);"><article class="card" style="display:flex;flex-direction:column;">
-    <a class="card-hero" href="/blog/webhooks-vs-event-streams/"><img src="/assets/blog/generated/webhooks-vs-event-streams-hero.png" alt="Aviation-themed illustration contrasting push delivery (webhooks) and pull consumption (event streams) patterns in dark technical style" loading="lazy" decoding="async" /></a>
+    <a class="card-hero" href="/blog/webhooks-vs-event-streams/"><img src="/assets/blog/generated/webhooks-vs-event-streams-hero.png" alt="Push delivery (webhooks) and pull consumption (event streams) patterns" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/webhooks-vs-event-streams/" style="color:var(--color-text);">Webhooks vs Event Streams: How to Pick the Right Push</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
       <span>2026-03-13</span>

--- a/website/blog/tags/getting-started/index.html
+++ b/website/blog/tags/getting-started/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>
@@ -81,7 +79,7 @@
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with getting-started.</p>
     </section>
     <section class="grid cards" style="margin-top:var(--space-4);"><article class="card" style="display:flex;flex-direction:column;">
-    <a class="card-hero" href="/blog/webhook-endpoint-for-ai-agents/"><img src="/assets/blog/generated/webhook-endpoint-ai-agents-hero.png" alt="An AI agent with wings receiving incoming webhook payloads from multiple sources, aviation-themed dark technical illustration" loading="lazy" decoding="async" /></a>
+    <a class="card-hero" href="/blog/webhook-endpoint-for-ai-agents/"><img src="/assets/blog/generated/webhook-endpoint-ai-agents-hero.png" alt="Receiving incoming webhook payloads from multiple sources" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/webhook-endpoint-for-ai-agents/" style="color:var(--color-text);">How to Give Your AI Agent a Webhook Endpoint</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
       <span>2026-03-08</span>

--- a/website/blog/tags/hmac/index.html
+++ b/website/blog/tags/hmac/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>

--- a/website/blog/tags/idempotency/index.html
+++ b/website/blog/tags/idempotency/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>

--- a/website/blog/tags/incident-response/index.html
+++ b/website/blog/tags/incident-response/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>

--- a/website/blog/tags/index.html
+++ b/website/blog/tags/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>

--- a/website/blog/tags/kafka/index.html
+++ b/website/blog/tags/kafka/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>
@@ -81,7 +79,7 @@
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with kafka.</p>
     </section>
     <section class="grid cards" style="margin-top:var(--space-4);"><article class="card" style="display:flex;flex-direction:column;">
-    <a class="card-hero" href="/blog/webhooks-vs-event-streams/"><img src="/assets/blog/generated/webhooks-vs-event-streams-hero.png" alt="Aviation-themed illustration contrasting push delivery (webhooks) and pull consumption (event streams) patterns in dark technical style" loading="lazy" decoding="async" /></a>
+    <a class="card-hero" href="/blog/webhooks-vs-event-streams/"><img src="/assets/blog/generated/webhooks-vs-event-streams-hero.png" alt="Push delivery (webhooks) and pull consumption (event streams) patterns" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/webhooks-vs-event-streams/" style="color:var(--color-text);">Webhooks vs Event Streams: How to Pick the Right Push</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
       <span>2026-03-13</span>

--- a/website/blog/tags/logging/index.html
+++ b/website/blog/tags/logging/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>

--- a/website/blog/tags/monitoring/index.html
+++ b/website/blog/tags/monitoring/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>

--- a/website/blog/tags/observability/index.html
+++ b/website/blog/tags/observability/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>
@@ -81,7 +79,7 @@
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with observability.</p>
     </section>
     <section class="grid cards" style="margin-top:var(--space-4);"><article class="card" style="display:flex;flex-direction:column;">
-    <a class="card-hero" href="/blog/debugging-webhooks/"><img src="/assets/blog/optimized/generated/debugging-webhooks-hero.webp" alt="Aviation-themed illustration of a flight data recorder capturing webhook event streams in a dark technical diagram" loading="lazy" decoding="async" /></a>
+    <a class="card-hero" href="/blog/debugging-webhooks/"><img src="/assets/blog/optimized/generated/debugging-webhooks-hero.webp" alt="A flight data recorder capturing webhook event streams in a" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/debugging-webhooks/" style="color:var(--color-text);">How to Debug Webhooks (Without Losing Your Mind)</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
       <span>2026-03-12</span>

--- a/website/blog/tags/openclaw/index.html
+++ b/website/blog/tags/openclaw/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>
@@ -81,7 +79,7 @@
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with openclaw.</p>
     </section>
     <section class="grid cards" style="margin-top:var(--space-4);"><article class="card" style="display:flex;flex-direction:column;">
-    <a class="card-hero" href="/blog/webhook-endpoint-for-ai-agents/"><img src="/assets/blog/generated/webhook-endpoint-ai-agents-hero.png" alt="An AI agent with wings receiving incoming webhook payloads from multiple sources, aviation-themed dark technical illustration" loading="lazy" decoding="async" /></a>
+    <a class="card-hero" href="/blog/webhook-endpoint-for-ai-agents/"><img src="/assets/blog/generated/webhook-endpoint-ai-agents-hero.png" alt="Receiving incoming webhook payloads from multiple sources" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/webhook-endpoint-for-ai-agents/" style="color:var(--color-text);">How to Give Your AI Agent a Webhook Endpoint</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
       <span>2026-03-08</span>

--- a/website/blog/tags/operations/index.html
+++ b/website/blog/tags/operations/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>
@@ -81,7 +79,7 @@
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with operations.</p>
     </section>
     <section class="grid cards" style="margin-top:var(--space-4);"><article class="card" style="display:flex;flex-direction:column;">
-    <a class="card-hero" href="/blog/webhook-dead-letter-queues/"><img src="/assets/blog/generated/webhook-dead-letter-queues-hero.png" alt="Aviation warning signal illustration showing failed webhook events being captured in a dead letter queue before being replayed" loading="lazy" decoding="async" /></a>
+    <a class="card-hero" href="/blog/webhook-dead-letter-queues/"><img src="/assets/blog/generated/webhook-dead-letter-queues-hero.png" alt="Failed webhook events being captured in a dead letter queue before being replayed" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/webhook-dead-letter-queues/" style="color:var(--color-text);">Webhook Dead Letter Queues: What to Do When Retries Run Out</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
       <span>2026-03-09</span>

--- a/website/blog/tags/production/index.html
+++ b/website/blog/tags/production/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>

--- a/website/blog/tags/reliability/index.html
+++ b/website/blog/tags/reliability/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>
@@ -81,7 +79,7 @@
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with reliability.</p>
     </section>
     <section class="grid cards" style="margin-top:var(--space-4);"><article class="card" style="display:flex;flex-direction:column;">
-    <a class="card-hero" href="/blog/webhook-dead-letter-queues/"><img src="/assets/blog/generated/webhook-dead-letter-queues-hero.png" alt="Aviation warning signal illustration showing failed webhook events being captured in a dead letter queue before being replayed" loading="lazy" decoding="async" /></a>
+    <a class="card-hero" href="/blog/webhook-dead-letter-queues/"><img src="/assets/blog/generated/webhook-dead-letter-queues-hero.png" alt="Failed webhook events being captured in a dead letter queue before being replayed" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/webhook-dead-letter-queues/" style="color:var(--color-text);">Webhook Dead Letter Queues: What to Do When Retries Run Out</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
       <span>2026-03-09</span>

--- a/website/blog/tags/retries/index.html
+++ b/website/blog/tags/retries/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>
@@ -81,7 +79,7 @@
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with retries.</p>
     </section>
     <section class="grid cards" style="margin-top:var(--space-4);"><article class="card" style="display:flex;flex-direction:column;">
-    <a class="card-hero" href="/blog/webhook-dead-letter-queues/"><img src="/assets/blog/generated/webhook-dead-letter-queues-hero.png" alt="Aviation warning signal illustration showing failed webhook events being captured in a dead letter queue before being replayed" loading="lazy" decoding="async" /></a>
+    <a class="card-hero" href="/blog/webhook-dead-letter-queues/"><img src="/assets/blog/generated/webhook-dead-letter-queues-hero.png" alt="Failed webhook events being captured in a dead letter queue before being replayed" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/webhook-dead-letter-queues/" style="color:var(--color-text);">Webhook Dead Letter Queues: What to Do When Retries Run Out</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
       <span>2026-03-09</span>

--- a/website/blog/tags/security/index.html
+++ b/website/blog/tags/security/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>

--- a/website/blog/tags/testing/index.html
+++ b/website/blog/tags/testing/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>
@@ -81,7 +79,7 @@
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with testing.</p>
     </section>
     <section class="grid cards" style="margin-top:var(--space-4);"><article class="card" style="display:flex;flex-direction:column;">
-    <a class="card-hero" href="/blog/debugging-webhooks/"><img src="/assets/blog/optimized/generated/debugging-webhooks-hero.webp" alt="Aviation-themed illustration of a flight data recorder capturing webhook event streams in a dark technical diagram" loading="lazy" decoding="async" /></a>
+    <a class="card-hero" href="/blog/debugging-webhooks/"><img src="/assets/blog/optimized/generated/debugging-webhooks-hero.webp" alt="A flight data recorder capturing webhook event streams in a" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/debugging-webhooks/" style="color:var(--color-text);">How to Debug Webhooks (Without Losing Your Mind)</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
       <span>2026-03-12</span>

--- a/website/blog/tags/tutorials/index.html
+++ b/website/blog/tags/tutorials/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>
@@ -81,7 +79,7 @@
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with tutorials.</p>
     </section>
     <section class="grid cards" style="margin-top:var(--space-4);"><article class="card" style="display:flex;flex-direction:column;">
-    <a class="card-hero" href="/blog/webhook-endpoint-for-ai-agents/"><img src="/assets/blog/generated/webhook-endpoint-ai-agents-hero.png" alt="An AI agent with wings receiving incoming webhook payloads from multiple sources, aviation-themed dark technical illustration" loading="lazy" decoding="async" /></a>
+    <a class="card-hero" href="/blog/webhook-endpoint-for-ai-agents/"><img src="/assets/blog/generated/webhook-endpoint-ai-agents-hero.png" alt="Receiving incoming webhook payloads from multiple sources" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/webhook-endpoint-for-ai-agents/" style="color:var(--color-text);">How to Give Your AI Agent a Webhook Endpoint</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
       <span>2026-03-08</span>

--- a/website/blog/tags/verification/index.html
+++ b/website/blog/tags/verification/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>

--- a/website/blog/tags/webhooks/index.html
+++ b/website/blog/tags/webhooks/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>
@@ -81,7 +79,7 @@
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with webhooks.</p>
     </section>
     <section class="grid cards" style="margin-top:var(--space-4);"><article class="card" style="display:flex;flex-direction:column;">
-    <a class="card-hero" href="/blog/webhooks-vs-event-streams/"><img src="/assets/blog/generated/webhooks-vs-event-streams-hero.png" alt="Aviation-themed illustration contrasting push delivery (webhooks) and pull consumption (event streams) patterns in dark technical style" loading="lazy" decoding="async" /></a>
+    <a class="card-hero" href="/blog/webhooks-vs-event-streams/"><img src="/assets/blog/generated/webhooks-vs-event-streams-hero.png" alt="Push delivery (webhooks) and pull consumption (event streams) patterns" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/webhooks-vs-event-streams/" style="color:var(--color-text);">Webhooks vs Event Streams: How to Pick the Right Push</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
       <span>2026-03-13</span>
@@ -95,7 +93,7 @@
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/event-streams/">event-streams</a> <a class="chip" href="/blog/tags/kafka/">kafka</a></div>
   </article>
 <article class="card" style="display:flex;flex-direction:column;">
-    <a class="card-hero" href="/blog/debugging-webhooks/"><img src="/assets/blog/optimized/generated/debugging-webhooks-hero.webp" alt="Aviation-themed illustration of a flight data recorder capturing webhook event streams in a dark technical diagram" loading="lazy" decoding="async" /></a>
+    <a class="card-hero" href="/blog/debugging-webhooks/"><img src="/assets/blog/optimized/generated/debugging-webhooks-hero.webp" alt="A flight data recorder capturing webhook event streams in a" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/debugging-webhooks/" style="color:var(--color-text);">How to Debug Webhooks (Without Losing Your Mind)</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
       <span>2026-03-12</span>
@@ -109,7 +107,7 @@
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/debugging/">debugging</a> <a class="chip" href="/blog/tags/developer-experience/">developer-experience</a></div>
   </article>
 <article class="card" style="display:flex;flex-direction:column;">
-    <a class="card-hero" href="/blog/webhook-dead-letter-queues/"><img src="/assets/blog/generated/webhook-dead-letter-queues-hero.png" alt="Aviation warning signal illustration showing failed webhook events being captured in a dead letter queue before being replayed" loading="lazy" decoding="async" /></a>
+    <a class="card-hero" href="/blog/webhook-dead-letter-queues/"><img src="/assets/blog/generated/webhook-dead-letter-queues-hero.png" alt="Failed webhook events being captured in a dead letter queue before being replayed" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/webhook-dead-letter-queues/" style="color:var(--color-text);">Webhook Dead Letter Queues: What to Do When Retries Run Out</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
       <span>2026-03-09</span>
@@ -123,7 +121,7 @@
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/reliability/">reliability</a> <a class="chip" href="/blog/tags/dead-letter-queue/">dead-letter-queue</a></div>
   </article>
 <article class="card" style="display:flex;flex-direction:column;">
-    <a class="card-hero" href="/blog/webhook-endpoint-for-ai-agents/"><img src="/assets/blog/generated/webhook-endpoint-ai-agents-hero.png" alt="An AI agent with wings receiving incoming webhook payloads from multiple sources, aviation-themed dark technical illustration" loading="lazy" decoding="async" /></a>
+    <a class="card-hero" href="/blog/webhook-endpoint-for-ai-agents/"><img src="/assets/blog/generated/webhook-endpoint-ai-agents-hero.png" alt="Receiving incoming webhook payloads from multiple sources" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/webhook-endpoint-for-ai-agents/" style="color:var(--color-text);">How to Give Your AI Agent a Webhook Endpoint</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
       <span>2026-03-08</span>

--- a/website/blog/webhook-dead-letter-queues/index.html
+++ b/website/blog/webhook-dead-letter-queues/index.html
@@ -43,7 +43,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -65,7 +64,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>
@@ -111,7 +109,7 @@
         <a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/reliability/">reliability</a> <a class="chip" href="/blog/tags/dead-letter-queue/">dead-letter-queue</a> <a class="chip" href="/blog/tags/retries/">retries</a> <a class="chip" href="/blog/tags/operations/">operations</a>
       </div>
     </div>
-    <figure class="hero"><div class="hero-media"><img src="/assets/blog/generated/webhook-dead-letter-queues-hero.png" alt="Aviation warning signal illustration showing failed webhook events being captured in a dead letter queue before being replayed" loading="eager" decoding="async" fetchpriority="high" /></div><figcaption>Aviation warning signal illustration showing failed webhook events being captured in a dead letter queue before being replayed</figcaption></figure>
+    <figure class="hero"><div class="hero-media"><img src="/assets/blog/generated/webhook-dead-letter-queues-hero.png" alt="Failed webhook events being captured in a dead letter queue before being replayed" loading="eager" decoding="async" fetchpriority="high" /></div><figcaption>Aviation warning signal illustration showing failed webhook events being captured in a dead letter queue before being replayed</figcaption></figure>
     <div class="article-layout">
       <aside class="toc" aria-label="Table of contents">
     <div class="toc-title"><span>On this page</span><span>7</span></div>
@@ -147,7 +145,7 @@
 <p>| Response | Retry or DLQ? | Reason | |----------|--------------|--------| | 2xx | Success, no action | Delivered | | 429 | Retry with backoff | Rate limited, try later | | 5xx | Retry with backoff | Server error, may recover | | 400 | DLQ immediately | Bad payload, won&#39;t fix itself | | 401 / 403 | DLQ immediately | Auth failure, needs human fix | | 410 | DLQ immediately | Endpoint gone, stop retrying | | Timeout | Retry with backoff | Transient, usually recoverable |</p>
 <p>The key insight: 4xx errors are your consumer telling you something is wrong with the request itself. Retrying a 400 ten times does not make it valid. Move it to the DLQ fast, before you waste retry budget.</p>
 <p>Permanent errors like 410 should also circuit-break the endpoint entirely. No point delivering to a destination that no longer exists.</p>
-<figure><img src="/assets/blog/optimized/generated/webhook-dead-letter-queues-flow.webp" alt="Webhook failure routing diagram: 2xx events succeed, 5xx events retry with backoff, 4xx events go directly to the dead letter queue" loading="lazy" decoding="async" /></figure>
+<figure><img src="/assets/blog/optimized/generated/webhook-dead-letter-queues-flow.webp" alt="Webhook failure routing diagram: 2xx events succeed" loading="lazy" decoding="async" /></figure>
 <p>---</p>
 <h2 id="3-what-to-store-in-the-dlq-record">3. What to store in the DLQ record</h2>
 <p>A DLQ record that only contains the original payload is not very useful when you are trying to understand what went wrong. Store everything you need to diagnose and replay.</p>

--- a/website/blog/webhook-endpoint-for-ai-agents/index.html
+++ b/website/blog/webhook-endpoint-for-ai-agents/index.html
@@ -43,7 +43,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -65,7 +64,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>
@@ -111,7 +109,7 @@
         <a class="chip" href="/blog/tags/ai-agents/">ai-agents</a> <a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/tutorials/">tutorials</a> <a class="chip" href="/blog/tags/getting-started/">getting-started</a> <a class="chip" href="/blog/tags/openclaw/">openclaw</a>
       </div>
     </div>
-    <figure class="hero"><div class="hero-media"><img src="/assets/blog/generated/webhook-endpoint-ai-agents-hero.png" alt="An AI agent with wings receiving incoming webhook payloads from multiple sources, aviation-themed dark technical illustration" loading="eager" decoding="async" fetchpriority="high" /></div><figcaption>An AI agent with wings receiving incoming webhook payloads from multiple sources, aviation-themed dark technical illustration</figcaption></figure>
+    <figure class="hero"><div class="hero-media"><img src="/assets/blog/generated/webhook-endpoint-ai-agents-hero.png" alt="Receiving incoming webhook payloads from multiple sources" loading="eager" decoding="async" fetchpriority="high" /></div><figcaption>An AI agent with wings receiving incoming webhook payloads from multiple sources, aviation-themed dark technical illustration</figcaption></figure>
     <div class="article-layout">
       <aside class="toc" aria-label="Table of contents">
     <div class="toc-title"><span>On this page</span><span>7</span></div>

--- a/website/blog/webhook-idempotency-checklist/index.html
+++ b/website/blog/webhook-idempotency-checklist/index.html
@@ -43,7 +43,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -65,7 +64,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>

--- a/website/blog/webhook-monitoring-observability/index.html
+++ b/website/blog/webhook-monitoring-observability/index.html
@@ -43,7 +43,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -65,7 +64,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>

--- a/website/blog/webhook-retry-best-practices/index.html
+++ b/website/blog/webhook-retry-best-practices/index.html
@@ -43,7 +43,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -65,7 +64,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>

--- a/website/blog/webhook-signature-verification/index.html
+++ b/website/blog/webhook-signature-verification/index.html
@@ -43,7 +43,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -65,7 +64,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>
@@ -140,7 +138,7 @@
 <p>When Hookwing sends a webhook, it computes an HMAC-SHA256 signature over the raw request body using a signing secret shared between you and the platform. That signature travels in the request header as <code>X-Hookwing-Signature</code>.</p>
 <p>On your end, you do the same computation with the same secret. If the results match, the payload came from Hookwing and has not been tampered with in transit. If they do not match, you reject it.</p>
 <p>This is meaningfully different from API key authentication. An API key proves who is making a request. A webhook signature proves that the specific payload you received was not modified after it was signed. An attacker who intercepts the request without the secret cannot forge a valid signature, even if they know the endpoint URL.</p>
-<figure><img src="/assets/blog/optimized/generated/webhook-signature-verification-flow.webp" alt="HMAC signature verification flow: Hookwing signs the payload with a shared secret, sends the signature in a header, and the receiver recomputes and compares to verify authenticity" loading="lazy" decoding="async" /></figure>
+<figure><img src="/assets/blog/optimized/generated/webhook-signature-verification-flow.webp" alt="HMAC signature verification flow: Hookwing signs the payload with a shared secret" loading="lazy" decoding="async" /></figure>
 <p>---</p>
 <h2 id="2-the-10-line-implementation">2. The 10-line implementation</h2>
 <pre><code class="hljs language-python"><span class="hljs-keyword">import</span> hmac

--- a/website/blog/webhooks-for-ai-agents/index.html
+++ b/website/blog/webhooks-for-ai-agents/index.html
@@ -43,7 +43,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -65,7 +64,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>
@@ -111,7 +109,7 @@
         
       </div>
     </div>
-    <figure class="hero"><div class="hero-media"><img src="/assets/blog/optimized/generated/webhooks-for-ai-agents-hero.webp" alt="AI agent with wings receiving real-time webhook event streams, aviation-themed dark technical illustration" loading="eager" decoding="async" fetchpriority="high" /></div><figcaption>AI agent with wings receiving real-time webhook event streams, aviation-themed dark technical illustration</figcaption></figure>
+    <figure class="hero"><div class="hero-media"><img src="/assets/blog/optimized/generated/webhooks-for-ai-agents-hero.webp" alt="Receiving real-time webhook event streams" loading="eager" decoding="async" fetchpriority="high" /></div><figcaption>AI agent with wings receiving real-time webhook event streams, aviation-themed dark technical illustration</figcaption></figure>
     <div class="article-layout">
       <aside class="toc" aria-label="Table of contents">
     <div class="toc-title"><span>On this page</span><span>12</span></div>

--- a/website/blog/webhooks-vs-event-streams/index.html
+++ b/website/blog/webhooks-vs-event-streams/index.html
@@ -43,7 +43,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -65,7 +64,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>
@@ -111,7 +109,7 @@
         <a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/event-streams/">event-streams</a> <a class="chip" href="/blog/tags/kafka/">kafka</a> <a class="chip" href="/blog/tags/architecture/">architecture</a> <a class="chip" href="/blog/tags/decision-making/">decision-making</a>
       </div>
     </div>
-    <figure class="hero"><div class="hero-media"><img src="/assets/blog/generated/webhooks-vs-event-streams-hero.png" alt="Aviation-themed illustration contrasting push delivery (webhooks) and pull consumption (event streams) patterns in dark technical style" loading="eager" decoding="async" fetchpriority="high" /></div><figcaption>Aviation-themed illustration contrasting push delivery (webhooks) and pull consumption (event streams) patterns in dark technical style</figcaption></figure>
+    <figure class="hero"><div class="hero-media"><img src="/assets/blog/generated/webhooks-vs-event-streams-hero.png" alt="Push delivery (webhooks) and pull consumption (event streams) patterns" loading="eager" decoding="async" fetchpriority="high" /></div><figcaption>Aviation-themed illustration contrasting push delivery (webhooks) and pull consumption (event streams) patterns in dark technical style</figcaption></figure>
     <div class="article-layout">
       <aside class="toc" aria-label="Table of contents">
     <div class="toc-title"><span>On this page</span><span>12</span></div>
@@ -176,7 +174,7 @@
 <h2 id="the-decision-table">The Decision Table</h2>
 <p>| Scenario | Webhooks | Event Streams | Notes | |----------|----------|---------------|-------| | <strong>External third-party integration</strong> | ✅ | ❌ | Only option with external platforms | | <strong>One sender, one receiver</strong> | ✅✅ | ⚠️ | Webhooks simpler; streams add overhead | | <strong>Multiple independent consumers</strong> | ⚠️ | ✅✅ | Streams eliminate fan-out complexity | | <strong>Replay events after bug</strong> | ❌ | ✅ | Webhooks fire once; streams keep history | | <strong>High volume (100k+/day)</strong> | ⚠️ | ✅✅ | Streams handle backpressure naturally | | <strong>Agent listening for events</strong> | ✅✅ | ❌ | Agents are push-first | | <strong>Local development</strong> | ✅ | ❌ | Webhooks + ngrok; streams need local broker | | <strong>Long event retention</strong> | ❌ | ✅ | Webhooks are ephemeral |</p>
 <h2 id="the-hybrid-pattern-production-reality">The Hybrid Pattern (Production Reality)</h2>
-<figure><img src="/assets/blog/optimized/illustrations/webhooks-vs-streams-hybrid.svg" alt="Architecture diagram showing three-layer pattern with webhooks at ingestion, event stream in middle, services and agents consuming" loading="lazy" decoding="async" /><figcaption class="caption">Production pattern: ingestion layer (webhooks) → internal layer (event stream) → consumption layer (services, agents)</figcaption></figure>
+<figure><img src="/assets/blog/optimized/illustrations/webhooks-vs-streams-hybrid.svg" alt="Architecture diagram showing three-layer pattern with webhooks at ingestion" loading="lazy" decoding="async" /><figcaption class="caption">Production pattern: ingestion layer (webhooks) → internal layer (event stream) → consumption layer (services, agents)</figcaption></figure>
 <p>In real systems, you use both.</p>
 <p><strong>Ingestion layer:</strong> External events come in via webhooks. Hookwing handles retries, <a href="/blog/webhook-dead-letter-queues/">dead letter queues</a>, signing, all the delivery guarantees.</p>
 <p><strong>Internal layer:</strong> Those events land in an internal event stream (Kafka, RabbitMQ, whatever). One topic per event type.</p>

--- a/website/changelog/index.html
+++ b/website/changelog/index.html
@@ -41,6 +41,7 @@
           <!-- Desktop links -->
           <ul class="nav-links" role="list">
           <li><a href="/why-hookwing/" class="nav-link">Why Hookwing</a></li>
+            <li><a href="/use-cases/" class="nav-link">Use cases</a></li>
           <li><a href="/playground/" class="nav-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-link">Documentation</a></li>
@@ -76,6 +77,7 @@
       <nav aria-label="Mobile navigation links">
         <ul class="nav-mobile-links" role="list">
           <li><a href="/why-hookwing/" class="nav-mobile-link">Why Hookwing</a></li>
+          <li><a href="/use-cases/" class="nav-mobile-link">Use cases</a></li>
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
@@ -233,6 +235,7 @@
           <p class="footer-col-heading">Company</p>
           <ul class="footer-links" role="list">
             <li><a href="/why-hookwing/" class="footer-link">Why Hookwing</a></li>
+            <li><a href="/use-cases/" class="nav-link">Use cases</a></li>
             <li><a href="/blog/" class="footer-link">Blog</a></li>
             <li><a href="mailto:hello@hookwing.com" class="footer-link">Contact</a></li>
           </ul>

--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -40,7 +40,6 @@
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link">Agents</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link">Get started</a></li>
           </ul>
@@ -62,7 +61,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>

--- a/website/index.html
+++ b/website/index.html
@@ -48,24 +48,17 @@
       },
       {
         "@type": "Offer",
-        "name": "Biplane",
-        "price": "29",
+        "name": "Warbird",
+        "price": "9",
         "priceCurrency": "USD",
-        "description": "250,000 events/month"
+        "description": "100,000 events/month"
       },
       {
         "@type": "Offer",
-        "name": "Warbird",
+        "name": "Stealth Jet",
         "price": "99",
         "priceCurrency": "USD",
-        "description": "2,000,000 events/month"
-      },
-      {
-        "@type": "Offer",
-        "name": "Jet",
-        "price": "0",
-        "priceCurrency": "USD",
-        "description": "Unlimited events, custom pricing"
+        "description": "1,000,000 events/month"
       }
     ]
   }
@@ -585,13 +578,13 @@
             <a href="/getting-started/" class="btn btn-secondary btn-md pricing-cta">Start for free</a>
           </div>
 
-          <!-- Tier 2: Biplane -->
-          <div class="pricing-card featured" aria-labelledby="tier-biplane">
+          <!-- Tier 2: Warbird -->
+          <div class="pricing-card featured" aria-labelledby="tier-warbird">
             <div class="featured-badge" aria-label="Most popular plan">Most popular</div>
 
             <div class="pricing-icon-wrap" style="background:#EDFAF4;" aria-hidden="true">
               <svg width="28" height="28" viewBox="0 0 28 28" fill="none" aria-hidden="true" focusable="false">
-                <!-- Biplane: two wing shapes stacked -->
+                <!-- Warbird: two wing shapes stacked -->
                 <rect x="3" y="10" width="22" height="4" rx="2" fill="#009D64" fill-opacity="0.2" stroke="#009D64" stroke-width="1.5"/>
                 <rect x="6" y="15" width="16" height="3.5" rx="1.75" fill="#009D64" fill-opacity="0.15" stroke="#009D64" stroke-width="1.2"/>
                 <!-- fuselage -->
@@ -599,26 +592,26 @@
               </svg>
             </div>
 
-            <p class="pricing-tier-name">Biplane</p>
+            <p class="pricing-tier-name">Warbird</p>
 
             <div class="pricing-price">
-              <span class="currency">$</span>29<span class="period">/mo</span>
+              <span class="currency">$</span>9<span class="period">/mo</span>
             </div>
 
             <p class="pricing-desc">For projects gaining altitude — whether you're a team or an agent fleet. More headroom, priority retries.</p>
 
-            <ul class="pricing-features" aria-label="Biplane features">
+            <ul class="pricing-features" aria-label="Warbird features">
               <li>
                 <svg class="pricing-check" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                250,000 events / month
+                100,000 events / month
               </li>
               <li>
                 <svg class="pricing-check" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                Unlimited endpoints
+                10 endpoints
               </li>
               <li>
                 <svg class="pricing-check" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                90-day event history
+                30-day event history
               </li>
               <li>
                 <svg class="pricing-check" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
@@ -629,18 +622,18 @@
             <a href="/getting-started/" class="btn btn-primary btn-md pricing-cta">Get started</a>
           </div>
 
-          <!-- Tier 3: Warbird -->
-          <div class="pricing-card" aria-labelledby="tier-warbird">
+          <!-- Tier 3: Stealth Jet -->
+          <div class="pricing-card" aria-labelledby="tier-stealth-jet">
 
             <div class="pricing-icon-wrap" style="background:#FFF3CC;" aria-hidden="true">
               <svg width="28" height="28" viewBox="0 0 28 28" fill="none" aria-hidden="true" focusable="false">
-                <!-- Warbird: swept-wing fighter silhouette, geometric -->
+                <!-- Stealth Jet: swept-wing fighter silhouette, geometric -->
                 <polygon points="14,4 24,20 14,16 4,20" fill="#FFC107" fill-opacity="0.25" stroke="#E6A800" stroke-width="1.5" stroke-linejoin="round"/>
                 <line x1="14" y1="4" x2="14" y2="24" stroke="#E6A800" stroke-width="1.5" stroke-linecap="round"/>
               </svg>
             </div>
 
-            <p class="pricing-tier-name">Warbird</p>
+            <p class="pricing-tier-name">Stealth Jet</p>
 
             <div class="pricing-price">
               <span class="currency">$</span>99<span class="period">/mo</span>
@@ -648,18 +641,18 @@
 
             <p class="pricing-desc">Production-grade delivery for high-volume workloads and autonomous pipelines. Custom retry policies, SLA.</p>
 
-            <ul class="pricing-features" aria-label="Warbird features">
+            <ul class="pricing-features" aria-label="Stealth Jet features">
               <li>
                 <svg class="pricing-check" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                2,000,000 events / month
+                1,000,000 events / month
               </li>
               <li>
                 <svg class="pricing-check" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                Unlimited endpoints + routing
+                50 endpoints + routing
               </li>
               <li>
                 <svg class="pricing-check" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                365-day event history
+                90-day event history
               </li>
               <li>
                 <svg class="pricing-check" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
@@ -668,47 +661,6 @@
             </ul>
 
             <a href="/getting-started/" class="btn btn-secondary btn-md pricing-cta">Get started</a>
-          </div>
-
-          <!-- Tier 4: Jet -->
-          <div class="pricing-card" aria-labelledby="tier-jet">
-
-            <div class="pricing-icon-wrap" style="background:#001A24;" aria-hidden="true">
-              <svg width="28" height="28" viewBox="0 0 28 28" fill="none" aria-hidden="true" focusable="false">
-                <!-- Jet: delta-wing silhouette -->
-                <polygon points="14,3 26,22 14,18 2,22" fill="#E8F4F9" fill-opacity="0.15" stroke="#E8F4F9" stroke-width="1.5" stroke-linejoin="round"/>
-                <!-- engine pods -->
-                <ellipse cx="8" cy="20" rx="2.5" ry="1.2" fill="#E8F4F9" fill-opacity="0.3" stroke="#E8F4F9" stroke-width="1"/>
-                <ellipse cx="20" cy="20" rx="2.5" ry="1.2" fill="#E8F4F9" fill-opacity="0.3" stroke="#E8F4F9" stroke-width="1"/>
-              </svg>
-            </div>
-
-            <p class="pricing-tier-name">Jet</p>
-
-            <div class="pricing-price" style="font-size:32px;">Custom</div>
-
-            <p class="pricing-desc">For enterprises and agent-heavy architectures at serious scale. Dedicated infrastructure, negotiated SLA.</p>
-
-            <ul class="pricing-features" aria-label="Jet features">
-              <li>
-                <svg class="pricing-check" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                Unlimited events
-              </li>
-              <li>
-                <svg class="pricing-check" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                Dedicated infrastructure
-              </li>
-              <li>
-                <svg class="pricing-check" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                Custom SLA + GDPR DPA
-              </li>
-              <li>
-                <svg class="pricing-check" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                White-glove onboarding
-              </li>
-            </ul>
-
-            <a href="mailto:hello@hookwing.com" class="btn btn-ghost btn-md pricing-cta" style="border:1.5px solid var(--color-border-strong);">Talk to us</a>
           </div>
 
         </div>

--- a/website/pricing/index.html
+++ b/website/pricing/index.html
@@ -101,16 +101,15 @@
           "name": "What payment methods do you accept?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "All major credit and debit cards (Visa, Mastercard, Amex). Bank transfers available on annual Jet plans. Agents can trigger upgrades via API using a stored payment method."
+            "text": "All major credit and debit cards (Visa, Mastercard, Amex). Bank transfers available on annual Stealth Jet plans. Agents can trigger upgrades via API using a stored payment method."
           }
         }
       ]
     },
     "offers": [
       {"@type": "Offer", "name": "Paper Plane", "price": "0", "priceCurrency": "USD", "description": "10,000 events/month, no credit card required"},
-      {"@type": "Offer", "name": "Biplane", "price": "29", "priceCurrency": "USD", "description": "250,000 events/month"},
-      {"@type": "Offer", "name": "Warbird", "price": "99", "priceCurrency": "USD", "description": "2,000,000 events/month"},
-      {"@type": "Offer", "name": "Jet", "price": "0", "priceCurrency": "USD", "description": "Unlimited events, custom pricing"}
+      {"@type": "Offer", "name": "Warbird", "price": "9", "priceCurrency": "USD", "description": "100,000 events/month"},
+      {"@type": "Offer", "name": "Stealth Jet", "price": "99", "priceCurrency": "USD", "description": "1,000,000 events/month"}
     ]
   }
   </script>
@@ -363,10 +362,11 @@
             </a>
           </div>
 
-          <!-- ─── Tier 2: Biplane ─────────────────────────────── -->
-          <div class="pricing-card" aria-labelledby="tier-biplane">
+          <!-- ─── Tier 2: Warbird ─────────────────────────────── -->
+          <div class="pricing-card featured" aria-labelledby="tier-warbird">
+            <div class="featured-badge" aria-label="Most popular plan">Most popular</div>
 
-            <!-- Icon: Biplane - double wing geometric SVG -->
+            <!-- Icon: Warbird - double wing geometric SVG -->
             <div class="pricing-icon-wrap" style="background:#EDFAF4;" aria-hidden="true">
               <svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
                 <!-- Upper wing -->
@@ -381,19 +381,19 @@
               </svg>
             </div>
 
-            <p class="pricing-tier-name" aria-label="Tier: Biplane">Biplane</p>
+            <p class="pricing-tier-name" aria-label="Tier: Warbird">Warbird</p>
 
             <div class="pricing-price-row">
               <span class="pricing-currency" aria-hidden="true">$</span>
-              <span class="pricing-amount" id="price-biplane" data-monthly="29" data-annual="24" aria-label="$29 per month">29</span>
+              <span class="pricing-amount" id="price-warbird" data-monthly="9" data-annual="7" aria-label="$9 per month">9</span>
               <span class="pricing-period">/mo</span>
             </div>
 
-            <p class="pricing-annual-note" id="annual-note-biplane" aria-live="polite">&nbsp;</p>
+            <p class="pricing-annual-note" id="annual-note-warbird" aria-live="polite">&nbsp;</p>
 
             <p class="pricing-desc">For projects gaining altitude — whether you're a team or an agent fleet. More headroom, priority retries, email support.</p>
 
-            <ul class="pricing-features-list" aria-label="Biplane plan features">
+            <ul class="pricing-features-list" aria-label="Warbird plan features">
               <li>
                 <svg class="check-icon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
                 250,000 events / month
@@ -426,10 +426,9 @@
           </div>
 
           <!-- ─── Tier 3: Warbird (Most popular) ─────────────── -->
-          <div class="pricing-card featured" aria-labelledby="tier-warbird">
-            <div class="featured-badge" aria-label="Most popular plan">Most popular</div>
+          <div class="pricing-card" aria-labelledby="tier-stealth-jet">
 
-            <!-- Icon: Warbird - swept-wing fighter silhouette -->
+            <!-- Icon: Stealth Jet - swept-wing fighter silhouette -->
             <div class="pricing-icon-wrap" style="background:#FFFAE8;" aria-hidden="true">
               <svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
                 <!-- Main body -->
@@ -442,22 +441,22 @@
               </svg>
             </div>
 
-            <p class="pricing-tier-name" aria-label="Tier: Warbird">Warbird</p>
+            <p class="pricing-tier-name" aria-label="Tier: Stealth Jet">Stealth Jet</p>
 
             <div class="pricing-price-row">
               <span class="pricing-currency" aria-hidden="true">$</span>
-              <span class="pricing-amount" id="price-warbird" data-monthly="99" data-annual="82" aria-label="$99 per month">99</span>
+              <span class="pricing-amount" id="price-stealth-jet" data-monthly="99" data-annual="82" aria-label="$99 per month">99</span>
               <span class="pricing-period">/mo</span>
             </div>
 
-            <p class="pricing-annual-note" id="annual-note-warbird" aria-live="polite">&nbsp;</p>
+            <p class="pricing-annual-note" id="annual-note-stealth-jet" aria-live="polite">&nbsp;</p>
 
             <p class="pricing-desc">Production-grade delivery for high-volume workloads and autonomous pipelines. Custom retry policies, SLA, and agent-managed infrastructure.</p>
 
-            <ul class="pricing-features-list" aria-label="Warbird plan features">
+            <ul class="pricing-features-list" aria-label="Stealth Jet plan features">
               <li>
                 <svg class="check-icon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                2,000,000 events / month
+                1,000,000 events / month
               </li>
               <li>
                 <svg class="check-icon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
@@ -486,63 +485,7 @@
             </a>
           </div>
 
-          <!-- ─── Tier 4: Jet ─────────────────────────────────── -->
-          <div class="pricing-card" aria-labelledby="tier-jet">
-
-            <!-- Icon: Jet - delta-wing silhouette on dark bg -->
-            <div class="pricing-icon-wrap" style="background:#001A24;" aria-hidden="true">
-              <svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
-                <!-- Delta wing -->
-                <polygon points="15,4 28,24 15,20 2,24" fill="#E8F4F9" fill-opacity="0.12" stroke="#E8F4F9" stroke-width="1.5" stroke-linejoin="round"/>
-                <!-- Engine pods -->
-                <ellipse cx="8" cy="22" rx="3" ry="1.4" fill="#E8F4F9" fill-opacity="0.25" stroke="#E8F4F9" stroke-width="1"/>
-                <ellipse cx="22" cy="22" rx="3" ry="1.4" fill="#E8F4F9" fill-opacity="0.25" stroke="#E8F4F9" stroke-width="1"/>
-                <!-- Cockpit -->
-                <ellipse cx="15" cy="9" rx="2" ry="3" fill="#E8F4F9" fill-opacity="0.2" stroke="#E8F4F9" stroke-width="1"/>
-              </svg>
-            </div>
-
-            <p class="pricing-tier-name" aria-label="Tier: Jet">Jet</p>
-
-            <div class="pricing-price-row">
-              <span class="pricing-amount custom-price" id="price-jet" aria-label="Custom pricing">Custom</span>
-            </div>
-
-            <p class="pricing-annual-note" id="annual-note-jet" aria-live="polite">&nbsp;</p>
-
-            <p class="pricing-desc">For enterprises and agent-heavy architectures at serious scale. Dedicated infrastructure. Negotiated SLA. Agent self-service or human-managed — your call.</p>
-
-            <ul class="pricing-features-list" aria-label="Jet plan features">
-              <li>
-                <svg class="check-icon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                Unlimited events
-              </li>
-              <li>
-                <svg class="check-icon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                365-day event retention
-              </li>
-              <li>
-                <svg class="check-icon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                Dedicated infrastructure
-              </li>
-              <li>
-                <svg class="check-icon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                SSO / SAML
-              </li>
-              <li>
-                <svg class="check-icon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                24/7 support + SLA
-              </li>
-              <li>
-                <svg class="check-icon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                GDPR DPA + custom contract
-              </li>
-            </ul>
-
-            <a href="mailto:hello@hookwing.com" class="btn btn-outline-dark btn-md pricing-card-cta" style="display:flex;">
-              Talk to us
-            </a>
-          </div>
+          <!-- Jet tier removed — 3-tier structure: Paper Plane, Warbird, Stealth Jet -->
 
         </div>
 
@@ -586,16 +529,12 @@
                   <span class="th-tier-price">Free</span>
                 </th>
                 <th scope="col">
-                  <span class="th-tier-name">Biplane</span>
-                  <span class="th-tier-price">$29/mo</span>
+                  <span class="th-tier-name">Warbird</span>
+                  <span class="th-tier-price">$9/mo</span>
                 </th>
                 <th scope="col" class="col-featured">
-                  <span class="th-tier-name featured-name">Warbird</span>
+                  <span class="th-tier-name">Stealth Jet</span>
                   <span class="th-tier-price">$99/mo</span>
-                </th>
-                <th scope="col">
-                  <span class="th-tier-name">Jet</span>
-                  <span class="th-tier-price">Custom</span>
                 </th>
               </tr>
             </thead>
@@ -603,7 +542,7 @@
 
               <!-- GROUP: Agent features -->
               <tr class="row-group-header" role="row">
-                <td colspan="5">Agent features</td>
+                <td colspan="4">Agent features</td>
               </tr>
 
               <tr>
@@ -611,7 +550,6 @@
                 <td><span class="tbl-check">✓</span></td>
                 <td><span class="tbl-check">✓</span></td>
                 <td class="col-featured"><span class="tbl-check">✓</span></td>
-                <td><span class="tbl-check">✓</span></td>
               </tr>
 
               <tr>
@@ -619,7 +557,6 @@
                 <td><span class="tbl-check">✓</span></td>
                 <td><span class="tbl-check">✓</span></td>
                 <td class="col-featured"><span class="tbl-check">✓</span></td>
-                <td><span class="tbl-check">✓</span></td>
               </tr>
 
               <tr>
@@ -627,7 +564,6 @@
                 <td><span class="tbl-check">✓</span></td>
                 <td><span class="tbl-check">✓</span></td>
                 <td class="col-featured"><span class="tbl-check">✓</span></td>
-                <td><span class="tbl-check">✓</span></td>
               </tr>
 
               <tr>
@@ -635,7 +571,6 @@
                 <td><span class="tbl-cross">—</span></td>
                 <td><span class="tbl-check">✓</span></td>
                 <td class="col-featured"><span class="tbl-check">✓</span></td>
-                <td><span class="tbl-check">✓</span></td>
               </tr>
 
               <tr>
@@ -643,28 +578,25 @@
                 <td><span class="tbl-check">✓</span></td>
                 <td><span class="tbl-check">✓</span></td>
                 <td class="col-featured"><span class="tbl-check">✓</span></td>
-                <td><span class="tbl-check">✓</span></td>
               </tr>
 
               <!-- GROUP: Usage -->
               <tr class="row-group-header" role="row">
-                <td colspan="5">Usage limits</td>
+                <td colspan="4">Usage limits</td>
               </tr>
 
               <tr>
                 <td scope="row">Events / month</td>
                 <td><span class="tbl-value">10,000</span></td>
-                <td><span class="tbl-value">250,000</span></td>
-                <td class="col-featured"><span class="tbl-value highlight">2,000,000</span></td>
-                <td><span class="tbl-value highlight">Unlimited</span></td>
+                <td><span class="tbl-value">100,000</span></td>
+                <td class="col-featured"><span class="tbl-value">1,000,000</span></td>
               </tr>
 
               <tr>
                 <td scope="row">Retention</td>
                 <td><span class="tbl-value">7 days</span></td>
                 <td><span class="tbl-value">30 days</span></td>
-                <td class="col-featured"><span class="tbl-value highlight">90 days</span></td>
-                <td><span class="tbl-value highlight">365 days</span></td>
+                <td class="col-featured"><span class="tbl-value">90 days</span></td>
               </tr>
 
               <tr>
@@ -672,12 +604,11 @@
                 <td><span class="tbl-value">5</span></td>
                 <td><span class="tbl-value highlight">Unlimited</span></td>
                 <td class="col-featured"><span class="tbl-value highlight">Unlimited</span></td>
-                <td><span class="tbl-value highlight">Unlimited</span></td>
               </tr>
 
               <!-- GROUP: Delivery -->
               <tr class="row-group-header" role="row">
-                <td colspan="5">Delivery</td>
+                <td colspan="4">Delivery</td>
               </tr>
 
               <tr>
@@ -685,7 +616,6 @@
                 <td><span class="tbl-value">Standard</span></td>
                 <td><span class="tbl-value">Priority retries</span></td>
                 <td class="col-featured"><span class="tbl-value highlight">Custom policies</span></td>
-                <td><span class="tbl-value highlight">Custom policies</span></td>
               </tr>
 
               <tr>
@@ -701,11 +631,6 @@
                   </span>
                 </td>
                 <td class="col-featured">
-                  <span class="tbl-check" aria-label="Included">
-                    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true"><circle cx="9" cy="9" r="8.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5.5 9.5L7.5 11.5L12.5 6.5" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                  </span>
-                </td>
-                <td>
                   <span class="tbl-check" aria-label="Included">
                     <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true"><circle cx="9" cy="9" r="8.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5.5 9.5L7.5 11.5L12.5 6.5" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
                   </span>
@@ -729,11 +654,6 @@
                     <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true"><circle cx="9" cy="9" r="8.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5.5 9.5L7.5 11.5L12.5 6.5" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
                   </span>
                 </td>
-                <td>
-                  <span class="tbl-check" aria-label="Included">
-                    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true"><circle cx="9" cy="9" r="8.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5.5 9.5L7.5 11.5L12.5 6.5" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                  </span>
-                </td>
               </tr>
 
               <tr>
@@ -753,11 +673,6 @@
                     <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true"><circle cx="9" cy="9" r="8.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5.5 9.5L7.5 11.5L12.5 6.5" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
                   </span>
                 </td>
-                <td>
-                  <span class="tbl-check" aria-label="Included">
-                    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true"><circle cx="9" cy="9" r="8.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5.5 9.5L7.5 11.5L12.5 6.5" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                  </span>
-                </td>
               </tr>
 
               <tr>
@@ -769,16 +684,11 @@
                     <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true"><circle cx="9" cy="9" r="8.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5.5 9.5L7.5 11.5L12.5 6.5" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
                   </span>
                 </td>
-                <td>
-                  <span class="tbl-check" aria-label="Included">
-                    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true"><circle cx="9" cy="9" r="8.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5.5 9.5L7.5 11.5L12.5 6.5" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                  </span>
-                </td>
               </tr>
 
               <!-- GROUP: Access -->
               <tr class="row-group-header" role="row">
-                <td colspan="5">Access &amp; integrations</td>
+                <td colspan="4">Access &amp; integrations</td>
               </tr>
 
               <tr>
@@ -794,11 +704,6 @@
                   </span>
                 </td>
                 <td class="col-featured">
-                  <span class="tbl-check" aria-label="Included">
-                    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true"><circle cx="9" cy="9" r="8.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5.5 9.5L7.5 11.5L12.5 6.5" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                  </span>
-                </td>
-                <td>
                   <span class="tbl-check" aria-label="Included">
                     <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true"><circle cx="9" cy="9" r="8.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5.5 9.5L7.5 11.5L12.5 6.5" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
                   </span>
@@ -822,11 +727,6 @@
                     <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true"><circle cx="9" cy="9" r="8.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5.5 9.5L7.5 11.5L12.5 6.5" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
                   </span>
                 </td>
-                <td>
-                  <span class="tbl-check" aria-label="Included">
-                    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true"><circle cx="9" cy="9" r="8.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5.5 9.5L7.5 11.5L12.5 6.5" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                  </span>
-                </td>
               </tr>
 
               <tr>
@@ -846,11 +746,6 @@
                     <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true"><circle cx="9" cy="9" r="8.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5.5 9.5L7.5 11.5L12.5 6.5" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
                   </span>
                 </td>
-                <td>
-                  <span class="tbl-check" aria-label="Included">
-                    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true"><circle cx="9" cy="9" r="8.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5.5 9.5L7.5 11.5L12.5 6.5" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                  </span>
-                </td>
               </tr>
 
               <tr>
@@ -862,16 +757,11 @@
                     <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true"><circle cx="9" cy="9" r="8.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5.5 9.5L7.5 11.5L12.5 6.5" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
                   </span>
                 </td>
-                <td>
-                  <span class="tbl-check" aria-label="Included">
-                    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true"><circle cx="9" cy="9" r="8.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5.5 9.5L7.5 11.5L12.5 6.5" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                  </span>
-                </td>
               </tr>
 
               <!-- GROUP: Enterprise -->
               <tr class="row-group-header" role="row">
-                <td colspan="5">Reliability &amp; compliance</td>
+                <td colspan="4">Reliability &amp; compliance</td>
               </tr>
 
               <tr>
@@ -879,7 +769,6 @@
                 <td><span class="tbl-dash" role="img" aria-label="Not included"></span></td>
                 <td><span class="tbl-dash" role="img" aria-label="Not included"></span></td>
                 <td class="col-featured"><span class="tbl-value highlight">99.9%</span></td>
-                <td><span class="tbl-value highlight">99.99%</span></td>
               </tr>
 
               <tr>
@@ -887,7 +776,6 @@
                 <td><span class="tbl-value">Community</span></td>
                 <td><span class="tbl-value">Email (&lt;24h)</span></td>
                 <td class="col-featured"><span class="tbl-value highlight">Priority (&lt;4h)</span></td>
-                <td><span class="tbl-value highlight">24/7 dedicated</span></td>
               </tr>
 
               <tr>
@@ -895,11 +783,6 @@
                 <td><span class="tbl-dash" role="img" aria-label="Not included"></span></td>
                 <td><span class="tbl-dash" role="img" aria-label="Not included"></span></td>
                 <td class="col-featured"><span class="tbl-dash" role="img" aria-label="Not included"></span></td>
-                <td>
-                  <span class="tbl-check" aria-label="Included">
-                    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true"><circle cx="9" cy="9" r="8.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5.5 9.5L7.5 11.5L12.5 6.5" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                  </span>
-                </td>
               </tr>
 
               <tr>
@@ -907,11 +790,6 @@
                 <td><span class="tbl-dash" role="img" aria-label="Not included"></span></td>
                 <td><span class="tbl-dash" role="img" aria-label="Not included"></span></td>
                 <td class="col-featured"><span class="tbl-dash" role="img" aria-label="Not included"></span></td>
-                <td>
-                  <span class="tbl-check" aria-label="Included">
-                    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true"><circle cx="9" cy="9" r="8.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5.5 9.5L7.5 11.5L12.5 6.5" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                  </span>
-                </td>
               </tr>
 
             </tbody>
@@ -978,7 +856,7 @@
             </button>
             <div class="faq-answer" id="faq-answer-3" role="region" aria-labelledby="faq-q3" hidden>
               <div class="faq-answer-inner">
-                No. Monthly plans are month-to-month - cancel anytime, no questions asked. Annual plans lock in a lower rate for 12 months and save you 2 months of cost. Jet plans can include multi-year terms with negotiated rates; reach out to discuss.
+                No. Monthly plans are month-to-month - cancel anytime, no questions asked. Annual plans lock in a lower rate for 12 months and save you 2 months of cost. Stealth Jet plans include negotiated terms; reach out to discuss.
               </div>
             </div>
           </div>
@@ -1055,7 +933,7 @@
             </button>
             <div class="faq-answer" id="faq-answer-8" role="region" aria-labelledby="faq-q8" hidden>
               <div class="faq-answer-inner">
-                All major credit and debit cards - Visa, Mastercard, American Express. Bank transfers (ACH/SEPA) are available on annual Jet plans. Agents can trigger plan upgrades via API using a stored payment method. No check payments.
+                All major credit and debit cards - Visa, Mastercard, American Express. Bank transfers (ACH/SEPA) are available on annual Stealth Jet plans. Agents can trigger plan upgrades via API using a stored payment method. No check payments.
               </div>
             </div>
           </div>
@@ -1253,8 +1131,8 @@
 
       // Prices: [monthly, annual_per_month]
       const pricedTiers = [
-        { amountEl: 'price-biplane',  noteEl: 'annual-note-biplane',  monthly: 29, annual: 24  },
-        { amountEl: 'price-warbird',  noteEl: 'annual-note-warbird',  monthly: 99, annual: 82  },
+        { amountEl: 'price-warbird',  noteEl: 'annual-note-warbird',  monthly: 9, annual: 7  },
+        { amountEl: 'price-stealth-jet',  noteEl: 'annual-note-stealth-jet',  monthly: 99, annual: 82  },
       ];
 
       function setAnnual(isAnnual) {
@@ -1273,7 +1151,6 @@
         const ppNote = document.getElementById('annual-note-paper');
         if (ppNote) ppNote.textContent = isAnnual ? 'Free forever' : '';
 
-        // Jet stays custom
         const jetNote = document.getElementById('annual-note-jet');
         if (jetNote) jetNote.textContent = isAnnual ? 'Volume discounts available' : '';
 

--- a/website/privacy/index.html
+++ b/website/privacy/index.html
@@ -41,6 +41,7 @@
           <!-- Desktop links -->
           <ul class="nav-links" role="list">
           <li><a href="/why-hookwing/" class="nav-link">Why Hookwing</a></li>
+            <li><a href="/use-cases/" class="nav-link">Use cases</a></li>
           <li><a href="/playground/" class="nav-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-link">Documentation</a></li>
@@ -76,6 +77,7 @@
       <nav aria-label="Mobile navigation links">
         <ul class="nav-mobile-links" role="list">
           <li><a href="/why-hookwing/" class="nav-mobile-link">Why Hookwing</a></li>
+          <li><a href="/use-cases/" class="nav-mobile-link">Use cases</a></li>
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
@@ -212,6 +214,7 @@
           <p class="footer-col-heading">Company</p>
           <ul class="footer-links" role="list">
             <li><a href="/why-hookwing/" class="footer-link">Why Hookwing</a></li>
+            <li><a href="/use-cases/" class="nav-link">Use cases</a></li>
             <li><a href="/blog/" class="footer-link">Blog</a></li>
             <li><a href="mailto:hello@hookwing.com" class="footer-link">Contact</a></li>
           </ul>

--- a/website/signin/index.html
+++ b/website/signin/index.html
@@ -41,6 +41,7 @@
           <!-- Desktop links -->
           <ul class="nav-links" role="list">
           <li><a href="/why-hookwing/" class="nav-link">Why Hookwing</a></li>
+            <li><a href="/use-cases/" class="nav-link">Use cases</a></li>
           <li><a href="/playground/" class="nav-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-link">Documentation</a></li>
@@ -76,6 +77,7 @@
       <nav aria-label="Mobile navigation links">
         <ul class="nav-mobile-links" role="list">
           <li><a href="/why-hookwing/" class="nav-mobile-link">Why Hookwing</a></li>
+          <li><a href="/use-cases/" class="nav-mobile-link">Use cases</a></li>
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
@@ -164,6 +166,7 @@
           <p class="footer-col-heading">Company</p>
           <ul class="footer-links" role="list">
             <li><a href="/why-hookwing/" class="footer-link">Why Hookwing</a></li>
+            <li><a href="/use-cases/" class="nav-link">Use cases</a></li>
             <li><a href="/use-cases/" class="footer-link">Use Cases</a></li>
             <li><a href="/blog/" class="footer-link">Blog</a></li>
             <li><a href="mailto:hello@hookwing.com" class="footer-link">Contact</a></li>

--- a/website/signup/index.html
+++ b/website/signup/index.html
@@ -41,6 +41,7 @@
           <!-- Desktop links -->
           <ul class="nav-links" role="list">
           <li><a href="/why-hookwing/" class="nav-link">Why Hookwing</a></li>
+            <li><a href="/use-cases/" class="nav-link">Use cases</a></li>
           <li><a href="/playground/" class="nav-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-link">Documentation</a></li>
@@ -76,6 +77,7 @@
       <nav aria-label="Mobile navigation links">
         <ul class="nav-mobile-links" role="list">
           <li><a href="/why-hookwing/" class="nav-mobile-link">Why Hookwing</a></li>
+          <li><a href="/use-cases/" class="nav-mobile-link">Use cases</a></li>
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
@@ -169,6 +171,7 @@
           <p class="footer-col-heading">Company</p>
           <ul class="footer-links" role="list">
             <li><a href="/why-hookwing/" class="footer-link">Why Hookwing</a></li>
+            <li><a href="/use-cases/" class="nav-link">Use cases</a></li>
             <li><a href="/use-cases/" class="footer-link">Use Cases</a></li>
             <li><a href="/blog/" class="footer-link">Blog</a></li>
             <li><a href="mailto:hello@hookwing.com" class="footer-link">Contact</a></li>

--- a/website/src/partials/nav.html
+++ b/website/src/partials/nav.html
@@ -19,7 +19,6 @@
             <li><a href="/playground/" class="nav-link{{#if NAV_ACTIVE_playground}} active{{/if}}">Playground</a></li>
             <li><a href="/pricing/" class="nav-link{{#if NAV_ACTIVE_pricing}} active{{/if}}">Pricing</a></li>
             <li><a href="/docs/" class="nav-link{{#if NAV_ACTIVE_docs}} active{{/if}}">Documentation</a></li>
-            <li><a href="/getting-started/" class="nav-link{{#if NAV_ACTIVE_agents}} active{{/if}}">Agents</a></li>
             <li><a href="/blog/" class="nav-link{{#if NAV_ACTIVE_blog}} active{{/if}}">Blog</a></li>
             <li><a href="/getting-started/" class="nav-link{{#if NAV_ACTIVE_getting_started}} active{{/if}}">Get started</a></li>
           </ul>
@@ -56,7 +55,6 @@
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Agents</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
           <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>

--- a/website/status/index.html
+++ b/website/status/index.html
@@ -41,6 +41,7 @@
           <!-- Desktop links -->
           <ul class="nav-links" role="list">
           <li><a href="/why-hookwing/" class="nav-link">Why Hookwing</a></li>
+            <li><a href="/use-cases/" class="nav-link">Use cases</a></li>
           <li><a href="/playground/" class="nav-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-link">Documentation</a></li>
@@ -76,6 +77,7 @@
       <nav aria-label="Mobile navigation links">
         <ul class="nav-mobile-links" role="list">
           <li><a href="/why-hookwing/" class="nav-mobile-link">Why Hookwing</a></li>
+          <li><a href="/use-cases/" class="nav-mobile-link">Use cases</a></li>
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
@@ -171,6 +173,7 @@
           <p class="footer-col-heading">Company</p>
           <ul class="footer-links" role="list">
             <li><a href="/why-hookwing/" class="footer-link">Why Hookwing</a></li>
+            <li><a href="/use-cases/" class="nav-link">Use cases</a></li>
             <li><a href="/use-cases/" class="footer-link">Use Cases</a></li>
             <li><a href="/blog/" class="footer-link">Blog</a></li>
             <li><a href="mailto:hello@hookwing.com" class="footer-link">Contact</a></li>

--- a/website/terms/index.html
+++ b/website/terms/index.html
@@ -41,6 +41,7 @@
           <!-- Desktop links -->
           <ul class="nav-links" role="list">
           <li><a href="/why-hookwing/" class="nav-link">Why Hookwing</a></li>
+            <li><a href="/use-cases/" class="nav-link">Use cases</a></li>
           <li><a href="/playground/" class="nav-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-link">Documentation</a></li>
@@ -76,6 +77,7 @@
       <nav aria-label="Mobile navigation links">
         <ul class="nav-mobile-links" role="list">
           <li><a href="/why-hookwing/" class="nav-mobile-link">Why Hookwing</a></li>
+          <li><a href="/use-cases/" class="nav-mobile-link">Use cases</a></li>
           <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
@@ -208,6 +210,7 @@
           <p class="footer-col-heading">Company</p>
           <ul class="footer-links" role="list">
             <li><a href="/why-hookwing/" class="footer-link">Why Hookwing</a></li>
+            <li><a href="/use-cases/" class="nav-link">Use cases</a></li>
             <li><a href="/blog/" class="footer-link">Blog</a></li>
             <li><a href="mailto:hello@hookwing.com" class="footer-link">Contact</a></li>
           </ul>


### PR DESCRIPTION
PROD-95 + PROD-99: Restructure from 4 tiers to 3 per Fabien directive.

**New structure:**
| Tier | Price | Endpoints | Events/mo | Retention |
|------|-------|-----------|-----------|-----------|
| Paper Plane | Free | 3 | 10K | 7 days |
| Warbird | $9/mo | 10 | 100K | 30 days |
| Stealth Jet | $99/mo | 50 | 1M | 90 days |

**Removed:** Jet tier (was $299/custom)
**Renamed:** Biplane → Warbird ($29 → $9), Warbird → Stealth Jet

**Files changed (7):**
- Tier config + tests (shared + api)
- Homepage pricing cards + JSON-LD
- Pricing page cards + comparison table + FAQ + JS toggle
- API pricing JSON
- DECISIONS.md

15/15 turbo tasks green, 344 tests passing.