### PR TITLE
fix(PROD-85/92): hero title token + volumetric green haze

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -156,7 +156,7 @@
     <section class="hero" aria-labelledby="hero-heading">
 
       <!-- Green Haze — ambient emerald undertone -->
-      <div class="haze-emerald" aria-hidden="true"></div>
+      <div class="haze-emerald" aria-hidden="true"><div class="haze-layer-1"></div><div class="haze-layer-2"></div><div class="haze-layer-3"></div></div>
 
       <!-- Contrail gradient mesh — atmospheric depth blobs -->
       <div class="contrail-mesh" aria-hidden="true">
@@ -684,7 +684,7 @@
     <section class="cta-section" aria-labelledby="cta-heading">
 
       <!-- Green Haze — ambient emerald undertone -->
-      <div class="haze-emerald" aria-hidden="true"></div>
+      <div class="haze-emerald" aria-hidden="true"><div class="haze-layer-1"></div><div class="haze-layer-2"></div><div class="haze-layer-3"></div></div>
 
       <!-- Decorative flight path in CTA -->
       <div class="cta-contrail" aria-hidden="true"></div>

--- a/website/styles/pages/home.css
+++ b/website/styles/pages/home.css
@@ -563,7 +563,7 @@
       line-height: 1.1;
       font-weight: 700;
       letter-spacing: -0.03em;
-      color: #F8FAFC;
+      color: var(--color-ink-inverse);
       max-width: 14ch;
       margin: 0 auto;
       position: relative;

--- a/website/styles/patterns.css
+++ b/website/styles/patterns.css
@@ -131,7 +131,7 @@ body::after {
   }
 }
 
-/* Green Haze — ambient emerald undertone for hero and CTA sections */
+/* Green Haze — volumetric war-fog drift for hero and CTA sections */
 .haze-emerald {
   position: absolute;
   inset: 0;
@@ -140,36 +140,77 @@ body::after {
   z-index: 1;
 }
 
-.haze-emerald::before {
-  content: '';
+.haze-layer-1,
+.haze-layer-2,
+.haze-layer-3 {
   position: absolute;
-  left: 50%;
-  bottom: -10%;
-  transform: translateX(-50%);
-  width: 70%;
-  max-width: 800px;
-  height: 60%;
-  background: radial-gradient(
-    ellipse at 50% 100%,
-    rgba(0, 157, 100, 0.12) 0%,
-    rgba(0, 157, 100, 0.05) 40%,
-    transparent 70%
-  );
+  border-radius: 50%;
+  pointer-events: none;
   filter: blur(80px);
-  animation: haze-breathe 8s ease-in-out infinite alternate;
 }
 
-@keyframes haze-breathe {
-  0%   { opacity: 0.7; transform: translateX(-50%) scale(1); }
-  100% { opacity: 1.0; transform: translateX(-50%) scale(1.08); }
+.haze-layer-1 {
+  width: 600px;
+  height: 400px;
+  left: calc(50% - 300px);
+  bottom: -15%;
+  background: radial-gradient(ellipse at center, rgba(0, 157, 100, 0.16) 0%, transparent 70%);
+  animation: haze-drift-a 52s ease-in-out infinite;
+}
+
+.haze-layer-2 {
+  width: 450px;
+  height: 320px;
+  left: calc(50% - 180px);
+  bottom: -5%;
+  background: radial-gradient(ellipse at center, rgba(0, 157, 100, 0.10) 0%, transparent 70%);
+  animation: haze-drift-b 68s ease-in-out infinite;
+  animation-delay: -24s;
+}
+
+.haze-layer-3 {
+  width: 320px;
+  height: 240px;
+  left: calc(50% - 200px);
+  bottom: 5%;
+  background: radial-gradient(ellipse at center, rgba(0, 157, 100, 0.07) 0%, transparent 70%);
+  animation: haze-drift-c 43s ease-in-out infinite;
+  animation-delay: -11s;
+}
+
+@keyframes haze-drift-a {
+  0%   { transform: translate(0px, 0px)    scale(1.00); opacity: 0.16; }
+  20%  { transform: translate(18px, -10px) scale(1.05); opacity: 0.20; }
+  45%  { transform: translate(28px, 6px)   scale(1.08); opacity: 0.14; }
+  70%  { transform: translate(10px, 22px)  scale(1.03); opacity: 0.19; }
+  100% { transform: translate(0px, 0px)    scale(1.00); opacity: 0.16; }
+}
+
+@keyframes haze-drift-b {
+  0%   { transform: translate(0px, 0px)     scale(1.00); opacity: 0.10; }
+  30%  { transform: translate(-22px, 14px)  scale(1.06); opacity: 0.16; }
+  60%  { transform: translate(-8px, -18px)  scale(0.96); opacity: 0.08; }
+  80%  { transform: translate(14px, 8px)    scale(1.02); opacity: 0.13; }
+  100% { transform: translate(0px, 0px)     scale(1.00); opacity: 0.10; }
+}
+
+@keyframes haze-drift-c {
+  0%   { transform: translate(0px, 0px)    scale(1.00); opacity: 0.07; }
+  35%  { transform: translate(-16px, -8px) scale(1.04); opacity: 0.12; }
+  65%  { transform: translate(20px, 16px)  scale(0.98); opacity: 0.06; }
+  100% { transform: translate(0px, 0px)    scale(1.00); opacity: 0.07; }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .haze-emerald::before { animation: none; opacity: 0.85; }
+  .haze-layer-1,
+  .haze-layer-2,
+  .haze-layer-3 { animation: none; }
 }
 
 @media (max-width: 767px) {
-  .haze-emerald::before { width: 90%; filter: blur(50px); }
+  .haze-layer-1 { width: 90%; left: 5%; filter: blur(50px); }
+  .haze-layer-2 { width: 70%; left: 15%; filter: blur(50px); }
+  .haze-layer-3 { width: 50%; left: 25%; filter: blur(50px); }
 }
 
 /* Transponder Beacon Pulse — CTAs */


### PR DESCRIPTION
**PROD-85 — CSS token fix:**
- `.hero-title` color: `#F8FAFC` → `var(--color-ink-inverse)` (home.css:567)
- Per Brenda's brand audit — no hardcoded hex values for semantic colors

**PROD-92 — Green haze animation (Brenda spec):**
- Replaced single `::before` pseudo-element with 3 stacked `.haze-layer-*` divs
- 3 independent keyframe animations at 43s/52s/68s with staggered delays (-11s/-24s)
- Each layer drifts with subtle translate (8–28px), scale (0.96–1.08), and opacity (0.06–0.20) shifts
- Effect: volumetric war-fog rolling over a dark airfield — atmospheric, not distracting
- `prefers-reduced-motion: reduce` disables all animations
- Mobile responsive: percentage-based widths, reduced blur

**PROD-98 status:** Already implemented in prior commits (flow nodes + comparison table CSS match Brenda's spec exactly). No changes needed.

3 files changed, 65 insertions(+), 24 deletions(-)