### PR TITLE
fix: migration 0002 D1 NOT NULL compat

### DIFF
--- a/migrations/0002_add_auth_columns.sql
+++ b/migrations/0002_add_auth_columns.sql
@@ -1,5 +1,7 @@
 -- Migration: Add email and password_hash to workspaces
 -- For PROD-59: Auth system
+-- Note: DEFAULT '' needed for D1 ALTER TABLE with NOT NULL on existing tables
 
-ALTER TABLE workspaces ADD COLUMN email TEXT NOT NULL UNIQUE;
-ALTER TABLE workspaces ADD COLUMN password_hash TEXT NOT NULL;
+ALTER TABLE workspaces ADD COLUMN email TEXT NOT NULL DEFAULT '';
+ALTER TABLE workspaces ADD COLUMN password_hash TEXT NOT NULL DEFAULT '';
+CREATE UNIQUE INDEX IF NOT EXISTS idx_workspaces_email ON workspaces(email);


### PR DESCRIPTION
D1 silently fails `ALTER TABLE ... NOT NULL` without a `DEFAULT` value, even on empty tables. This caused the auth columns (`email`, `password_hash`) to be missing from the live workspaces table, resulting in 500s on signup/login.

Fix: Added `DEFAULT ''` to both columns and an explicit `CREATE UNIQUE INDEX` for email.

Already applied manually to the live D1 database — this prevents the issue on fresh deploys.