### PR TITLE
fix(PROD-117): Paper Plane/Warbird/Fighter Jet at $0/$19/$89

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -11,4 +11,4 @@
 | 2026-03-13 | All deploys through CI — no manual deploys | Fabien | SOC 2 principle: audit trail for all changes |
 | 2026-03-13 | Dev domain only (dev.hookwing.com) — never share .pages.dev URLs | Fabien | Cloudflare Access protects dev domains; .pages.dev is unprotected |
 | 2026-03-13 | Infrastructure separation: product infra ≠ operational tooling | Fabien | SOC 2 Type 2 compliance principle |
-| 2026-03-15 | 3-tier pricing: Free ($0, 25K events), Pro ($19, 100K events), Enterprise (custom) | Fabien/Remi | Research-backed pricing, generous free tier, overage model on Pro |
+| 2026-03-15 | 3-tier pricing: Paper Plane ($0, 25K), Warbird ($19, 100K), Fighter Jet ($89, 10M) — all fixed prices, no "contact us" | Fabien/Remi | Research-backed, generous free tier, overage on Warbird |

--- a/packages/api/src/__tests__/dashboard-flows.test.ts
+++ b/packages/api/src/__tests__/dashboard-flows.test.ts
@@ -275,11 +275,11 @@ describe('Dashboard Flow: Public Routes', () => {
     expect(body.length).toBeGreaterThan(0);
   });
 
-  it('GET /tiers/free should return tier details', async () => {
-    const res = await createApp().request('/tiers/free');
+  it('GET /tiers/paper-plane should return tier details', async () => {
+    const res = await createApp().request('/tiers/paper-plane');
     expect(res.status).toBe(200);
     const body = (await res.json()) as Record<string, unknown>;
-    expect(body.slug).toBe('free');
+    expect(body.slug).toBe('paper-plane');
     expect(body).toHaveProperty('limits');
     expect(body).toHaveProperty('features');
   });

--- a/packages/api/src/__tests__/health.test.ts
+++ b/packages/api/src/__tests__/health.test.ts
@@ -47,6 +47,6 @@ describe('cross-package imports', () => {
     // Verify the shared package is importable (workspace link works)
     const shared = await import('@hookwing/shared');
     expect(shared.DEFAULT_TIERS).toBeDefined();
-    expect(shared.getTierBySlug('free')).toBeDefined();
+    expect(shared.getTierBySlug('paper-plane')).toBeDefined();
   });
 });

--- a/packages/api/src/__tests__/tiers.test.ts
+++ b/packages/api/src/__tests__/tiers.test.ts
@@ -16,9 +16,9 @@ describe('GET /tiers', () => {
     const res = await app.request('/tiers');
     const body = (await res.json()) as Array<{ slug: string }>;
     const slugs = body.map((t) => t.slug);
-    expect(slugs).toContain('free');
-    expect(slugs).toContain('pro');
-    expect(slugs).toContain('enterprise');
+    expect(slugs).toContain('paper-plane');
+    expect(slugs).toContain('warbird');
+    expect(slugs).toContain('fighter-jet');
   });
 
   it('should NOT include removed tiers', async () => {
@@ -32,15 +32,15 @@ describe('GET /tiers', () => {
 
 describe('GET /tiers/:slug', () => {
   it('should return 200 with tier config for valid slug', async () => {
-    const res = await app.request('/tiers/free');
+    const res = await app.request('/tiers/paper-plane');
     expect(res.status).toBe(200);
     const body = (await res.json()) as { slug: string; name: string };
-    expect(body.slug).toBe('free');
-    expect(body.name).toBe('Free');
+    expect(body.slug).toBe('paper-plane');
+    expect(body.name).toBe('Paper Plane');
   });
 
   it('should return 200 for each valid tier slug', async () => {
-    for (const slug of ['free', 'pro', 'enterprise']) {
+    for (const slug of ['paper-plane', 'warbird', 'fighter-jet']) {
       const res = await app.request(`/tiers/${slug}`);
       expect(res.status).toBe(200);
     }
@@ -75,7 +75,7 @@ describe('checkTierFeature middleware', () => {
       feature: string;
     };
     expect(body.error).toBe('Feature not available on your tier');
-    expect(body.tier).toBe('free');
+    expect(body.tier).toBe('paper-plane');
     expect(body.feature).toBe('custom_headers');
   });
 

--- a/packages/api/src/middleware/tier.ts
+++ b/packages/api/src/middleware/tier.ts
@@ -4,7 +4,7 @@ import type { Context, MiddlewareHandler } from 'hono';
 /**
  * Hardcoded tier for now (auth/DB lookup comes in PROD-58/59)
  */
-const CURRENT_TIER_SLUG = 'free';
+const CURRENT_TIER_SLUG = 'paper-plane';
 
 /**
  * Get the current tier config for the request.

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -82,7 +82,7 @@ auth.post('/signup', async (c) => {
     passwordHash,
     name: workspaceName ?? `${email.split('@')[0]}'s Workspace`,
     slug,
-    tierSlug: 'free',
+    tierSlug: 'paper-plane',
     createdAt: now,
     updatedAt: now,
   });
@@ -101,7 +101,7 @@ auth.post('/signup', async (c) => {
     createdAt: now,
   });
 
-  const tier = getTierBySlug('free');
+  const tier = getTierBySlug('paper-plane');
 
   return c.json(
     {

--- a/packages/shared/src/__tests__/endpoints.test.ts
+++ b/packages/shared/src/__tests__/endpoints.test.ts
@@ -59,7 +59,7 @@ describe('endpointCreateSchema', () => {
   it('should accept optional metadata', () => {
     const result = endpointCreateSchema.safeParse({
       url: 'https://example.com/webhook',
-      metadata: { tier: 'pro', region: 'us-east-1' },
+      metadata: { tier: 'warbird', region: 'us-east-1' },
     });
     expect(result.success).toBe(true);
   });

--- a/packages/shared/src/__tests__/tiers.test.ts
+++ b/packages/shared/src/__tests__/tiers.test.ts
@@ -15,57 +15,58 @@ describe('DEFAULT_TIERS', () => {
 
   it('should contain all required tier slugs', () => {
     const slugs = DEFAULT_TIERS.map((t) => t.slug);
-    expect(slugs).toContain('free');
-    expect(slugs).toContain('pro');
-    expect(slugs).toContain('enterprise');
+    expect(slugs).toContain('paper-plane');
+    expect(slugs).toContain('warbird');
+    expect(slugs).toContain('fighter-jet');
   });
 
   it('should NOT contain removed tiers', () => {
     const slugs = DEFAULT_TIERS.map((t) => t.slug);
-    expect(slugs).not.toContain('paper-plane');
-    expect(slugs).not.toContain('warbird');
+    expect(slugs).not.toContain('free');
+    expect(slugs).not.toContain('pro');
+    expect(slugs).not.toContain('enterprise');
     expect(slugs).not.toContain('stealth-jet');
     expect(slugs).not.toContain('biplane');
     expect(slugs).not.toContain('jet');
   });
 
-  it('should have free at $0/mo', () => {
-    const tier = getTierBySlug('free');
+  it('should have Paper Plane at $0/mo', () => {
+    const tier = getTierBySlug('paper-plane');
     expect(tier?.price_monthly_usd).toBe(0);
   });
 
-  it('should have pro at $19/mo', () => {
-    const tier = getTierBySlug('pro');
+  it('should have Warbird at $19/mo', () => {
+    const tier = getTierBySlug('warbird');
     expect(tier?.price_monthly_usd).toBe(19);
   });
 
-  it('should have enterprise at $0/mo (custom pricing)', () => {
-    const tier = getTierBySlug('enterprise');
-    expect(tier?.price_monthly_usd).toBe(0);
+  it('should have Fighter Jet at $89/mo', () => {
+    const tier = getTierBySlug('fighter-jet');
+    expect(tier?.price_monthly_usd).toBe(89);
   });
 
-  it('should have free with 25K events/mo', () => {
-    const tier = getTierBySlug('free');
+  it('should have Paper Plane with 25K events/mo', () => {
+    const tier = getTierBySlug('paper-plane');
     expect(tier?.limits.max_events_per_month).toBe(25_000);
   });
 
-  it('should have pro with 100K events/mo', () => {
-    const tier = getTierBySlug('pro');
+  it('should have Warbird with 100K events/mo', () => {
+    const tier = getTierBySlug('warbird');
     expect(tier?.limits.max_events_per_month).toBe(100_000);
   });
 
-  it('should have free with 7-day retention', () => {
-    const tier = getTierBySlug('free');
+  it('should have Paper Plane with 7-day retention', () => {
+    const tier = getTierBySlug('paper-plane');
     expect(tier?.limits.retention_days).toBe(7);
   });
 
-  it('should have pro with 30-day retention', () => {
-    const tier = getTierBySlug('pro');
+  it('should have Warbird with 30-day retention', () => {
+    const tier = getTierBySlug('warbird');
     expect(tier?.limits.retention_days).toBe(30);
   });
 
-  it('should have enterprise with 90-day retention', () => {
-    const tier = getTierBySlug('enterprise');
+  it('should have Fighter Jet with 90-day retention', () => {
+    const tier = getTierBySlug('fighter-jet');
     expect(tier?.limits.retention_days).toBe(90);
   });
 
@@ -83,27 +84,28 @@ describe('DEFAULT_TIERS', () => {
 });
 
 describe('getTierBySlug', () => {
-  it('should return free tier by slug', () => {
-    const tier = getTierBySlug('free');
+  it('should return Paper Plane tier by slug', () => {
+    const tier = getTierBySlug('paper-plane');
     expect(tier).toBeDefined();
-    expect(tier?.name).toBe('Free');
+    expect(tier?.name).toBe('Paper Plane');
   });
 
-  it('should return pro tier by slug', () => {
-    const tier = getTierBySlug('pro');
+  it('should return Warbird tier by slug', () => {
+    const tier = getTierBySlug('warbird');
     expect(tier).toBeDefined();
-    expect(tier?.name).toBe('Pro');
+    expect(tier?.name).toBe('Warbird');
   });
 
-  it('should return enterprise tier by slug', () => {
-    const tier = getTierBySlug('enterprise');
+  it('should return Fighter Jet tier by slug', () => {
+    const tier = getTierBySlug('fighter-jet');
     expect(tier).toBeDefined();
-    expect(tier?.name).toBe('Enterprise');
+    expect(tier?.name).toBe('Fighter Jet');
   });
 
   it('should return undefined for removed tiers', () => {
-    expect(getTierBySlug('paper-plane')).toBeUndefined();
-    expect(getTierBySlug('warbird')).toBeUndefined();
+    expect(getTierBySlug('free')).toBeUndefined();
+    expect(getTierBySlug('pro')).toBeUndefined();
+    expect(getTierBySlug('enterprise')).toBeUndefined();
     expect(getTierBySlug('stealth-jet')).toBeUndefined();
     expect(getTierBySlug('biplane')).toBeUndefined();
     expect(getTierBySlug('jet')).toBeUndefined();
@@ -116,22 +118,22 @@ describe('getTierBySlug', () => {
 });
 
 describe('isFeatureEnabled', () => {
-  it('should return true for core features on free', () => {
-    const tier = getTierBySlug('free')!;
+  it('should return true for core features on Paper Plane', () => {
+    const tier = getTierBySlug('paper-plane')!;
     expect(isFeatureEnabled(tier, 'transformations')).toBe(true);
     expect(isFeatureEnabled(tier, 'webhook_signing')).toBe(true);
     expect(isFeatureEnabled(tier, 'analytics')).toBe(true);
   });
 
-  it('should return false for premium features on free', () => {
-    const tier = getTierBySlug('free')!;
+  it('should return false for premium features on Paper Plane', () => {
+    const tier = getTierBySlug('paper-plane')!;
     expect(isFeatureEnabled(tier, 'custom_headers')).toBe(false);
     expect(isFeatureEnabled(tier, 'ip_whitelist')).toBe(false);
     expect(isFeatureEnabled(tier, 'dead_letter_queue')).toBe(false);
   });
 
-  it('should return true for all features on enterprise', () => {
-    const tier = getTierBySlug('enterprise')!;
+  it('should return true for all features on Fighter Jet', () => {
+    const tier = getTierBySlug('fighter-jet')!;
     expect(isFeatureEnabled(tier, 'custom_headers')).toBe(true);
     expect(isFeatureEnabled(tier, 'ip_whitelist')).toBe(true);
     expect(isFeatureEnabled(tier, 'transformations')).toBe(true);
@@ -144,38 +146,38 @@ describe('isFeatureEnabled', () => {
 
 describe('isWithinLimit', () => {
   it('should return true when within limits', () => {
-    const tier = getTierBySlug('free')!;
+    const tier = getTierBySlug('paper-plane')!;
     expect(isWithinLimit(tier, 'max_events_per_month', 25_000)).toBe(true);
     expect(isWithinLimit(tier, 'max_events_per_month', 1)).toBe(true);
   });
 
   it('should return false when exceeding limits', () => {
-    const tier = getTierBySlug('free')!;
+    const tier = getTierBySlug('paper-plane')!;
     expect(isWithinLimit(tier, 'max_events_per_month', 25_001)).toBe(false);
   });
 
-  it('should return true for high limits on enterprise', () => {
-    const tier = getTierBySlug('enterprise')!;
+  it('should return true for high limits on Fighter Jet', () => {
+    const tier = getTierBySlug('fighter-jet')!;
     expect(isWithinLimit(tier, 'max_events_per_month', 1_000_000)).toBe(true);
   });
 });
 
 describe('getUpgradePath', () => {
-  it('should return 2 upgrade options for free', () => {
-    const upgrades = getUpgradePath('free');
+  it('should return 2 upgrade options for Paper Plane', () => {
+    const upgrades = getUpgradePath('paper-plane');
     expect(upgrades).toHaveLength(2);
-    expect(upgrades[0]?.slug).toBe('pro');
-    expect(upgrades[1]?.slug).toBe('enterprise');
+    expect(upgrades[0]?.slug).toBe('warbird');
+    expect(upgrades[1]?.slug).toBe('fighter-jet');
   });
 
-  it('should return 1 upgrade for pro (enterprise)', () => {
-    const upgrades = getUpgradePath('pro');
+  it('should return 1 upgrade for Warbird (Fighter Jet)', () => {
+    const upgrades = getUpgradePath('warbird');
     expect(upgrades).toHaveLength(1);
-    expect(upgrades[0]?.slug).toBe('enterprise');
+    expect(upgrades[0]?.slug).toBe('fighter-jet');
   });
 
-  it('should return empty for enterprise', () => {
-    expect(getUpgradePath('enterprise')).toHaveLength(0);
+  it('should return empty for Fighter Jet', () => {
+    expect(getUpgradePath('fighter-jet')).toHaveLength(0);
   });
 
   it('should return empty array for unknown slug', () => {
@@ -216,7 +218,7 @@ describe('TierConfigSchema validation', () => {
   });
 
   it('should reject negative price', () => {
-    const tier = getTierBySlug('free')!;
+    const tier = getTierBySlug('paper-plane')!;
     expect(() => TierConfigSchema.parse({ ...tier, price_monthly_usd: -1 })).toThrow();
   });
 });

--- a/packages/shared/src/config/tiers.ts
+++ b/packages/shared/src/config/tiers.ts
@@ -34,8 +34,8 @@ export type TierFeatures = z.infer<typeof TierFeaturesSchema>;
 
 export const DEFAULT_TIERS: TierConfig[] = [
   {
-    slug: 'free',
-    name: 'Free',
+    slug: 'paper-plane',
+    name: 'Paper Plane',
     price_monthly_usd: 0,
     limits: {
       max_destinations: 999, // unlimited endpoints
@@ -57,8 +57,8 @@ export const DEFAULT_TIERS: TierConfig[] = [
     },
   },
   {
-    slug: 'pro',
-    name: 'Pro',
+    slug: 'warbird',
+    name: 'Warbird',
     price_monthly_usd: 19,
     limits: {
       max_destinations: 999, // unlimited endpoints
@@ -80,9 +80,9 @@ export const DEFAULT_TIERS: TierConfig[] = [
     },
   },
   {
-    slug: 'enterprise',
-    name: 'Enterprise',
-    price_monthly_usd: 0, // custom pricing
+    slug: 'fighter-jet',
+    name: 'Fighter Jet',
+    price_monthly_usd: 89,
     limits: {
       max_destinations: 999,
       max_events_per_month: 10_000_000,

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -10,7 +10,7 @@ export const workspaces = sqliteTable('workspaces', {
   passwordHash: text('password_hash').notNull(),
   name: text('name').notNull(),
   slug: text('slug').notNull().unique(),
-  tierSlug: text('tier_slug').notNull().default('free'),
+  tierSlug: text('tier_slug').notNull().default('paper-plane'),
   stripeCustomerId: text('stripe_customer_id'),
   stripeSubscriptionId: text('stripe_subscription_id'),
   isPlayground: integer('is_playground').notNull().default(0), // 1 for temporary playground sessions

--- a/website/api/pricing/index.json
+++ b/website/api/pricing/index.json
@@ -1,8 +1,8 @@
 {
   "tiers": [
     {
-      "slug": "free",
-      "name": "Free",
+      "slug": "paper-plane",
+      "name": "Paper Plane",
       "price_monthly_usd": 0,
       "events_per_month": 25000,
       "retention_days": 7,
@@ -26,11 +26,11 @@
       }
     },
     {
-      "slug": "pro",
-      "name": "Pro",
+      "slug": "warbird",
+      "name": "Warbird",
       "price_monthly_usd": 19,
       "events_per_month": 100000,
-      "overage_per_100k": 0.5,
+      "overage_per_100k": 0.50,
       "retention_days": 30,
       "users": "Unlimited",
       "rate_limit_per_second": 25,
@@ -54,13 +54,13 @@
       }
     },
     {
-      "slug": "enterprise",
-      "name": "Enterprise",
-      "price_monthly_usd": null,
-      "events_per_month": "Custom",
+      "slug": "fighter-jet",
+      "name": "Fighter Jet",
+      "price_monthly_usd": 89,
+      "events_per_month": 10000000,
       "retention_days": 90,
       "users": "Unlimited",
-      "rate_limit_per_second": "Custom",
+      "rate_limit_per_second": 200,
       "endpoints": "Unlimited",
       "features": {
         "api_access": true,

--- a/website/app/index.html
+++ b/website/app/index.html
@@ -121,7 +121,7 @@
         <div class="topbar-right">
 <div class="workspace-info">
             <span class="workspace-name" id="workspace-name">Loading...</span>
-            <span class="tier-badge" id="tier-badge">Free</span>
+            <span class="tier-badge" id="tier-badge">Paper Plane</span>
           </div>
           <button class="btn btn-ghost signout-btn" id="signout-btn">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -381,9 +381,9 @@ curl "https://api.hookwing.com/v1/events?limit=10" \
         <table class="param-table">
           <thead><tr><th>Tier</th><th>RPS Limit</th><th>Events/month</th></tr></thead>
           <tbody>
-            <tr><td>Free</td><td>10</td><td>25,000</td></tr>
-            <tr><td>Pro ($19/mo)</td><td>25</td><td>100,000</td></tr>
-            <tr><td>Enterprise (custom)</td><td>200</td><td>Custom</td></tr>
+            <tr><td>Paper Plane (free)</td><td>10</td><td>25,000</td></tr>
+            <tr><td>Warbird ($19/mo)</td><td>25</td><td>100,000</td></tr>
+            <tr><td>Fighter Jet ($89/mo)</td><td>200</td><td>10,000,000</td></tr>
           </tbody>
         </table>
 

--- a/website/index.html
+++ b/website/index.html
@@ -41,22 +41,22 @@
     "offers": [
       {
         "@type": "Offer",
-        "name": "Free",
+        "name": "Paper Plane",
         "price": "0",
         "priceCurrency": "USD",
         "description": "25,000 events/month, free forever"
       },
       {
         "@type": "Offer",
-        "name": "Pro",
+        "name": "Warbird",
         "price": "19",
         "priceCurrency": "USD",
         "description": "100,000 events/month"
       },
       {
         "@type": "Offer",
-        "name": "Enterprise",
-        "price": "0",
+        "name": "Fighter Jet",
+        "price": "89",
         "priceCurrency": "USD",
         "description": "Custom pricing, SSO, dedicated support"
       }
@@ -511,10 +511,10 @@
 
         <div class="pricing-grid">
 
-          <!-- Tier 1: Free -->
-          <div class="pricing-card" aria-labelledby="tier-free">
+          <!-- Tier 1: Paper Plane -->
+          <div class="pricing-card" aria-labelledby="tier-paper-plane">
 
-            <p class="pricing-tier-name">Free</p>
+            <p class="pricing-tier-name">Paper Plane</p>
 
             <div class="pricing-price">
               <span class="currency">$</span>0
@@ -530,7 +530,7 @@
               No credit card required
             </div>
 
-            <ul class="pricing-features" aria-label="Free plan features">
+            <ul class="pricing-features" aria-label="Paper Plane features">
               <li>
                 <svg class="pricing-check" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
                 25,000 events / month
@@ -552,11 +552,11 @@
             <a href="/signup/" class="btn btn-secondary btn-md pricing-cta">Start for free</a>
           </div>
 
-          <!-- Tier 2: Pro -->
-          <div class="pricing-card featured" aria-labelledby="tier-pro">
+          <!-- Tier 2: Warbird -->
+          <div class="pricing-card featured" aria-labelledby="tier-warbird">
             <div class="featured-badge" aria-label="Most popular plan">Most popular</div>
 
-            <p class="pricing-tier-name">Pro</p>
+            <p class="pricing-tier-name">Warbird</p>
 
             <div class="pricing-price">
               <span class="currency">$</span>19<span class="period">/mo</span>
@@ -564,7 +564,7 @@
 
             <p class="pricing-desc">For teams and agent fleets in production. More events, longer retention, priority support.</p>
 
-            <ul class="pricing-features" aria-label="Pro plan features">
+            <ul class="pricing-features" aria-label="Warbird features">
               <li>
                 <svg class="pricing-check" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
                 100,000 events / month
@@ -586,29 +586,29 @@
             <a href="/signup/" class="btn btn-primary btn-md pricing-cta">Get started</a>
           </div>
 
-          <!-- Tier 3: Enterprise -->
-          <div class="pricing-card" aria-labelledby="tier-enterprise">
+          <!-- Tier 3: Fighter Jet -->
+          <div class="pricing-card" aria-labelledby="tier-fighter-jet">
 
-            <p class="pricing-tier-name">Enterprise</p>
+            <p class="pricing-tier-name">Fighter Jet</p>
 
             <div class="pricing-price">
-              <span class="pricing-custom">Custom</span>
+              <span class="currency">$</span>89<span class="period">/mo</span>
             </div>
 
-            <p class="pricing-desc">For high-volume workloads and compliance requirements. SSO, static IPs, dedicated support.</p>
+            <p class="pricing-desc">Production-grade delivery for high-volume workloads. SSO, static IPs, dedicated support.</p>
 
-            <ul class="pricing-features" aria-label="Enterprise plan features">
+            <ul class="pricing-features" aria-label="Fighter Jet features">
+              <li>
+                <svg class="pricing-check" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                10,000,000 events / month
+              </li>
               <li>
                 <svg class="pricing-check" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
                 90-day event retention
               </li>
               <li>
                 <svg class="pricing-check" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                SSO / SAML
-              </li>
-              <li>
-                <svg class="pricing-check" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                Static IPs
+                SSO / SAML + static IPs
               </li>
               <li>
                 <svg class="pricing-check" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
@@ -616,7 +616,7 @@
               </li>
             </ul>
 
-            <a href="mailto:hello@hookwing.com" class="btn btn-secondary btn-md pricing-cta">Contact us</a>
+            <a href="/signup/" class="btn btn-secondary btn-md pricing-cta">Get started</a>
           </div>
 
         </div>

--- a/website/pricing/index.html
+++ b/website/pricing/index.html
@@ -101,15 +101,15 @@
           "name": "What payment methods do you accept?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "All major credit and debit cards (Visa, Mastercard, Amex). Bank transfers available on annual Enterprise plans. Agents can trigger upgrades via API using a stored payment method."
+            "text": "All major credit and debit cards (Visa, Mastercard, Amex). Bank transfers available on annual Fighter Jet plans. Agents can trigger upgrades via API using a stored payment method."
           }
         }
       ]
     },
     "offers": [
-      {"@type": "Offer", "name": "Free", "price": "0", "priceCurrency": "USD", "description": "25,000 events/month, no credit card required"},
-      {"@type": "Offer", "name": "Pro", "price": "19", "priceCurrency": "USD", "description": "100,000 events/month"},
-      {"@type": "Offer", "name": "Enterprise", "price": "99", "priceCurrency": "USD", "description": "1,000,000 events/month"}
+      {"@type": "Offer", "name": "Paper Plane", "price": "0", "priceCurrency": "USD", "description": "25,000 events/month, no credit card required"},
+      {"@type": "Offer", "name": "Warbird", "price": "19", "priceCurrency": "USD", "description": "100,000 events/month"},
+      {"@type": "Offer", "name": "Fighter Jet", "price": "89", "priceCurrency": "USD", "description": "10,000,000 events/month"}
     ]
   }
   </script>
@@ -296,7 +296,7 @@
         <div class="pricing-grid">
 
           <!-- ─── Tier 1: Free ─────────────────────────── -->
-          <div class="pricing-card has-top-badge" aria-labelledby="tier-free">
+          <div class="pricing-card has-top-badge" aria-labelledby="tier-paper-plane">
 
             <!-- "No credit card" badge above card -->
             <div class="pricing-free-note-badge" aria-label="No credit card required">
@@ -312,11 +312,11 @@
               <img src="/assets/illustrations/tiers/tier-free.webp" width="72" alt="" />
             </div>
 
-            <p class="pricing-tier-name" aria-label="Tier: Free">Free</p>
+            <p class="pricing-tier-name" aria-label="Tier: Paper Plane">Paper Plane</p>
 
             <div class="pricing-price-row">
               <span class="pricing-currency" aria-hidden="true">$</span>
-              <span class="pricing-amount" id="price-paper-monthly" aria-label="$0 per month">0</span>
+              <span class="pricing-amount" id="price-paper-plane-monthly" aria-label="$0 per month">0</span>
               <span class="pricing-period">/mo</span>
             </div>
 
@@ -324,7 +324,7 @@
 
             <p class="pricing-desc">Everything you need to build and run something real. No tricks, no timers, no 2FA blocking your agents.</p>
 
-            <ul class="pricing-features-list" aria-label="Free plan features">
+            <ul class="pricing-features-list" aria-label="Paper Plane plan features">
               <li>
                 <svg class="check-icon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
                 25,000 events / month
@@ -357,7 +357,7 @@
           </div>
 
           <!-- ─── Tier 2: Pro ─────────────────────────────── -->
-          <div class="pricing-card featured" aria-labelledby="tier-pro">
+          <div class="pricing-card featured" aria-labelledby="tier-warbird">
             <div class="featured-badge" aria-label="Most popular plan">Most popular</div>
 
             <!-- Icon: Pro - double wing geometric SVG -->
@@ -365,11 +365,11 @@
               <img src="/assets/illustrations/tiers/tier-pro.webp" width="72" alt="" />
             </div>
 
-            <p class="pricing-tier-name" aria-label="Tier: Pro">Pro</p>
+            <p class="pricing-tier-name" aria-label="Tier: Warbird">Warbird</p>
 
             <div class="pricing-price-row">
               <span class="pricing-currency" aria-hidden="true">$</span>
-              <span class="pricing-amount" id="price-pro" data-monthly="19" data-annual="15" aria-label="$19 per month">19</span>
+              <span class="pricing-amount" id="price-warbird" data-monthly="19" data-annual="15" aria-label="$19 per month">19</span>
               <span class="pricing-period">/mo</span>
             </div>
 
@@ -377,7 +377,7 @@
 
             <p class="pricing-desc">For projects gaining altitude — whether you're a team or an agent fleet. More headroom, priority retries, email support.</p>
 
-            <ul class="pricing-features-list" aria-label="Pro plan features">
+            <ul class="pricing-features-list" aria-label="Warbird plan features">
               <li>
                 <svg class="check-icon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
                 250,000 events / month
@@ -410,29 +410,29 @@
           </div>
 
           <!-- ─── Tier 3: Pro (Most popular) ─────────────── -->
-          <div class="pricing-card" aria-labelledby="tier-enterprise">
+          <div class="pricing-card" aria-labelledby="tier-fighter-jet">
 
-            <!-- Icon: Enterprise - swept-wing fighter silhouette -->
+            <!-- Icon: Fighter Jet - swept-wing fighter silhouette -->
             <div class="pricing-icon-wrap" style="background:transparent;" aria-hidden="true">
               <img src="/assets/illustrations/tiers/tier-enterprise.webp" width="72" alt="" />
             </div>
 
-            <p class="pricing-tier-name" aria-label="Tier: Enterprise">Enterprise</p>
+            <p class="pricing-tier-name" aria-label="Tier: Fighter Jet">Fighter Jet</p>
 
             <div class="pricing-price-row">
               <span class="pricing-currency" aria-hidden="true">$</span>
-              <span class="pricing-amount" id="price-enterprise" data-monthly="0" data-annual="0" aria-label="Custom pricing">99</span>
+              <span class="pricing-amount" id="price-fighter-jet" data-monthly="89" data-annual="71" aria-label="$89 per month">89</span>
               <span class="pricing-period">/mo</span>
             </div>
 
             <p class="pricing-annual-note" id="annual-note-enterprise" aria-live="polite">&nbsp;</p>
 
-            <p class="pricing-desc">Production-grade delivery for high-volume workloads and autonomous pipelines. Custom retry policies, SLA, and agent-managed infrastructure.</p>
+            <p class="pricing-desc">Production-grade delivery for high-volume workloads and autonomous pipelines. IP whitelisting, SSO/SAML, static IPs, and dedicated support.</p>
 
-            <ul class="pricing-features-list" aria-label="Enterprise plan features">
+            <ul class="pricing-features-list" aria-label="Fighter Jet plan features">
               <li>
                 <svg class="check-icon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                1,000,000 events / month
+                10,000,000 events / month
               </li>
               <li>
                 <svg class="check-icon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
@@ -461,7 +461,7 @@
             </a>
           </div>
 
-          <!-- Jet tier removed — 3-tier structure: Free, Pro, Enterprise -->
+          <!-- Jet tier removed — 3-tier structure: Paper Plane, Warbird, Fighter Jet -->
 
         </div>
 
@@ -501,16 +501,16 @@
               <tr>
                 <th scope="col" aria-label="Feature">Feature</th>
                 <th scope="col">
-                  <span class="th-tier-name">Free</span>
-                  <span class="th-tier-price">Free</span>
+                  <span class="th-tier-name">Paper Plane</span>
+                  <span class="th-tier-price">$0/mo</span>
                 </th>
                 <th scope="col">
-                  <span class="th-tier-name">Pro</span>
-                  <span class="th-tier-price">$9/mo</span>
+                  <span class="th-tier-name">Warbird</span>
+                  <span class="th-tier-price">$19/mo</span>
                 </th>
                 <th scope="col" class="col-featured">
-                  <span class="th-tier-name">Enterprise</span>
-                  <span class="th-tier-price">$99/mo</span>
+                  <span class="th-tier-name">Fighter Jet</span>
+                  <span class="th-tier-price">$89/mo</span>
                 </th>
               </tr>
             </thead>
@@ -563,9 +563,9 @@
 
               <tr>
                 <td scope="row">Events / month</td>
-                <td><span class="tbl-value">10,000</span></td>
+                <td><span class="tbl-value">25,000</span></td>
                 <td><span class="tbl-value">100,000</span></td>
-                <td class="col-featured"><span class="tbl-value">1,000,000</span></td>
+                <td class="col-featured"><span class="tbl-value">10,000,000</span></td>
               </tr>
 
               <tr>
@@ -577,7 +577,7 @@
 
               <tr>
                 <td scope="row">Endpoints</td>
-                <td><span class="tbl-value">5</span></td>
+                <td><span class="tbl-value highlight">Unlimited</span></td>
                 <td><span class="tbl-value highlight">Unlimited</span></td>
                 <td class="col-featured"><span class="tbl-value highlight">Unlimited</span></td>
               </tr>
@@ -735,7 +735,7 @@
                 </td>
               </tr>
 
-              <!-- GROUP: Enterprise -->
+              <!-- GROUP: Fighter Jet -->
               <tr class="row-group-header" role="row">
                 <td colspan="4">Reliability &amp; compliance</td>
               </tr>
@@ -832,7 +832,7 @@
             </button>
             <div class="faq-answer" id="faq-answer-3" role="region" aria-labelledby="faq-q3" hidden>
               <div class="faq-answer-inner">
-                No. Monthly plans are month-to-month - cancel anytime, no questions asked. Annual plans lock in a lower rate for 12 months and save you 2 months of cost. Enterprise plans include negotiated terms; reach out to discuss.
+                No. Monthly plans are month-to-month - cancel anytime, no questions asked. Annual plans lock in a lower rate for 12 months and save you 2 months of cost. Fighter Jet plans include negotiated terms; reach out to discuss.
               </div>
             </div>
           </div>
@@ -909,7 +909,7 @@
             </button>
             <div class="faq-answer" id="faq-answer-8" role="region" aria-labelledby="faq-q8" hidden>
               <div class="faq-answer-inner">
-                All major credit and debit cards - Visa, Mastercard, American Express. Bank transfers (ACH/SEPA) are available on annual Enterprise plans. Agents can trigger plan upgrades via API using a stored payment method. No check payments.
+                All major credit and debit cards - Visa, Mastercard, American Express. Bank transfers (ACH/SEPA) are available on annual Fighter Jet plans. Agents can trigger plan upgrades via API using a stored payment method. No check payments.
               </div>
             </div>
           </div>
@@ -984,7 +984,7 @@
         <!-- Product column -->
         <div>
           <p class="footer-col-heading">Product</p>
-          <ul class="footer-links" role="list" aria-label="Product navigation">
+          <ul class="footer-links" role="list" aria-label="Warbirdduct navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>

--- a/website/why-hookwing/index.html
+++ b/website/why-hookwing/index.html
@@ -10,7 +10,7 @@
   <title>Why Hookwing - Built agent-first</title>
   <meta name="description" content="The only webhook platform designed from day one to work without a human in the loop. Reliable enough for production. Simple enough for a three-line setup." />
   <meta property="og:title" content="Why Hookwing - Built for the age of AI" />
-  <meta property="og:description" content="99.9% delivery rate. Simple API. No hidden fees. Built for developers and AI agents." />
+  <meta property="og:description" content="6 automatic retries. Simple API. No hidden fees. Built for developers and AI agents." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://hookwing.com/why-hookwing/" />
   <meta property="og:image" content="https://hookwing.com/assets/og/default.png" />
@@ -990,19 +990,19 @@
                 </tr>
                 <tr>
                   <td>Entry paid tier</td>
-                  <td class="col-hookwing"><span class="compare-price-highlight">$29/mo</span></td>
+                  <td class="col-hookwing"><span class="compare-price-highlight">$19/mo</span></td>
                   <td><span style="color:rgba(255,80,80,.7);font-weight:600;">$490/mo</span></td>
                   <td><span style="color:rgba(255,193,7,.9);font-weight:600;">$39/mo</span></td>
                 </tr>
                 <tr>
                   <td>Growth / mid tier</td>
-                  <td class="col-hookwing"><span class="compare-price-highlight">$99/mo</span></td>
+                  <td class="col-hookwing"><span class="compare-price-highlight">$89/mo</span></td>
                   <td><span class="compare-price-muted">No mid tier</span></td>
                   <td><span style="color:rgba(255,80,80,.7);font-weight:600;">$499/mo</span></td>
                 </tr>
                 <tr>
                   <td>Free tier events/month</td>
-                  <td class="col-hookwing"><span class="compare-price-highlight">10,000</span></td>
+                  <td class="col-hookwing"><span class="compare-price-highlight">25,000</span></td>
                   <td style="color:rgba(255,255,255,.6);">10,000</td>
                   <td style="color:rgba(255,255,255,.6);">10,000</td>
                 </tr>
@@ -1125,7 +1125,7 @@
                 </tr>
                 <tr>
                   <td>Uptime SLA (paid)</td>
-                  <td class="col-hookwing"><span class="compare-price-highlight">99.9%</span></td>
+                  <td class="col-hookwing"><span class="compare-price-highlight">Coming soon</span></td>
                   <td style="color:rgba(255,255,255,.6);">99.9% (Free), 99.99% (Pro)</td>
                   <td style="color:rgba(255,255,255,.6);">99.999% (Growth+)</td>
                 </tr>
@@ -1150,7 +1150,7 @@
                 <tr>
                   <td>Audit logs</td>
                   <td class="col-hookwing"><span class="compare-check">✓ All plans</span></td>
-                  <td><span class="compare-partial">Enterprise</span></td>
+                  <td><span class="compare-partial">Custom only</span></td>
                   <td><span class="compare-partial">Growth+</span></td>
                 </tr>
                 <tr>
@@ -1176,10 +1176,10 @@
           </div>
 
           <div class="compare-pricing-card hookwing-card">
-            <div class="compare-pricing-name">Hookwing Warbird</div>
-            <div class="compare-pricing-price">$99<span style="font-size:18px;font-weight:400;color:rgba(255,255,255,.5);">/mo</span></div>
-            <div class="compare-pricing-desc">2M events/mo · 90-day retention · Agent-ready</div>
-            <div class="compare-pricing-events">3× more events. MCP + Skills included.</div>
+            <div class="compare-pricing-name">Hookwing Fighter Jet</div>
+            <div class="compare-pricing-price">$89<span style="font-size:18px;font-weight:400;color:rgba(255,255,255,.5);">/mo</span></div>
+            <div class="compare-pricing-desc">10M events/mo · 90-day retention · SSO · Static IPs</div>
+            <div class="compare-pricing-events">Full platform. MCP + Skills included.</div>
             <span class="compare-pricing-savings">80% cheaper than Svix Pro</span>
           </div>
 


### PR DESCRIPTION
Fabien correction — revert from Free/Pro/Enterprise to named tiers. Fighter Jet is fixed $89/mo, NOT custom.

| Tier | Slug | Price | Events |
|------|------|-------|--------|
| 🟢 Paper Plane | paper-plane | $0 | 25K/mo |
| 🔵 Warbird | warbird | $19 | 100K/mo |
| 🟣 Fighter Jet | fighter-jet | $89 | 10M/mo |

16 files, 15/15 turbo green.