### PR TITLE
fix(PROD-125): 2FA/CAPTCHA copy reframe

### DIFF
--- a/website/blog/webhooks-vs-event-streams/index.html
+++ b/website/blog/webhooks-vs-event-streams/index.html
@@ -166,7 +166,7 @@
 <p>Agents are webhook-native. They have a URL, they receive HTTP requests, they respond. No consumer group coordination, no polling loop, no Kafka client library. Just a simple listener.</p>
 <p>An agent listening for webhooks needs:</p>
 <ul>
-<li><strong>No CAPTCHA, no 2FA.</strong> Authentication is API keys only.</li>
+<li><strong>No CAPTCHA or 2FA by default.</strong> Authentication is API keys, with optional 2FA when needed.</li>
 <li><strong>Reliable push delivery.</strong> The webhook platform (Hookwing) handles <a href="/blog/webhook-retry-best-practices/">retries</a>, so the agent doesn&#39;t miss events.</li>
 <li><strong>Fast setup.</strong> Agent provisions an endpoint via API, sends the URL to a partner, receives events.</li>
 </ul>

--- a/website/getting-started/index.html
+++ b/website/getting-started/index.html
@@ -292,7 +292,7 @@
 
           <!-- Path C: Agent API -->
           <article class="path-card path-agent" aria-labelledby="path-agent">
-            <div class="path-badge path-badge-blue" aria-label="For AI agents">Agent-native · No 2FA</div>
+            <div class="path-badge path-badge-blue" aria-label="For AI agents">Agent-native · API-key auth</div>
 
             <div class="path-icon path-icon-dark" aria-hidden="true">
               <svg width="28" height="28" viewBox="0 0 28 28" fill="none" aria-hidden="true" focusable="false">
@@ -316,7 +316,7 @@
                   <circle cx="9" cy="9" r="8.25" fill="rgba(255,255,255,0.08)" stroke="rgba(255,255,255,0.4)" stroke-width="1.2"/>
                   <path d="M6 9.5L8 11.5L12.5 7" stroke="rgba(255,255,255,0.75)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
                 </svg>
-                No 2FA. No browser. No CAPTCHA.
+                No 2FA or CAPTCHA by default. API-key auth.
               </li>
               <li class="path-feature">
                 <svg class="path-feature-icon" viewBox="0 0 18 18" fill="none" aria-hidden="true">

--- a/website/index.html
+++ b/website/index.html
@@ -249,7 +249,7 @@
 
           <div class="trust-stat">
             <span class="trust-stat-value">0</span>
-            <span class="trust-stat-label">CAPTCHAs</span>
+            <span class="trust-stat-label">CAPTCHAs by default</span>
           </div>
 
         </div>
@@ -280,7 +280,7 @@
             <img src="/assets/illustrations/features/feature-agent-native.svg" class="feature-icon" width="48" height="48" alt="" aria-hidden="true" />
 
             <h3 id="feat-agent">Agent-Ready</h3>
-            <p>Designed from day one for autonomous agents. No 2FA. No CAPTCHA. No browser. No human in the loop. API keys only. MCP native. Agents can provision themselves, manage endpoints, and upgrade plans, all via HTTP.</p>
+            <p>Designed from day one for autonomous agents. No 2FA or CAPTCHA by default. No browser. No human in the loop. API keys only. MCP native. Agents can provision themselves, manage endpoints, and upgrade plans, all via HTTP.</p>
 
             <div class="feature-detail">
               <div class="feature-detail-item">
@@ -645,7 +645,7 @@
           <h2 class="cta-title" id="cta-heading">Ready for takeoff?</h2>
 
           <p class="cta-sub">
-            Start free. No credit card. No 2FA. No CAPTCHA.
+            Start free. No credit card. API-key auth by default.
             Whether you're a developer or an agent, you're in the air in seconds.
           </p>
 

--- a/website/pricing/index.html
+++ b/website/pricing/index.html
@@ -8,7 +8,7 @@
   <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <title>Pricing - Hookwing</title>
-  <meta name="description" content="Simple pricing. No surprises. No 2FA. From paper planes to jets, for developers and agents alike. Start free. Scale programmatically." />
+  <meta name="description" content="Simple pricing. No surprises. API-key auth by default. From paper planes to jets, for developers and agents alike. Start free. Scale programmatically." />
   <meta property="og:title" content="Pricing - Hookwing" />
   <meta property="og:description" content="Simple pricing. No surprises. From paper planes to jets." />
   <meta property="og:type" content="website" />
@@ -85,7 +85,7 @@
           "name": "Can agents sign up and pay via API?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "Yes. Hookwing is designed for this. No 2FA, no CAPTCHA. Agents can create accounts, provision endpoints, and manage billing entirely via API. Machine-readable pricing is available at /api/pricing."
+            "text": "Yes. Hookwing is designed for this. No 2FA or CAPTCHA by default. Agents can create accounts, provision endpoints, and manage billing entirely via API. Machine-readable pricing is available at /api/pricing."
           }
         },
         {
@@ -245,7 +245,7 @@
         </div>
 
         <h1 class="pricing-hero-title" id="pricing-hero-heading">
-          Simple pricing. No surprises. No 2FA.
+          Simple pricing. No surprises. API-key auth by default.
         </h1>
 
         <p class="pricing-hero-sub">
@@ -322,7 +322,7 @@
 
             <p class="pricing-annual-note" id="annual-note-paper" aria-live="polite">&nbsp;</p>
 
-            <p class="pricing-desc">Everything you need to build and run something real. No tricks, no timers, no 2FA blocking your agents.</p>
+            <p class="pricing-desc">Everything you need to build and run something real. No tricks, no timers. API-key auth by default.</p>
 
             <ul class="pricing-features-list" aria-label="Paper Plane plan features">
               <li>
@@ -522,7 +522,7 @@
               </tr>
 
               <tr>
-                <td scope="row">No 2FA / API-key auth only</td>
+                <td scope="row">API-key auth by default</td>
                 <td><span class="tbl-check">✓</span></td>
                 <td><span class="tbl-check">✓</span></td>
                 <td class="col-featured"><span class="tbl-check">✓</span></td>
@@ -877,7 +877,7 @@
             </button>
             <div class="faq-answer" id="faq-answer-6" role="region" aria-labelledby="faq-q6" hidden>
               <div class="faq-answer-inner">
-                Yes, this is a first-class use case, not a workaround. Hookwing was designed for agents to operate without any human in the loop. No 2FA. No CAPTCHA. No browser flows.
+                Yes, this is a first-class use case, not a workaround. Hookwing was designed for agents to operate without any human in the loop. No 2FA or CAPTCHA by default. API-key auth. No browser flows.
                 Agents can create accounts, provision endpoints, send events, inspect delivery, and upgrade plans, entirely via HTTP.
                 Machine-readable pricing at <a href="/api/pricing"><code>/api/pricing</code></a> so agents can evaluate tiers before committing.
               </div>

--- a/website/use-cases/index.html
+++ b/website/use-cases/index.html
@@ -348,7 +348,7 @@
               <tr>
                 <td scope="row">Agent access</td>
                 <td>Varies, no standard</td>
-                <td class="col-hookwing"><span class="tbl-value highlight">REST API, no 2FA, pull or push</span></td>
+                <td class="col-hookwing"><span class="tbl-value highlight">REST API, API-key auth, pull or push</span></td>
               </tr>
               <tr>
                 <td scope="row">Cloud account required</td>

--- a/website/why-hookwing/index.html
+++ b/website/why-hookwing/index.html
@@ -212,7 +212,7 @@
               Every other webhook platform was built for humans, then adapted for agents. Hookwing was designed for agents first. And it shows.
             </p>
             <p class="trust-body">
-              No 2FA. No CAPTCHA. No browser flows. Agents authenticate with long-lived, scoped API keys. They create endpoints, inspect events, upgrade plans, and decommission themselves, all over HTTP.
+              No 2FA or CAPTCHA by default. Agents authenticate with long-lived, scoped API keys. No browser. No human in the loop. They create endpoints, inspect events, upgrade plans, and decommission themselves, all over HTTP.
             </p>
             <p class="trust-body">
               Developers get the same clean API. Everyone wins.
@@ -225,7 +225,7 @@
                   <path d="M6.5 10.5L9 13L13.5 8" stroke="#E6A800" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
                 </svg>
                 <div class="trust-feature-text">
-                  <strong>No 2FA. No CAPTCHA. Ever.</strong> Agents authenticate with API keys. Long-lived, scoped, revocable. No browser. No human in the loop. This isn't a workaround. It's the design.
+                  <strong>No 2FA or CAPTCHA by default</strong> — add them when your use case needs them. Agents authenticate with API keys. Long-lived, scoped, revocable. No browser. No human in the loop.
                 </div>
               </div>
               <div class="trust-feature-item">
@@ -350,7 +350,7 @@
 
                 <!-- Agent badge -->
                 <rect x="144" y="258" width="112" height="26" rx="13" fill="#FFF3CC" fill-opacity="0.08" stroke="#FFC107" stroke-width="1.5" stroke-opacity="0.5"/>
-                <text x="200" y="275" text-anchor="middle" font-family="Inter, sans-serif" font-size="9.5" fill="rgba(255,193,7,.9)" font-weight="600">No 2FA required</text>
+                <text x="200" y="275" text-anchor="middle" font-family="Inter, sans-serif" font-size="9.5" fill="rgba(255,193,7,.9)" font-weight="600">API-key auth by default</text>
               </svg>
             </div>
           </div>
@@ -1089,7 +1089,7 @@
                   <td><span class="compare-partial">Dev-time only</span></td>
                 </tr>
                 <tr>
-                  <td>API-only auth (no 2FA)</td>
+                  <td>API-key auth by default</td>
                   <td class="col-hookwing"><span class="compare-check">✓ Designed for it</span></td>
                   <td><span class="compare-partial">Possible</span></td>
                   <td><span class="compare-partial">Possible</span></td>


### PR DESCRIPTION
Connor's approved copy. 15 instances across 6 files.

**Before:** 'No 2FA. No CAPTCHA. Ever.'
**After:** 'No 2FA or CAPTCHA by default — add them when your use case needs them.'

Consistent reframe from 'we don't have it' to 'off by default, opt in when needed.'