### PR TITLE
fix: deploy fanout-viz.js — dashboard load failure

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -67,6 +67,7 @@ jobs:
           cp playground/playground.js /tmp/deploy/playground/ 2>/dev/null || true
           cp -r app/lib /tmp/deploy/app/ 2>/dev/null || true
           cp app/app.js /tmp/deploy/app/ 2>/dev/null || true
+          cp app/fanout-viz.js /tmp/deploy/app/ 2>/dev/null || true
           [ -d images ] && mkdir -p /tmp/deploy/images && cp images/*.webp /tmp/deploy/images/ 2>/dev/null || true
 
       - name: Deploy to Cloudflare Pages


### PR DESCRIPTION
Dashboard was stuck on 'Loading dashboard...' spinner because `/app/fanout-viz.js` was not being copied to deploy dir. CF Pages SPA fallback served text/html, browser refused execution (strict MIME).

Fix: add `cp app/fanout-viz.js /tmp/deploy/app/` to deploy-dev.yml.