### PR TITLE
fix: dashboard api.js — expose as window globals for classic script

### DIFF
--- a/website/app/lib/api.js
+++ b/website/app/lib/api.js
@@ -76,12 +76,11 @@ function isAuthenticated() {
   return !!getApiKey();
 }
 
-export {
-  API_BASE,
-  getApiKey,
-  setApiKey,
-  clearApiKey,
-  apiCall,
-  signOut,
-  isAuthenticated,
-};
+// Expose as globals for classic script loading
+window.API_BASE = API_BASE;
+window.getApiKey = getApiKey;
+window.setApiKey = setApiKey;
+window.clearApiKey = clearApiKey;
+window.apiCall = apiCall;
+window.signOut = signOut;
+window.isAuthenticated = isAuthenticated;


### PR DESCRIPTION
api.js used ES `export` but loaded as classic `<script>`. `isAuthenticated()` and `apiCall()` were undefined in app.js, causing dashboard to hang on 'Loading dashboard...' indefinitely.

Fix: replace `export { ... }` with `window.X = X` assignments.