### PR TITLE
fix: dashboard spinner hidden state

### DIFF
--- a/website/styles/pages/app.css
+++ b/website/styles/pages/app.css
@@ -72,6 +72,7 @@ body{overflow:hidden}
 .loading-state{display:flex;flex-direction:column;align-items:center;justify-content:center;height:100%;gap:var(--space-4);color:var(--color-ink-muted)}
 .loading-spinner{width:32px;height:32px;border:3px solid var(--color-border);border-top-color:var(--color-brand-action);border-radius:50%;animation:spin .8s linear infinite}
 @keyframes spin{to{transform:rotate(360deg)}}
+.loading-state[hidden],.dashboard-content[hidden]{display:none!important}
 
 /* Dashboard content */
 .dashboard-content{display:flex;flex-direction:column;gap:var(--space-8)}


### PR DESCRIPTION
Root cause: app.js correctly sets loading-state.hidden = true, but app.css forces .loading-state { display:flex } and .dashboard-content { display:flex }, overriding the hidden attribute. The spinner stays visible and the real content is pushed below it.

Fix: add .loading-state[hidden], .dashboard-content[hidden] { display:none!important } in website/styles/pages/app.css.