### PR TITLE
fix: bump dashboard CSS version

### DIFF
--- a/website/app/index.html
+++ b/website/app/index.html
@@ -20,7 +20,7 @@
   <link rel="stylesheet" href="/styles/components.css?v=7" />
   <link rel="stylesheet" href="/styles/patterns.css?v=8" />
   <!-- Dashboard CSS -->
-  <link rel="stylesheet" href="/styles/pages/app.css?v=7" />
+  <link rel="stylesheet" href="/styles/pages/app.css?v=8" />
   <!-- FanoutViz CSS -->
   <link rel="stylesheet" href="/styles/components/fanout-viz.css?v=7" />
 </head>


### PR DESCRIPTION
Dashboard spinner hidden-state fix landed in app.css, but app/index.html still referenced /styles/pages/app.css?v=7 so browsers served stale CSS. Bump to v=8 so the new [hidden] rule is fetched immediately.