### PR TITLE
fix(PROD-141): align playground copy with actual 1h session behavior

### DIFF
--- a/website/getting-started/index.html
+++ b/website/getting-started/index.html
@@ -222,7 +222,7 @@
                 <line x1="7" y1="4" x2="7" y2="7.5" stroke="#94A3B8" stroke-width="1.5" stroke-linecap="round"/>
                 <circle cx="7" cy="9.5" r="0.7" fill="#94A3B8"/>
               </svg>
-              100 events · 24h expiry
+              1 hour session
             </div>
 
             <a href="/getting-started/" class="btn btn-secondary btn-lg path-cta">


### PR DESCRIPTION
## PROD-141: Playground Promise Alignment

### Fix
Changed getting-started page playground description from '100 events · 24h expiry' to accurately describe the actual behavior: 1-hour sessions with rate limiting.

### Files Changed
- `website/getting-started/index.html` — copy fix