### PR TITLE
fix(PROD-142): remove non-existent Python/Go/Ruby SDK claims

### DIFF
--- a/website/getting-started/index.html
+++ b/website/getting-started/index.html
@@ -583,25 +583,6 @@
 
         <div class="sdk-grid">
 
-          <!-- Python -->
-          <div class="sdk-card" aria-label="Python SDK">
-            <div class="sdk-card-header">
-              <div class="sdk-lang-icon" style="background:#F0F9FF;">
-                <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
-                  <rect width="20" height="20" rx="4" fill="#3776AB" fill-opacity="0.12"/>
-                  <path d="M10 3C7.5 3 7 4 7 5.5V7h6v1H5.5C4 8 3 8.8 3 11s.9 3 2.5 3H7v-1.5C7 11 8 10 10 10h3c1.8 0 4-1.2 4-3.5V5.5C17 4 16 3 10 3zm-1 2a.75.75 0 110 1.5A.75.75 0 019 5zM10 17c2.5 0 3-1 3-2.5V13H7v-1h7.5c1.5 0 2.5-.8 2.5-3s-.9-3-2.5-3H13v1.5c0 1.5-1 2.5-3 2.5H7c-1.8 0-4 1.2-4 3.5V14.5C3 16 4 17 10 17zm1-2a.75.75 0 110-1.5.75.75 0 010 1.5z" fill="#3776AB"/>
-                </svg>
-              </div>
-              <span class="sdk-lang-name">Python</span>
-            </div>
-            <div class="sdk-code-area">
-              <pre><code><span class="tok-comment"># pip install hookwing</span>
-<span class="tok-keyword">from</span> hookwing <span class="tok-keyword">import</span> Client
-client = Client(api_key=<span class="tok-string">"hwk_..."</span>)
-ep = client.endpoints.create(<span class="tok-string">"my-ep"</span>)</code></pre>
-            </div>
-          </div>
-
           <!-- Node.js -->
           <div class="sdk-card" aria-label="Node.js SDK">
             <div class="sdk-card-header">
@@ -618,44 +599,6 @@ ep = client.endpoints.create(<span class="tok-string">"my-ep"</span>)</code></pr
 <span class="tok-keyword">import</span> { Hookwing } <span class="tok-keyword">from</span> <span class="tok-string">'hookwing'</span>
 <span class="tok-keyword">const</span> hw = <span class="tok-keyword">new</span> <span class="tok-function">Hookwing</span>(process.env.HW_KEY)
 <span class="tok-keyword">await</span> hw.endpoints.<span class="tok-function">create</span>(<span class="tok-string">'my-ep'</span>)</code></pre>
-            </div>
-          </div>
-
-          <!-- Go -->
-          <div class="sdk-card" aria-label="Go SDK">
-            <div class="sdk-card-header">
-              <div class="sdk-lang-icon" style="background:#F0FAFF;">
-                <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
-                  <rect width="20" height="20" rx="4" fill="#00ACD7" fill-opacity="0.12"/>
-                  <path d="M3 8h3M3 12h3M17 8h-3M17 12h-3M7 8c0-1.1.9-2 2-2h2c1.1 0 2 .9 2 2v4c0 1.1-.9 2-2 2H9c-1.1 0-2-.9-2-2V8z" stroke="#00ACD7" stroke-width="1.5" stroke-linecap="round"/>
-                </svg>
-              </div>
-              <span class="sdk-lang-name">Go</span>
-            </div>
-            <div class="sdk-code-area">
-              <pre><code><span class="tok-comment">// go get hookwing.com/go</span>
-hw := hookwing.<span class="tok-function">New</span>(os.<span class="tok-function">Getenv</span>(<span class="tok-string">"HW_KEY"</span>))
-ep, _ := hw.Endpoints.<span class="tok-function">Create</span>(ctx,
-  &amp;hookwing.CreateEndpoint{Name: <span class="tok-string">"ep"</span>})</code></pre>
-            </div>
-          </div>
-
-          <!-- Ruby -->
-          <div class="sdk-card" aria-label="Ruby SDK">
-            <div class="sdk-card-header">
-              <div class="sdk-lang-icon" style="background:#FFF5F5;">
-                <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
-                  <rect width="20" height="20" rx="4" fill="#CC342D" fill-opacity="0.12"/>
-                  <path d="M10 3L3 8v6l7 3 7-3V8l-7-5zm0 2.5L15 9v4.5L10 16l-5-2.5V9l5-3.5z" fill="#CC342D"/>
-                </svg>
-              </div>
-              <span class="sdk-lang-name">Ruby</span>
-            </div>
-            <div class="sdk-code-area">
-              <pre><code><span class="tok-comment"># gem install hookwing</span>
-<span class="tok-keyword">require</span> <span class="tok-string">'hookwing'</span>
-hw = Hookwing::Client.<span class="tok-function">new</span>(ENV[<span class="tok-string">'HW_KEY'</span>])
-ep = hw.endpoints.<span class="tok-function">create</span>(name: <span class="tok-string">'my-ep'</span>)</code></pre>
             </div>
           </div>
 


### PR DESCRIPTION
## PROD-142: SDK Surface Honesty

Removed Python, Go, and Ruby SDK cards from getting-started page. Only JavaScript/TypeScript SDK and REST/curl examples remain — these are the only ones that actually exist.

### Files Changed
- `website/getting-started/index.html` — removed 3 SDK cards (57 lines)