### PR TITLE
fix(PROD-144): status page connects to real /api/status endpoint

### DIFF
--- a/website/status/index.html
+++ b/website/status/index.html
@@ -7,7 +7,7 @@
   <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <title>System Status — Hookwing</title>
-  <meta name="description" content="Real-time uptime monitoring for all Hookwing services." />
+  <meta name="description" content="Current status of Hookwing services." />
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="icon" type="image/png" href="/favicon-32.png" sizes="32x32" />
   <link rel="apple-touch-icon" href="/apple-touch-icon.png" sizes="180x180" />
@@ -94,46 +94,50 @@
   </header>
 
   <main id="main-content">
-    <section class="wip-section" aria-labelledby="wip-heading">
-      <div class="wip-inner">
+    <section class="status-section" aria-labelledby="status-heading">
+      <div class="status-inner">
 
-        <div class="status-badge" role="status" aria-live="polite">
-          <span class="status-dot" aria-hidden="true"></span>
-          Current status: All systems operational
+        <h1 class="status-title" id="status-heading">System Status</h1>
+        <p class="status-desc">Current status of Hookwing services, as reported by our API.</p>
+
+        <!-- Status indicator -->
+        <div class="status-card" id="status-card" role="status" aria-live="polite">
+          <div class="status-card-header">
+            <span class="status-indicator" id="status-indicator" aria-hidden="true"></span>
+            <span class="status-text" id="status-text">Loading...</span>
+          </div>
+
+          <!-- Service list -->
+          <div class="status-services" id="status-services">
+            <div class="status-service">
+              <span class="service-name">API</span>
+              <span class="service-status" id="service-api">—</span>
+            </div>
+            <div class="status-service">
+              <span class="service-name">Database</span>
+              <span class="service-status" id="service-db">—</span>
+            </div>
+          </div>
+
+          <!-- Meta info -->
+          <div class="status-meta" id="status-meta">
+            <div class="meta-item">
+              <span class="meta-label">Version</span>
+              <span class="meta-value" id="status-version">—</span>
+            </div>
+            <div class="meta-item">
+              <span class="meta-label">Last checked</span>
+              <span class="meta-value" id="status-timestamp">—</span>
+            </div>
+          </div>
         </div>
 
-        <!-- SVG Illustration: uptime bars + signal rings -->
-        <div class="wip-illustration" aria-hidden="true">
-          <svg viewBox="0 0 220 220" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <circle cx="110" cy="110" r="96" stroke="#009D64" stroke-width="1" stroke-dasharray="6 4" opacity="0.2"/>
-            <circle cx="110" cy="110" r="72" stroke="#009D64" stroke-width="1" opacity="0.12"/>
-            <!-- Uptime bars -->
-            <rect x="46" y="140" width="12" height="30" rx="3" fill="#009D64" opacity="0.25"/>
-            <rect x="62" y="120" width="12" height="50" rx="3" fill="#009D64" opacity="0.4"/>
-            <rect x="78" y="110" width="12" height="60" rx="3" fill="#009D64" opacity="0.6"/>
-            <rect x="94" y="100" width="12" height="70" rx="3" fill="#009D64" opacity="0.8"/>
-            <rect x="110" y="105" width="12" height="65" rx="3" fill="#009D64"/>
-            <rect x="126" y="115" width="12" height="55" rx="3" fill="#009D64" opacity="0.75"/>
-            <rect x="142" y="108" width="12" height="62" rx="3" fill="#009D64" opacity="0.9"/>
-            <rect x="158" y="120" width="12" height="50" rx="3" fill="#009D64" opacity="0.5"/>
-            <!-- Base line -->
-            <line x1="40" y1="172" x2="178" y2="172" stroke="#009D64" stroke-width="1.5" opacity="0.2"/>
-            <!-- Check circle at top -->
-            <circle cx="110" cy="62" r="22" fill="#EDFAF4" stroke="#009D64" stroke-width="2"/>
-            <path d="M101 62l6 6 12-12" stroke="#009D64" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-          </svg>
-        </div>
+        <!-- API endpoint info -->
+        <p class="status-api-note">
+          Status fetched from <code>/api/status</code> endpoint
+        </p>
 
-        <h1 class="wip-title" id="wip-heading">System Status</h1>
-        <p class="wip-desc">Real-time uptime monitoring for all Hookwing services. Live metrics available at launch.</p>
-
-        <form class="wip-form" action="#" method="post" aria-label="Get notified of status updates">
-          <label for="notify-email" class="visually-hidden">Email address</label>
-          <input class="wip-input" type="email" id="notify-email" name="email" placeholder="you@example.com" autocomplete="email" required />
-          <button class="btn btn-primary btn-md" type="submit">Get notified</button>
-        </form>
-
-        <p class="wip-back">← <a href="/">Back to homepage</a></p>
+        <p class="status-back">← <a href="/">Back to homepage</a></p>
       </div>
     </section>
   </main>
@@ -191,5 +195,78 @@
       </div>
     </div>
   </footer>
+
+  <script>
+    (function() {
+      const API_URL = 'https://dev.api.hookwing.com/api/status';
+
+      const statusIndicator = document.getElementById('status-indicator');
+      const statusText = document.getElementById('status-text');
+      const serviceApi = document.getElementById('service-api');
+      const serviceDb = document.getElementById('service-db');
+      const statusVersion = document.getElementById('status-version');
+      const statusTimestamp = document.getElementById('status-timestamp');
+
+      function setStatus(state, message) {
+        statusIndicator.className = 'status-indicator ' + state;
+        statusText.textContent = message;
+      }
+
+      function setServiceStatus(element, status) {
+        element.textContent = status === 'ok' ? 'Operational' : status;
+        element.className = 'service-status ' + (status === 'ok' ? 'status-ok' : 'status-error');
+      }
+
+      function formatTimestamp(ts) {
+        if (!ts) return '—';
+        try {
+          const date = new Date(ts);
+          return date.toLocaleString('en-US', {
+            month: 'short',
+            day: 'numeric',
+            hour: 'numeric',
+            minute: '2-digit',
+            hour12: true,
+            timeZoneName: 'short'
+          });
+        } catch {
+          return ts;
+        }
+      }
+
+      fetch(API_URL)
+        .then(function(r) {
+          if (!r.ok) throw new Error('API returned ' + r.status);
+          return r.json();
+        })
+        .then(function(data) {
+          // Overall status
+          if (data.status === 'operational') {
+            setStatus('status-ok', 'All systems operational');
+          } else if (data.status === 'degraded') {
+            setStatus('status-degraded', 'Some services degraded');
+          } else {
+            setStatus('status-error', 'System error');
+          }
+
+          // Individual services
+          if (data.services) {
+            setServiceStatus(serviceApi, data.services.api || 'unknown');
+            setServiceStatus(serviceDb, data.services.db || 'unknown');
+          }
+
+          // Meta
+          statusVersion.textContent = data.version || '—';
+          statusTimestamp.textContent = formatTimestamp(data.timestamp);
+        })
+        .catch(function(err) {
+          setStatus('status-error', 'Unable to reach API');
+          serviceApi.textContent = 'Unknown';
+          serviceDb.textContent = 'Unknown';
+          statusVersion.textContent = '—';
+          statusTimestamp.textContent = '—';
+        });
+    })();
+  </script>
 </body>
 </html>

--- a/website/styles/pages/status.css
+++ b/website/styles/pages/status.css
@@ -97,19 +97,38 @@
     
     .visually-hidden{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
     /* PAGE */
-    .wip-section{padding:var(--space-10) 0;display:flex;align-items:center;justify-content:center}
-    .wip-inner{max-width:560px;width:100%;margin:0 auto;text-align:center;padding:0 var(--space-4)}
-    .status-badge{display:inline-flex;align-items:center;gap:var(--space-2);background:#EDFAF4;color:#006B44;font-family:var(--font-mono);font-size:13px;font-weight:600;padding:var(--space-2) var(--space-4);border-radius:var(--radius-full);border:1.5px solid #D6F5E9;margin-bottom:var(--space-6)}
-    .status-badge .status-dot{width:8px;height:8px;background:#009D64}
-    
-    .wip-title{font-family:var(--font-display);font-size:clamp(28px,5vw,44px);font-weight:700;letter-spacing:-0.02em;line-height:1.15;color:var(--color-ink-strong);margin-bottom:var(--space-4)}
-    .wip-desc{font-size:18px;line-height:30px;color:var(--color-ink-muted);margin-bottom:var(--space-7);max-width:44ch;margin-left:auto;margin-right:auto}
-    .wip-illustration{margin:0 auto var(--space-8);width:220px;height:220px}
-    .wip-form{display:flex;gap:var(--space-2);max-width:420px;margin:0 auto var(--space-6)}
-    .wip-input{flex:1;height:44px;padding:0 var(--space-4);background:#FFFFFF;border:1.5px solid var(--color-border);border-radius:var(--radius-md);font-family:var(--font-body);font-size:15px;color:var(--color-ink-strong);transition:border-color var(--dur-fast) var(--ease);outline:none}
-    .wip-input::placeholder{color:var(--color-ink-disabled)}
-    .wip-input:focus{border-color:var(--color-brand-action);box-shadow:0 0 0 3px rgba(0,157,100,.15)}
-    .wip-back{font-size:14px;color:var(--color-ink-muted)}
-    .wip-back a{color:var(--color-brand-action);font-weight:500}
-    @media(max-width:480px){.wip-form{flex-direction:column}.wip-input{width:100%}}
+    .status-section{padding:var(--space-10) 0;display:flex;align-items:center;justify-content:center}
+    .status-inner{max-width:520px;width:100%;margin:0 auto;text-align:center;padding:0 var(--space-4)}
+
+    .status-title{font-family:var(--font-display);font-size:clamp(28px,5vw,44px);font-weight:700;letter-spacing:-0.02em;line-height:1.15;color:var(--color-ink-strong);margin-bottom:var(--space-3)}
+    .status-desc{font-size:16px;line-height:26px;color:var(--color-ink-muted);margin-bottom:var(--space-7)}
+
+    /* Status Card */
+    .status-card{background:#fff;border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-6);text-align:left;margin-bottom:var(--space-5)}
+    .status-card-header{display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-5);padding-bottom:var(--space-4);border-bottom:1px solid var(--color-border)}
+    .status-indicator{width:10px;height:10px;border-radius:50%;flex-shrink:0}
+    .status-indicator.status-ok{background:#00C07A;box-shadow:0 0 0 0 rgba(0,192,122,.4);animation:ping 2.5s ease-in-out infinite}
+    .status-indicator.status-degraded{background:#FFC107;box-shadow:0 0 0 0 rgba(255,193,7,.4);animation:ping 2.5s ease-in-out infinite}
+    .status-indicator.status-error{background:#E53935;box-shadow:0 0 0 0 rgba(229,57,53,.4);animation:ping 2.5s ease-in-out infinite}
+    .status-text{font-family:var(--font-mono);font-size:14px;font-weight:600;color:var(--color-ink-strong)}
+
+    /* Services */
+    .status-services{display:flex;flex-direction:column;gap:var(--space-3);margin-bottom:var(--space-5)}
+    .status-service{display:flex;justify-content:space-between;align-items:center}
+    .service-name{font-size:14px;color:var(--color-ink-base)}
+    .service-status{font-family:var(--font-mono);font-size:13px;font-weight:500}
+    .service-status.status-ok{color:#009D64}
+    .service-status.status-error{color:#E53935}
+
+    /* Meta */
+    .status-meta{display:flex;gap:var(--space-6);padding-top:var(--space-4);border-top:1px solid var(--color-border)}
+    .meta-item{display:flex;flex-direction:column;gap:var(--space-1)}
+    .meta-label{font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.05em;color:var(--color-ink-disabled)}
+    .meta-value{font-family:var(--font-mono);font-size:13px;color:var(--color-ink-base)}
+
+    .status-api-note{font-size:13px;color:var(--color-ink-disabled);margin-bottom:var(--space-6)}
+    .status-api-note code{font-family:var(--font-mono);font-size:12px;background:var(--color-surface-raised);padding:2px 6px;border-radius:var(--radius-xs)}
+
+    .status-back{font-size:14px;color:var(--color-ink-muted)}
+    .status-back a{color:var(--color-brand-action);font-weight:500}
     


### PR DESCRIPTION
Replaces static placeholder with live status fetched from /api/status. Shows real service state, version, DB status. Graceful fallback when API unreachable.

Files: website/status/index.html, website/styles/pages/status.css