### PR TITLE
fix(PROD-145): align MCP and agent integration claims with reality

### DIFF
--- a/website/getting-started/index.html
+++ b/website/getting-started/index.html
@@ -337,7 +337,7 @@
                   <circle cx="9" cy="9" r="8.25" fill="rgba(255,255,255,0.08)" stroke="rgba(255,255,255,0.4)" stroke-width="1.2"/>
                   <path d="M6 9.5L8 11.5L12.5 7" stroke="rgba(255,255,255,0.75)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
                 </svg>
-                MCP server + Agent Skill included
+                MCP server included
               </li>
               <li class="path-feature">
                 <svg class="path-feature-icon" viewBox="0 0 18 18" fill="none" aria-hidden="true">

--- a/website/index.html
+++ b/website/index.html
@@ -295,7 +295,7 @@
                   <circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/>
                   <path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
                 </svg>
-                MCP server + API skill support
+                MCP server support
               </div>
               <div class="feature-detail-item">
                 <svg class="feature-check" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">

--- a/website/pricing/index.html
+++ b/website/pricing/index.html
@@ -343,7 +343,7 @@
               </li>
               <li>
                 <svg class="check-icon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                Agent skill + MCP included
+                MCP included
               </li>
               <li>
                 <svg class="check-icon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
@@ -396,7 +396,7 @@
               </li>
               <li>
                 <svg class="check-icon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                Agent skill + MCP included
+                MCP included
               </li>
               <li>
                 <svg class="check-icon" viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
@@ -529,7 +529,7 @@
               </tr>
 
               <tr>
-                <td scope="row">Agent skill + MCP</td>
+                <td scope="row">MCP</td>
                 <td><span class="tbl-check">✓</span></td>
                 <td><span class="tbl-check">✓</span></td>
                 <td class="col-featured"><span class="tbl-check">✓</span></td>
@@ -706,7 +706,7 @@
               </tr>
 
               <tr>
-                <td scope="row">Agent skill / MCP</td>
+                <td scope="row">MCP</td>
                 <td>
                   <span class="tbl-check" aria-label="Included">
                     <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true"><circle cx="9" cy="9" r="8.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/><path d="M5.5 9.5L7.5 11.5L12.5 6.5" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/website/why-hookwing/index.html
+++ b/website/why-hookwing/index.html
@@ -252,15 +252,6 @@
                   <path d="M6.5 10.5L9 13L13.5 8" stroke="#E6A800" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
                 </svg>
                 <div class="trust-feature-text">
-                  <strong>Agent Skills for any LLM framework.</strong> First-class Hookwing skill for LLM agents. Import it, and your agent can manage webhook infrastructure without writing a single line of API code.
-                </div>
-              </div>
-              <div class="trust-feature-item">
-                <svg class="check-icon" viewBox="0 0 20 20" fill="none" aria-hidden="true" focusable="false">
-                  <circle cx="10" cy="10" r="9.5" fill="#FFFAE8" stroke="#FFC107" stroke-width="1"/>
-                  <path d="M6.5 10.5L9 13L13.5 8" stroke="#E6A800" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
-                </svg>
-                <div class="trust-feature-text">
                   <strong>HTTP-native billing. Agents can pay.</strong> Agents can upgrade plans via API. POST to /v1/billing/upgrade. No browser. No form. No credit card flow. Stored payment method, single call.
                 </div>
               </div>
@@ -1081,12 +1072,6 @@
                   <td class="col-hookwing"><span class="compare-check">✓ Native</span></td>
                   <td><span class="compare-cross">✗</span></td>
                   <td><span class="compare-partial">Via CLI</span></td>
-                </tr>
-                <tr>
-                  <td>Agent skills (LLM tools)</td>
-                  <td class="col-hookwing"><span class="compare-check">✓ Native</span></td>
-                  <td><span class="compare-cross">✗</span></td>
-                  <td><span class="compare-partial">Dev-time only</span></td>
                 </tr>
                 <tr>
                   <td>API-key auth by default</td>


### PR DESCRIPTION
Fixed MCP package name references, removed non-existent 'Agent Skill' claims, corrected install commands to match @hookwing/mcp package.

Files: website/getting-started/index.html, website/index.html, website/pricing/index.html, website/why-hookwing/index.html