### PR TITLE
fix(PROD-93): humanizer pass — natural voice across website copy

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -8,9 +8,9 @@
   <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <title>Hookwing - Webhook infrastructure built for agents</title>
-  <meta name="description" content="The only webhook platform designed from day one to work without a human in the loop. Production Grade. Simple. Agent-Ready." />
+  <meta name="description" content="The only webhook platform built to work without a human in the loop. Production Grade. Simple. Agent-Ready." />
   <meta property="og:title" content="Hookwing - Webhook infrastructure built for agents" />
-  <meta property="og:description" content="The only webhook platform designed from day one to work without a human in the loop." />
+  <meta property="og:description" content="The only webhook platform built to work without a human in the loop." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://hookwing.com" />
   <meta property="og:image" content="https://hookwing.com/assets/og/default.png" />
@@ -199,11 +199,11 @@
       <div class="container" style="position:relative;z-index:1;">
 <h1 class="hero-title" id="hero-heading">
           Webhook infrastructure built for <span class="accent">agents</span>.
-          Trusted by developers.
+          Developers use it too.
         </h1>
 
         <p class="hero-sub">
-          The only webhook platform designed from day one to work without a human in the loop.
+          We built the only webhook platform that works without a human in the loop.
         </p>
 
         <div class="hero-actions">
@@ -268,7 +268,7 @@
             Infrastructure that gets out of your way
           </h2>
           <p class="section-sub">
-            Built for the agent that never sleeps. And the developer who built it.
+            Built for the agent that never sleeps — and the developer who built it.
           </p>
         </div>
 
@@ -280,7 +280,7 @@
             <img src="/assets/illustrations/features/feature-agent-native.svg" class="feature-icon" width="48" height="48" alt="" aria-hidden="true" />
 
             <h3 id="feat-agent">Agent-Ready</h3>
-            <p>Designed from day one for autonomous agents. No 2FA or CAPTCHA by default. No browser. No human in the loop. API keys only. MCP native. Agents can provision themselves, manage endpoints, and upgrade plans, all via HTTP.</p>
+            <p>We built this for autonomous agents from the start. No 2FA or CAPTCHA by default, no browser required, no human in the loop. Just API keys. It's MCP native too, so agents can provision themselves, manage endpoints, and upgrade plans via HTTP.</p>
 
             <div class="feature-detail">
               <div class="feature-detail-item">
@@ -313,7 +313,7 @@
             <img src="/assets/illustrations/features/feature-simple.svg" class="feature-icon" width="48" height="48" alt="" aria-hidden="true" />
 
             <h3 id="feat-simple">Simple</h3>
-            <p>One API call. Structured JSON responses. Machine-readable errors with suggested fixes. Agents can read our API as fluently as developers do, because we designed it that way.</p>
+            <p>One API call. Structured JSON responses. Errors that actually tell you what's wrong and how to fix it. We designed the API so agents can read it as fluently as developers do.</p>
 
             <div class="feature-detail">
               <div class="feature-detail-item">
@@ -347,7 +347,7 @@
             <img src="/assets/illustrations/features/feature-reliability.svg" class="feature-icon" width="48" height="48" alt="" aria-hidden="true" />
 
             <h3 id="feat-reliable">Production Grade</h3>
-            <p>Events land, every time. Whether it's a human watching or an agent running unattended at 3am. Automatic retries with exponential backoff. No manual intervention needed.</p>
+            <p>Events land. Whether you're watching or it's 3am and your agent is running unattended. We've got automatic retries with exponential backoff — no manual intervention needed.</p>
 
             <div class="feature-detail">
               <div class="feature-detail-item">

--- a/website/pricing/index.html
+++ b/website/pricing/index.html
@@ -8,9 +8,9 @@
   <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <title>Pricing - Hookwing</title>
-  <meta name="description" content="Simple pricing. No surprises. API-key auth by default. From paper planes to jets, for developers and agents alike. Start free. Scale programmatically." />
+  <meta name="description" content="Simple pricing. No gotchas. API-key auth by default. From paper planes to jets. Start free. Scale when you're ready." />
   <meta property="og:title" content="Pricing - Hookwing" />
-  <meta property="og:description" content="Simple pricing. No surprises. From paper planes to jets." />
+  <meta property="og:description" content="Simple pricing. No gotchas. From paper planes to jets." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://hookwing.com/pricing" />
   <meta property="og:image" content="https://hookwing.com/assets/og/default.png" />
@@ -245,12 +245,12 @@
         </div>
 
         <h1 class="pricing-hero-title" id="pricing-hero-heading">
-          Simple pricing. No surprises. API-key auth by default.
+          Simple pricing. No gotchas. API-key auth by default.
         </h1>
 
         <p class="pricing-hero-sub">
-          From paper planes to jets, for developers and agents alike.
-          Start free. Scale programmatically.
+          From paper planes to jets. Developers and agents welcome.
+          Start free. Scale when you're ready.
         </p>
 
       </div>

--- a/website/why-hookwing/index.html
+++ b/website/why-hookwing/index.html
@@ -8,7 +8,7 @@
   <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <title>Why Hookwing - Built agent-first</title>
-  <meta name="description" content="The only webhook platform designed from day one to work without a human in the loop. Reliable enough for production. Simple enough for a three-line setup." />
+  <meta name="description" content="The only webhook platform built to work without a human in the loop. Reliable enough for production. Simple enough for a three-line setup." />
   <meta property="og:title" content="Why Hookwing - Built for the age of AI" />
   <meta property="og:description" content="6 automatic retries. Simple API. No hidden fees. Built for developers and AI agents." />
   <meta property="og:type" content="website" />
@@ -165,7 +165,7 @@
           </h1>
 
           <p class="why-hero-sub">
-            The only webhook platform designed from day one to work without a human in the loop. Reliable enough for production. Simple enough for a three-line setup.
+            The only webhook platform built to work without a human in the loop. Reliable enough for production. Simple enough for a three-line setup.
           </p>
 
           <!-- Quick trust pills -->


### PR DESCRIPTION
Rewrote AI-sounding copy across homepage, pricing, and why-hookwing pages. More natural rhythm, contractions, developer-to-developer tone. No structural or factual changes.

Files: website/index.html, website/pricing/index.html, website/why-hookwing/index.html