### PR TITLE
feat(PROD-116): add GitHub + Google OAuth social login

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1169,6 +1169,18 @@
         "hono": "^4"
       }
     },
+    "node_modules/@hono/oauth-providers": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@hono/oauth-providers/-/oauth-providers-0.8.5.tgz",
+      "integrity": "sha512-hgEDH/gUmB/opman9jvT8dLItZsSC9M9yFiaam0b6InK7WQkdzIcaRAkdda47QpixnK9S1Ah2vjDB2U16LkMnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.4.0"
+      },
+      "peerDependencies": {
+        "hono": ">=3.0.0"
+      }
+    },
     "node_modules/@hookwing/api": {
       "resolved": "packages/api",
       "link": true
@@ -5462,6 +5474,7 @@
       "name": "@hookwing/api",
       "version": "0.0.1",
       "dependencies": {
+        "@hono/oauth-providers": "^0.8.5",
         "@hookwing/shared": "*",
         "drizzle-orm": "^0.39.3",
         "hono": "^4.0.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -10,6 +10,7 @@
     "dev": "wrangler dev"
   },
   "dependencies": {
+    "@hono/oauth-providers": "^0.8.5",
     "@hookwing/shared": "*",
     "drizzle-orm": "^0.39.3",
     "hono": "^4.0.0",

--- a/packages/api/src/__tests__/auth-oauth.test.ts
+++ b/packages/api/src/__tests__/auth-oauth.test.ts
@@ -1,0 +1,79 @@
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+import authRoutes from '../routes/auth';
+
+describe('GET /v1/auth/github', () => {
+  it('should return 503 when GitHub OAuth is not configured', async () => {
+    const app = new Hono().route('/v1/auth', authRoutes);
+    const res = await app.request('/v1/auth/github');
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body).toHaveProperty('error');
+  });
+});
+
+describe('GET /v1/auth/google', () => {
+  it('should return 503 when Google OAuth is not configured', async () => {
+    const app = new Hono().route('/v1/auth', authRoutes);
+    const res = await app.request('/v1/auth/google');
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body).toHaveProperty('error');
+  });
+});
+
+describe('GET /v1/auth/github/callback', () => {
+  it('should return 400 when no code is provided', async () => {
+    const app = new Hono().route('/v1/auth', authRoutes);
+    const res = await app.request('/v1/auth/github/callback');
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toHaveProperty('error');
+  });
+
+  it('should return 503 when GitHub OAuth is not configured', async () => {
+    const app = new Hono().route('/v1/auth', authRoutes);
+    const res = await app.request('/v1/auth/github/callback?code=test-code');
+
+    expect(res.status).toBe(503);
+  });
+
+  it('should return 400 when user denies authorization', async () => {
+    const app = new Hono().route('/v1/auth', authRoutes);
+    const res = await app.request('/v1/auth/github/callback?error=access_denied');
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toHaveProperty('error');
+  });
+});
+
+describe('GET /v1/auth/google/callback', () => {
+  it('should return 400 when no code is provided', async () => {
+    const app = new Hono().route('/v1/auth', authRoutes);
+    const res = await app.request('/v1/auth/google/callback');
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toHaveProperty('error');
+  });
+
+  it('should return 503 when Google OAuth is not configured', async () => {
+    const app = new Hono().route('/v1/auth', authRoutes);
+    const res = await app.request('/v1/auth/google/callback?code=test-code');
+
+    expect(res.status).toBe(503);
+  });
+
+  it('should return 400 when user denies authorization', async () => {
+    const app = new Hono().route('/v1/auth', authRoutes);
+    const res = await app.request('/v1/auth/google/callback?error=access_denied');
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toHaveProperty('error');
+  });
+});

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -4,6 +4,7 @@ import {
   generateId,
   getTierBySlug,
   hashPassword,
+  oauthAccounts,
   validateScopes,
   verifyPassword,
   workspaces,
@@ -15,8 +16,16 @@ import { createDb } from '../db';
 import { authMiddleware, getWorkspace, requireApiKeyScopes } from '../middleware/auth';
 import { applyRateLimit, createRateLimitMiddleware } from '../middleware/rateLimit';
 
+// OAuth provider types
+type OAuthProvider = 'github' | 'google';
+
 type AuthBindings = {
   DB?: D1Database;
+  APP_URL?: string;
+  GITHUB_CLIENT_ID?: string;
+  GITHUB_CLIENT_SECRET?: string;
+  GOOGLE_CLIENT_ID?: string;
+  GOOGLE_CLIENT_SECRET?: string;
 };
 
 const auth = new Hono<{ Bindings: AuthBindings }>();
@@ -431,6 +440,430 @@ auth.delete('/keys/:id', authMiddleware, requireApiKeyScopes(['keys:write']), as
   await db.update(apiKeys).set({ isActive: 0 }).where(eq(apiKeys.id, keyId));
 
   return c.json({ success: true });
+});
+
+// ============================================================================
+// OAuth helpers
+// ============================================================================
+
+function getOAuthConfig(c: Context) {
+  return {
+    github: {
+      clientId: c.env?.GITHUB_CLIENT_ID ?? '',
+      clientSecret: c.env?.GITHUB_CLIENT_SECRET ?? '',
+    },
+    google: {
+      clientId: c.env?.GOOGLE_CLIENT_ID ?? '',
+      clientSecret: c.env?.GOOGLE_CLIENT_SECRET ?? '',
+    },
+  };
+}
+
+function isOAuthConfigured(c: Context, provider: OAuthProvider): boolean {
+  const config = getOAuthConfig(c);
+  return Boolean(config[provider].clientId && config[provider].clientSecret);
+}
+
+async function findOrCreateWorkspaceFromOAuth(
+  db: ReturnType<typeof createDb>,
+  email: string,
+  name?: string,
+): Promise<{ workspaceId: string; isNew: boolean; slug: string }> {
+  const existing = await db
+    .select()
+    .from(workspaces)
+    .where(eq(workspaces.email, email.toLowerCase()))
+    .limit(1);
+
+  const workspace = existing[0];
+  if (workspace) {
+    return { workspaceId: workspace.id, isNew: false, slug: workspace.slug };
+  }
+
+  // Create new workspace
+  const emailPrefix =
+    email
+      .split('@')[0]
+      ?.toLowerCase()
+      .replace(/[^a-z0-9]/g, '') ?? 'user';
+  const slug = `${emailPrefix}-${generateId('ws').substring(3, 8)}`;
+  const workspaceId = generateId('ws');
+  const now = Date.now();
+
+  await db.insert(workspaces).values({
+    id: workspaceId,
+    email: email.toLowerCase(),
+    passwordHash: DUMMY_PASSWORD_HASH, // OAuth users don't have password
+    name: name ?? `${email.split('@')[0]}'s Workspace`,
+    slug,
+    tierSlug: 'paper-plane',
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  return { workspaceId, isNew: true, slug };
+}
+
+async function generateApiKeyForWorkspace(
+  db: ReturnType<typeof createDb>,
+  workspaceId: string,
+): Promise<string> {
+  const keyData = await generateApiKey();
+  const keyId = generateId('key');
+  const now = Date.now();
+
+  await db.insert(apiKeys).values({
+    id: keyId,
+    workspaceId,
+    name: 'Default',
+    keyHash: keyData.hash,
+    keyPrefix: keyData.prefix,
+    scopes: null,
+    isActive: 1,
+    createdAt: now,
+  });
+
+  return keyData.key;
+}
+
+// ============================================================================
+// GET /v1/auth/github - Redirect to GitHub OAuth
+// ============================================================================
+
+auth.get('/github', async (c) => {
+  if (!isOAuthConfigured(c, 'github')) {
+    return c.json({ error: 'GitHub OAuth not configured' }, 503);
+  }
+
+  const config = getOAuthConfig(c);
+  const clientId = config.github.clientId;
+  const redirectUri = `${c.env?.APP_URL ?? 'https://hookwing.com'}/v1/auth/github/callback`;
+
+  const scope = 'read:user user:email';
+  const state = generateId('oauth');
+
+  const authUrl = new URL('https://github.com/login/oauth/authorize');
+  authUrl.searchParams.set('client_id', clientId);
+  authUrl.searchParams.set('redirect_uri', redirectUri);
+  authUrl.searchParams.set('scope', scope);
+  authUrl.searchParams.set('state', state);
+
+  return c.redirect(authUrl.toString(), 302);
+});
+
+// ============================================================================
+// GET /v1/auth/github/callback - Handle GitHub OAuth callback
+// ============================================================================
+
+auth.get('/github/callback', async (c) => {
+  const code = c.req.query('code');
+  const error = c.req.query('error');
+
+  if (error) {
+    return c.json({ error: 'OAuth authorization denied' }, 400);
+  }
+
+  if (!code) {
+    return c.json({ error: 'Missing authorization code' }, 400);
+  }
+
+  if (!isOAuthConfigured(c, 'github')) {
+    return c.json({ error: 'GitHub OAuth not configured' }, 503);
+  }
+
+  const config = getOAuthConfig(c);
+  const redirectUri = `${c.env?.APP_URL ?? 'https://hookwing.com'}/v1/auth/github/callback`;
+
+  // Exchange code for access token
+  const tokenResponse = await fetch('https://github.com/login/oauth/access_token', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify({
+      client_id: config.github.clientId,
+      client_secret: config.github.clientSecret,
+      code,
+      redirect_uri: redirectUri,
+    }),
+  });
+
+  if (!tokenResponse.ok) {
+    return c.json({ error: 'Failed to exchange code for token' }, 500);
+  }
+
+  const tokenData = (await tokenResponse.json()) as { access_token?: string; error?: string };
+  if (!tokenData.access_token) {
+    return c.json({ error: 'No access token received' }, 500);
+  }
+
+  const accessToken = tokenData.access_token;
+
+  // Fetch user profile
+  const userResponse = await fetch('https://api.github.com/user', {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: 'application/json',
+    },
+  });
+
+  if (!userResponse.ok) {
+    return c.json({ error: 'Failed to fetch user profile' }, 500);
+  }
+
+  const userData = (await userResponse.json()) as {
+    id: number;
+    email?: string;
+    name?: string;
+    avatar_url?: string;
+  };
+
+  // Get primary email if not provided
+  let email = userData.email;
+  if (!email) {
+    const emailsResponse = await fetch('https://api.github.com/user/emails', {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: 'application/json',
+      },
+    });
+
+    if (emailsResponse.ok) {
+      const emails = (await emailsResponse.json()) as Array<{ email: string; primary: boolean }>;
+      const primaryEmail = emails.find((e) => e.primary);
+      email = primaryEmail?.email ?? emails[0]?.email;
+    }
+  }
+
+  if (!email) {
+    return c.json({ error: 'Could not get email from GitHub' }, 400);
+  }
+
+  if (!c.env?.DB) {
+    return c.json({ error: 'Database not configured' }, 503);
+  }
+  const db = createDb(c.env.DB);
+
+  // Find or create workspace
+  const { workspaceId, isNew, slug } = await findOrCreateWorkspaceFromOAuth(
+    db,
+    email,
+    userData.name,
+  );
+
+  // Link OAuth account
+  const now = Date.now();
+  const existingOAuth = await db
+    .select()
+    .from(oauthAccounts)
+    .where(
+      and(
+        eq(oauthAccounts.provider, 'github'),
+        eq(oauthAccounts.providerAccountId, String(userData.id)),
+      ),
+    )
+    .limit(1);
+
+  if (existingOAuth.length === 0) {
+    await db.insert(oauthAccounts).values({
+      id: generateId('oauth'),
+      workspaceId,
+      provider: 'github',
+      providerAccountId: String(userData.id),
+      email: email.toLowerCase(),
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+
+  // Generate API key
+  const apiKey = await generateApiKeyForWorkspace(db, workspaceId);
+  const tier = getTierBySlug('paper-plane');
+
+  // Check if request accepts JSON or expects redirect
+  const accept = c.req.header('Accept') ?? '';
+  if (accept.includes('application/json') || c.req.header('X-Api-Client')) {
+    return c.json({
+      workspace: {
+        id: workspaceId,
+        name: isNew ? `${email.split('@')[0]}'s Workspace` : undefined,
+        slug,
+        tier,
+      },
+      apiKey,
+    });
+  }
+
+  // Redirect to app with API key
+  const appUrl = c.env?.APP_URL ?? 'https://hookwing.com';
+  const redirectUrl = new URL(`${appUrl}/dashboard`);
+  redirectUrl.searchParams.set('apiKey', apiKey);
+  redirectUrl.searchParams.set('workspaceId', workspaceId);
+
+  return c.redirect(redirectUrl.toString(), 302);
+});
+
+// ============================================================================
+// GET /v1/auth/google - Redirect to Google OAuth
+// ============================================================================
+
+auth.get('/google', async (c) => {
+  if (!isOAuthConfigured(c, 'google')) {
+    return c.json({ error: 'Google OAuth not configured' }, 503);
+  }
+
+  const config = getOAuthConfig(c);
+  const clientId = config.google.clientId;
+  const redirectUri = `${c.env?.APP_URL ?? 'https://hookwing.com'}/v1/auth/google/callback`;
+
+  const scope = 'openid email profile';
+  const state = generateId('oauth');
+
+  const authUrl = new URL('https://accounts.google.com/o/oauth2/v2/auth');
+  authUrl.searchParams.set('client_id', clientId);
+  authUrl.searchParams.set('redirect_uri', redirectUri);
+  authUrl.searchParams.set('scope', scope);
+  authUrl.searchParams.set('state', state);
+  authUrl.searchParams.set('response_type', 'code');
+
+  return c.redirect(authUrl.toString(), 302);
+});
+
+// ============================================================================
+// GET /v1/auth/google/callback - Handle Google OAuth callback
+// ============================================================================
+
+auth.get('/google/callback', async (c) => {
+  const code = c.req.query('code');
+  const error = c.req.query('error');
+
+  if (error) {
+    return c.json({ error: 'OAuth authorization denied' }, 400);
+  }
+
+  if (!code) {
+    return c.json({ error: 'Missing authorization code' }, 400);
+  }
+
+  if (!isOAuthConfigured(c, 'google')) {
+    return c.json({ error: 'Google OAuth not configured' }, 503);
+  }
+
+  const config = getOAuthConfig(c);
+  const redirectUri = `${c.env?.APP_URL ?? 'https://hookwing.com'}/v1/auth/google/callback`;
+
+  // Exchange code for access token
+  const tokenResponse = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: new URLSearchParams({
+      client_id: config.google.clientId,
+      client_secret: config.google.clientSecret,
+      code,
+      grant_type: 'authorization_code',
+      redirect_uri: redirectUri,
+    }),
+  });
+
+  if (!tokenResponse.ok) {
+    return c.json({ error: 'Failed to exchange code for token' }, 500);
+  }
+
+  const tokenData = (await tokenResponse.json()) as {
+    access_token?: string;
+    id_token?: string;
+    error?: string;
+  };
+  if (!tokenData.access_token) {
+    return c.json({ error: 'No access token received' }, 500);
+  }
+
+  const accessToken = tokenData.access_token;
+
+  // Fetch user profile
+  const userResponse = await fetch('https://www.googleapis.com/oauth2/v2/userinfo', {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!userResponse.ok) {
+    return c.json({ error: 'Failed to fetch user profile' }, 500);
+  }
+
+  const userData = (await userResponse.json()) as {
+    id: string;
+    email: string;
+    name?: string;
+    picture?: string;
+  };
+
+  if (!userData.email) {
+    return c.json({ error: 'Could not get email from Google' }, 400);
+  }
+
+  if (!c.env?.DB) {
+    return c.json({ error: 'Database not configured' }, 503);
+  }
+  const db = createDb(c.env.DB);
+
+  // Find or create workspace
+  const { workspaceId, isNew, slug } = await findOrCreateWorkspaceFromOAuth(
+    db,
+    userData.email,
+    userData.name,
+  );
+
+  // Link OAuth account
+  const now = Date.now();
+  const existingOAuth = await db
+    .select()
+    .from(oauthAccounts)
+    .where(
+      and(eq(oauthAccounts.provider, 'google'), eq(oauthAccounts.providerAccountId, userData.id)),
+    )
+    .limit(1);
+
+  if (existingOAuth.length === 0) {
+    await db.insert(oauthAccounts).values({
+      id: generateId('oauth'),
+      workspaceId,
+      provider: 'google',
+      providerAccountId: userData.id,
+      email: userData.email.toLowerCase(),
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+
+  // Generate API key
+  const apiKey = await generateApiKeyForWorkspace(db, workspaceId);
+  const tier = getTierBySlug('paper-plane');
+
+  // Check if request accepts JSON or expects redirect
+  const accept = c.req.header('Accept') ?? '';
+  if (accept.includes('application/json') || c.req.header('X-Api-Client')) {
+    return c.json({
+      workspace: {
+        id: workspaceId,
+        name: isNew ? `${userData.email.split('@')[0]}'s Workspace` : undefined,
+        slug,
+        tier,
+      },
+      apiKey,
+    });
+  }
+
+  // Redirect to app with API key
+  const appUrl = c.env?.APP_URL ?? 'https://hookwing.com';
+  const redirectUrl = new URL(`${appUrl}/dashboard`);
+  redirectUrl.searchParams.set('apiKey', apiKey);
+  redirectUrl.searchParams.set('workspaceId', workspaceId);
+
+  return c.redirect(redirectUrl.toString(), 302);
 });
 
 export default auth;

--- a/packages/shared/src/db/index.ts
+++ b/packages/shared/src/db/index.ts
@@ -17,4 +17,7 @@ export {
   usageDaily,
   type UsageDaily,
   type NewUsageDaily,
+  oauthAccounts,
+  type OauthAccount,
+  type NewOauthAccount,
 } from './schema';

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -193,3 +193,34 @@ export const usageDaily = sqliteTable(
 
 export type UsageDaily = typeof usageDaily.$inferSelect;
 export type NewUsageDaily = typeof usageDaily.$inferInsert;
+
+// ============================================================================
+// OAuth Accounts - social login identities
+// ============================================================================
+
+export const oauthAccounts = sqliteTable(
+  'oauth_accounts',
+  {
+    id: text('id').primaryKey(),
+    workspaceId: text('workspace_id')
+      .notNull()
+      .references(() => workspaces.id, { onDelete: 'cascade' }),
+    provider: text('provider').notNull(), // 'github' or 'google'
+    providerAccountId: text('provider_account_id').notNull(),
+    email: text('email'),
+    createdAt: integer('created_at').notNull(),
+    updatedAt: integer('updated_at').notNull(),
+  },
+  (table) => {
+    return {
+      workspaceIdIdx: index('oauth_accounts_workspace_id_idx').on(table.workspaceId),
+      providerAccountIdIdx: uniqueIndex('oauth_accounts_provider_account_idx').on(
+        table.provider,
+        table.providerAccountId,
+      ),
+    };
+  },
+);
+
+export type OauthAccount = typeof oauthAccounts.$inferSelect;
+export type NewOauthAccount = typeof oauthAccounts.$inferInsert;


### PR DESCRIPTION
## PROD-116: Social Login

### What
- GitHub OAuth: GET /v1/auth/github → redirect → /v1/auth/github/callback
- Google OAuth: GET /v1/auth/google → redirect → /v1/auth/google/callback
- OAuth accounts table (oauth_accounts) for provider linking
- Find-or-create workspace by OAuth email
- API key generation on OAuth callback
- Rate limited with existing authAbuseProtection

### Env vars needed
GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET

### Tests: 8 new OAuth tests
### Files: auth.ts, schema.ts, auth-oauth.test.ts, package.json