### PR TITLE
feat(PROD-152): Go SDK — webhook verification + typed API client

### DIFF
--- a/packages/go-sdk/README.md
+++ b/packages/go-sdk/README.md
@@ -1,0 +1,103 @@
+# Hookwing Go SDK
+
+Go SDK for Hookwing webhook signature verification and typed API client.
+
+## Installation
+
+```bash
+go get github.com/gethookwing/hookwing-go
+```
+
+## Webhook Verification
+
+Verify incoming webhook signatures with HMAC-SHA256:
+
+```go
+package main
+
+import (
+    "io"
+    "net/http"
+
+    hookwing "github.com/gethookwing/hookwing-go"
+)
+
+func main() {
+    wh := hookwing.NewWebhook("whsec_your_signing_secret")
+
+    http.HandleFunc("/webhook", func(w http.ResponseWriter, r *http.Request) {
+        payload, _ := io.ReadAll(r.Body)
+
+        event, err := wh.Verify(payload, r.Header)
+        if err != nil {
+            http.Error(w, err.Error(), http.StatusBadRequest)
+            return
+        }
+
+        // Handle the verified event
+        println("Received event:", event.Type)
+    })
+}
+```
+
+### Headers
+
+- `X-Hookwing-Signature`: HMAC-SHA256 signature (format: `sha256=<hex>`)
+- `X-Hookwing-Timestamp`: Unix timestamp in milliseconds
+- `X-Event-Type`: Event type (optional, falls back to payload type)
+
+### Options
+
+```go
+// Set custom tolerance (default: 5 minutes)
+wh := hookwing.NewWebhook("secret", hookwing.WithToleranceMs(10*60*1000))
+```
+
+## API Client
+
+Manage endpoints, events, and deliveries:
+
+```go
+package main
+
+import (
+    "context"
+
+    hookwing "github.com/gethookwing/hookwing-go"
+)
+
+func main() {
+    client := hookwing.NewClient("your-api-key")
+
+    // List endpoints
+    endpoints, _ := client.ListEndpoints(context.Background())
+
+    // Create endpoint
+    endpoint, _ := client.CreateEndpoint(context.Background(), hookwing.CreateEndpointRequest{
+        Name: "My Endpoint",
+        URL:  "https://example.com/webhook",
+    })
+
+    // List events
+    events, _ := client.ListEvents(context.Background(), hookwing.WithLimit(50))
+
+    // Replay event
+    client.ReplayEvent(context.Background(), "evt_123")
+}
+```
+
+### Options
+
+```go
+// Custom base URL
+client := hookwing.NewClient("api-key", hookwing.WithBaseURL("https://api.hookwing.com"))
+
+// Custom HTTP client
+client := hookwing.NewClient("api-key", hookwing.WithHTTPClient(&http.Client{Timeout: 60*time.Second}))
+```
+
+## Testing
+
+```bash
+go test ./...
+```

--- a/packages/go-sdk/client.go
+++ b/packages/go-sdk/client.go
@@ -1,0 +1,251 @@
+package hookwing
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	// DefaultBaseURL is the default base URL for the Hookwing API.
+	DefaultBaseURL = "https://api.hookwing.com"
+)
+
+// ClientOption is a functional option for configuring a Client.
+type ClientOption func(*Client)
+
+// WithBaseURL sets the base URL for the API.
+func WithBaseURL(baseURL string) ClientOption {
+	return func(c *Client) {
+		c.baseURL = strings.TrimSuffix(baseURL, "/")
+	}
+}
+
+// WithHTTPClient sets a custom HTTP client.
+func WithHTTPClient(httpClient *http.Client) ClientOption {
+	return func(c *Client) {
+		c.http = httpClient
+	}
+}
+
+// WithTimeout sets the request timeout.
+func WithTimeout(timeout time.Duration) ClientOption {
+	return func(c *Client) {
+		c.timeout = timeout
+	}
+}
+
+// Client is a typed API client for Hookwing.
+type Client struct {
+	apiKey   string
+	baseURL  string
+	http     *http.Client
+	timeout  time.Duration
+}
+
+// NewClient creates a new Hookwing API client.
+func NewClient(apiKey string, opts ...ClientOption) *Client {
+	c := &Client{
+		apiKey:   apiKey,
+		baseURL:  DefaultBaseURL,
+		http:     &http.Client{},
+		timeout:  30 * time.Second,
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c
+}
+
+// ListOption is a functional option for list methods.
+type ListOption func(*ListOptions)
+
+// WithEndpointID filters by endpoint ID.
+func WithEndpointID(endpointID string) ListOption {
+	return func(o *ListOptions) {
+		o.EndpointID = endpointID
+	}
+}
+
+// WithEventID filters by event ID.
+func WithEventID(eventID string) ListOption {
+	return func(o *ListOptions) {
+		o.EventID = eventID
+	}
+}
+
+// WithEventType filters by event type.
+func WithEventType(eventType string) ListOption {
+	return func(o *ListOptions) {
+		o.EventType = eventType
+	}
+}
+
+// WithStatus filters by status.
+func WithStatus(status string) ListOption {
+	return func(o *ListOptions) {
+		o.Status = status
+	}
+}
+
+// WithLimit sets the limit.
+func WithLimit(limit int) ListOption {
+	return func(o *ListOptions) {
+		o.Limit = limit
+	}
+}
+
+func (c *Client) request(ctx context.Context, method, path string, body any) (*http.Response, error) {
+	var bodyReader io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal request body: %w", err)
+		}
+		bodyReader = bytes.NewReader(b)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	if bodyReader != nil {
+		req.Header.Set("Content-Length", "0") // Will be set automatically
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+
+	return resp, nil
+}
+
+func (c *Client) doRequest(ctx context.Context, method, path string, body any, response any) error {
+	resp, err := c.request(ctx, method, path, body)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	if response == nil {
+		return nil
+	}
+
+	return json.NewDecoder(resp.Body).Decode(response)
+}
+
+// ListEndpoints lists all endpoints.
+func (c *Client) ListEndpoints(ctx context.Context) ([]Endpoint, error) {
+	var resp EndpointsResponse
+	err := c.doRequest(ctx, http.MethodGet, "/v1/endpoints", nil, &resp)
+	return resp.Endpoints, err
+}
+
+// CreateEndpoint creates a new endpoint.
+func (c *Client) CreateEndpoint(ctx context.Context, req CreateEndpointRequest) (*Endpoint, error) {
+	var resp EndpointResponse
+	err := c.doRequest(ctx, http.MethodPost, "/v1/endpoints", req, &resp)
+	return &resp.Endpoint, err
+}
+
+// GetEndpoint gets an endpoint by ID.
+func (c *Client) GetEndpoint(ctx context.Context, id string) (*Endpoint, error) {
+	var resp EndpointResponse
+	err := c.doRequest(ctx, http.MethodGet, fmt.Sprintf("/v1/endpoints/%s", id), nil, &resp)
+	return &resp.Endpoint, err
+}
+
+// ListEvents lists events.
+func (c *Client) ListEvents(ctx context.Context, opts ...ListOption) ([]Event, error) {
+	options := &ListOptions{Limit: 50}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	query := url.Values{}
+	if options.EndpointID != "" {
+		query.Set("endpoint_id", options.EndpointID)
+	}
+	if options.EventType != "" {
+		query.Set("event_type", options.EventType)
+	}
+	if options.Limit > 0 {
+		query.Set("limit", fmt.Sprintf("%d", options.Limit))
+	}
+
+	path := "/v1/events"
+	if len(query) > 0 {
+		path += "?" + query.Encode()
+	}
+
+	var resp EventsResponse
+	err := c.doRequest(ctx, http.MethodGet, path, nil, &resp)
+	return resp.Events, err
+}
+
+// GetEvent gets an event by ID.
+func (c *Client) GetEvent(ctx context.Context, id string) (*Event, error) {
+	var resp EventResponse
+	err := c.doRequest(ctx, http.MethodGet, fmt.Sprintf("/v1/events/%s", id), nil, &resp)
+	return &resp.Event, err
+}
+
+// ReplayEvent replays an event.
+func (c *Client) ReplayEvent(ctx context.Context, id string) error {
+	return c.doRequest(ctx, http.MethodPost, fmt.Sprintf("/v1/events/%s/replay", id), nil, nil)
+}
+
+// ListDeliveries lists deliveries.
+func (c *Client) ListDeliveries(ctx context.Context, opts ...ListOption) ([]Delivery, error) {
+	options := &ListOptions{Limit: 50}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	query := url.Values{}
+	if options.EventID != "" {
+		query.Set("event_id", options.EventID)
+	}
+	if options.EndpointID != "" {
+		query.Set("endpoint_id", options.EndpointID)
+	}
+	if options.Status != "" {
+		query.Set("status", options.Status)
+	}
+	if options.Limit > 0 {
+		query.Set("limit", fmt.Sprintf("%d", options.Limit))
+	}
+
+	path := "/v1/deliveries"
+	if len(query) > 0 {
+		path += "?" + query.Encode()
+	}
+
+	var resp DeliveriesResponse
+	err := c.doRequest(ctx, http.MethodGet, path, nil, &resp)
+	return resp.Deliveries, err
+}
+
+// GetDelivery gets a delivery by ID.
+func (c *Client) GetDelivery(ctx context.Context, id string) (*Delivery, error) {
+	var resp DeliveryResponse
+	err := c.doRequest(ctx, http.MethodGet, fmt.Sprintf("/v1/deliveries/%s", id), nil, &resp)
+	return &resp.Delivery, err
+}

--- a/packages/go-sdk/client_test.go
+++ b/packages/go-sdk/client_test.go
@@ -1,0 +1,321 @@
+package hookwing
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestClient_NewClient(t *testing.T) {
+	client := NewClient("test-api-key")
+	if client.apiKey != "test-api-key" {
+		t.Errorf("expected apiKey test-api-key, got %s", client.apiKey)
+	}
+	if client.baseURL != DefaultBaseURL {
+		t.Errorf("expected baseURL %s, got %s", DefaultBaseURL, client.baseURL)
+	}
+}
+
+func TestClient_WithBaseURL(t *testing.T) {
+	client := NewClient("test-api-key", WithBaseURL("https://custom.example.com"))
+	if client.baseURL != "https://custom.example.com" {
+		t.Errorf("expected baseURL https://custom.example.com, got %s", client.baseURL)
+	}
+}
+
+func TestClient_ListEndpoints(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify auth header
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer test-api-key" {
+			t.Errorf("expected Authorization header 'Bearer test-api-key', got %s", auth)
+		}
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET method, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/endpoints" {
+			t.Errorf("expected path /v1/endpoints, got %s", r.URL.Path)
+		}
+
+		resp := EndpointsResponse{
+			Endpoints: []Endpoint{
+				{ID: "ep_123", Name: "Test Endpoint", URL: "https://example.com/webhook"},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient("test-api-key", WithBaseURL(server.URL))
+	endpoints, err := client.ListEndpoints(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(endpoints) != 1 {
+		t.Errorf("expected 1 endpoint, got %d", len(endpoints))
+	}
+	if endpoints[0].ID != "ep_123" {
+		t.Errorf("expected endpoint ID ep_123, got %s", endpoints[0].ID)
+	}
+}
+
+func TestClient_CreateEndpoint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST method, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/endpoints" {
+			t.Errorf("expected path /v1/endpoints, got %s", r.URL.Path)
+		}
+
+		var req CreateEndpointRequest
+		json.NewDecoder(r.Body).Decode(&req)
+		if req.Name != "My Endpoint" {
+			t.Errorf("expected name 'My Endpoint', got %s", req.Name)
+		}
+		if req.URL != "https://example.com/webhook" {
+			t.Errorf("expected URL https://example.com/webhook, got %s", req.URL)
+		}
+
+		resp := EndpointResponse{
+			Endpoint: Endpoint{
+				ID:   "ep_new",
+				Name: req.Name,
+				URL:  req.URL,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient("test-api-key", WithBaseURL(server.URL))
+	endpoint, err := client.CreateEndpoint(context.Background(), CreateEndpointRequest{
+		Name: "My Endpoint",
+		URL:  "https://example.com/webhook",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if endpoint.ID != "ep_new" {
+		t.Errorf("expected endpoint ID ep_new, got %s", endpoint.ID)
+	}
+}
+
+func TestClient_GetEndpoint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET method, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/endpoints/ep_123" {
+			t.Errorf("expected path /v1/endpoints/ep_123, got %s", r.URL.Path)
+		}
+
+		resp := EndpointResponse{
+			Endpoint: Endpoint{ID: "ep_123", Name: "Test"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient("test-api-key", WithBaseURL(server.URL))
+	endpoint, err := client.GetEndpoint(context.Background(), "ep_123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if endpoint.ID != "ep_123" {
+		t.Errorf("expected endpoint ID ep_123, got %s", endpoint.ID)
+	}
+}
+
+func TestClient_ListEvents(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/events" {
+			t.Errorf("expected path /v1/events, got %s", r.URL.Path)
+		}
+
+		// Check query params
+		if r.URL.Query().Get("endpoint_id") != "ep_123" {
+			t.Errorf("expected endpoint_id query param ep_123")
+		}
+		if r.URL.Query().Get("event_type") != "order.created" {
+			t.Errorf("expected event_type query param order.created")
+		}
+
+		resp := EventsResponse{
+			Events: []Event{
+				{ID: "evt_123", EventType: "order.created", Payload: map[string]any{"order_id": "ord_456"}},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient("test-api-key", WithBaseURL(server.URL))
+	events, err := client.ListEvents(context.Background(),
+		WithEndpointID("ep_123"),
+		WithEventType("order.created"),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(events) != 1 {
+		t.Errorf("expected 1 event, got %d", len(events))
+	}
+	if events[0].ID != "evt_123" {
+		t.Errorf("expected event ID evt_123, got %s", events[0].ID)
+	}
+}
+
+func TestClient_GetEvent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET method, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/events/evt_123" {
+			t.Errorf("expected path /v1/events/evt_123, got %s", r.URL.Path)
+		}
+
+		resp := EventResponse{
+			Event: Event{ID: "evt_123", EventType: "test"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient("test-api-key", WithBaseURL(server.URL))
+	event, err := client.GetEvent(context.Background(), "evt_123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event.ID != "evt_123" {
+		t.Errorf("expected event ID evt_123, got %s", event.ID)
+	}
+}
+
+func TestClient_ReplayEvent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST method, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/events/evt_123/replay" {
+			t.Errorf("expected path /v1/events/evt_123/replay, got %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := NewClient("test-api-key", WithBaseURL(server.URL))
+	err := client.ReplayEvent(context.Background(), "evt_123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestClient_ListDeliveries(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/deliveries" {
+			t.Errorf("expected path /v1/deliveries, got %s", r.URL.Path)
+		}
+
+		resp := DeliveriesResponse{
+			Deliveries: []Delivery{
+				{ID: "dlv_123", EventID: "evt_123", EndpointID: "ep_123", Status: "success"},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient("test-api-key", WithBaseURL(server.URL))
+	deliveries, err := client.ListDeliveries(context.Background(),
+		WithEventID("evt_123"),
+		WithEndpointID("ep_123"),
+		WithStatus("success"),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(deliveries) != 1 {
+		t.Errorf("expected 1 delivery, got %d", len(deliveries))
+	}
+	if deliveries[0].ID != "dlv_123" {
+		t.Errorf("expected delivery ID dlv_123, got %s", deliveries[0].ID)
+	}
+}
+
+func TestClient_GetDelivery(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET method, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/deliveries/dlv_123" {
+			t.Errorf("expected path /v1/deliveries/dlv_123, got %s", r.URL.Path)
+		}
+
+		resp := DeliveryResponse{
+			Delivery: Delivery{ID: "dlv_123", Status: "success"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient("test-api-key", WithBaseURL(server.URL))
+	delivery, err := client.GetDelivery(context.Background(), "dlv_123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if delivery.ID != "dlv_123" {
+		t.Errorf("expected delivery ID dlv_123, got %s", delivery.ID)
+	}
+}
+
+func TestClient_APIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error":"unauthorized"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient("test-api-key", WithBaseURL(server.URL))
+	_, err := client.ListEndpoints(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestClient_ListEventsWithLimit(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		limit := r.URL.Query().Get("limit")
+		if limit != "25" {
+			t.Errorf("expected limit 25, got %s", limit)
+		}
+
+		resp := EventsResponse{Events: []Event{}}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient("test-api-key", WithBaseURL(server.URL))
+	_, err := client.ListEvents(context.Background(), WithLimit(25))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// Test helper function for fmt.Sprintf usage
+func ExampleWebhook_Verify() {
+	// This is just to ensure fmt is imported and used correctly
+	_ = fmt.Sprintf("%d", time.Now().UnixMilli())
+}

--- a/packages/go-sdk/go.mod
+++ b/packages/go-sdk/go.mod
@@ -1,0 +1,3 @@
+module github.com/gethookwing/hookwing-go
+
+go 1.21

--- a/packages/go-sdk/types.go
+++ b/packages/go-sdk/types.go
@@ -1,0 +1,94 @@
+package hookwing
+
+import "time"
+
+// Endpoint represents a webhook endpoint.
+type Endpoint struct {
+	ID          string     `json:"id"`
+	Name        string     `json:"name"`
+	URL         string     `json:"url"`
+	Description *string    `json:"description,omitempty"`
+	Events      []string   `json:"events,omitempty"`
+	Secret      *string    `json:"secret,omitempty"`
+	IsEnabled   bool       `json:"is_enabled"`
+	CreatedAt   *time.Time `json:"created_at,omitempty"`
+	UpdatedAt   *time.Time `json:"updated_at,omitempty"`
+}
+
+// Event represents a webhook event.
+type Event struct {
+	ID        string         `json:"id"`
+	EventType string         `json:"event_type"`
+	Payload   map[string]any `json:"payload"`
+	CreatedAt *time.Time     `json:"created_at,omitempty"`
+}
+
+// Delivery represents a webhook delivery attempt.
+type Delivery struct {
+	ID            string     `json:"id"`
+	EventID       string     `json:"event_id"`
+	EndpointID    string     `json:"endpoint_id"`
+	URL           string     `json:"url"`
+	StatusCode    *int       `json:"status_code,omitempty"`
+	Status        string     `json:"status"`
+	ResponseBody  *string    `json:"response_body,omitempty"`
+	ErrorMessage  *string    `json:"error_message,omitempty"`
+	Attempt       int        `json:"attempt"`
+	CreatedAt     *time.Time `json:"created_at,omitempty"`
+	CompletedAt   *time.Time `json:"completed_at,omitempty"`
+}
+
+// WebhookEvent represents a parsed webhook event from verification.
+type WebhookEvent struct {
+	ID        string         `json:"id"`
+	Type      string         `json:"type"`
+	Timestamp int64          `json:"timestamp"`
+	Payload   map[string]any `json:"payload"`
+}
+
+// CreateEndpointRequest represents the request to create an endpoint.
+type CreateEndpointRequest struct {
+	Name        string   `json:"name"`
+	URL         string   `json:"url"`
+	Description string   `json:"description,omitempty"`
+	Events      []string `json:"events,omitempty"`
+}
+
+// ListOptions represents options for listing resources.
+type ListOptions struct {
+	EndpointID string `json:"endpoint_id,omitempty"`
+	EventID     string `json:"event_id,omitempty"`
+	EventType   string `json:"event_type,omitempty"`
+	Status      string `json:"status,omitempty"`
+	Limit       int    `json:"limit,omitempty"`
+}
+
+// EndpointsResponse represents the API response for listing endpoints.
+type EndpointsResponse struct {
+	Endpoints []Endpoint `json:"endpoints"`
+}
+
+// EndpointResponse represents the API response for a single endpoint.
+type EndpointResponse struct {
+	Endpoint Endpoint `json:"endpoint"`
+}
+
+// EventsResponse represents the API response for listing events.
+type EventsResponse struct {
+	Events []Event `json:"events"`
+}
+
+// EventResponse represents the API response for a single event.
+type EventResponse struct {
+	Event Event `json:"event"`
+}
+
+// DeliveriesResponse represents the API response for listing deliveries.
+type DeliveriesResponse struct {
+	Deliveries []Delivery `json:"deliveries"`
+}
+
+// DeliveryResponse represents the API response for a single delivery.
+type DeliveryResponse struct {
+	Delivery Delivery `json:"delivery"`
+}

--- a/packages/go-sdk/webhook.go
+++ b/packages/go-sdk/webhook.go
@@ -1,0 +1,163 @@
+package hookwing
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// SignatureHeader is the header name for the webhook signature.
+	SignatureHeader = "X-Hookwing-Signature"
+	// TimestampHeader is the header name for the webhook timestamp.
+	TimestampHeader = "X-Hookwing-Timestamp"
+	// EventTypeHeader is the header name for the event type.
+	EventTypeHeader = "X-Event-Type"
+
+	// DefaultToleranceMs is the default tolerance for timestamp verification (5 minutes).
+	DefaultToleranceMs int64 = 5 * 60 * 1000
+)
+
+// WebhookVerificationError represents an error during webhook verification.
+type WebhookVerificationError struct {
+	Message string
+}
+
+func (e *WebhookVerificationError) Error() string {
+	return e.Message
+}
+
+// WebhookOption is a functional option for configuring a Webhook.
+type WebhookOption func(*Webhook)
+
+// WithToleranceMs sets the tolerance for timestamp verification in milliseconds.
+func WithToleranceMs(toleranceMs int64) WebhookOption {
+	return func(w *Webhook) {
+		w.toleranceMs = toleranceMs
+	}
+}
+
+// Webhook verifies HMAC-SHA256 signatures on incoming webhook deliveries.
+type Webhook struct {
+	secret      string
+	toleranceMs int64
+}
+
+// NewWebhook creates a new Webhook verifier.
+func NewWebhook(secret string, opts ...WebhookOption) *Webhook {
+	// Strip 'whsec_' prefix if present
+	secret = strings.TrimPrefix(secret, "whsec_")
+
+	w := &Webhook{
+		secret:      secret,
+		toleranceMs: DefaultToleranceMs,
+	}
+
+	for _, opt := range opts {
+		opt(w)
+	}
+
+	return w
+}
+
+// Verify verifies a webhook payload and returns the parsed event.
+func (w *Webhook) Verify(payload []byte, headers http.Header) (*WebhookEvent, error) {
+	signature := headers.Get(SignatureHeader)
+	timestamp := headers.Get(TimestampHeader)
+
+	if signature == "" {
+		return nil, &WebhookVerificationError{Message: "Missing X-Hookwing-Signature header"}
+	}
+	if timestamp == "" {
+		return nil, &WebhookVerificationError{Message: "Missing X-Hookwing-Timestamp header"}
+	}
+
+	// Validate timestamp format
+	ts, err := strconv.ParseInt(timestamp, 10, 64)
+	if err != nil {
+		return nil, &WebhookVerificationError{Message: "Invalid X-Hookwing-Timestamp header"}
+	}
+
+	// Check timestamp staleness
+	now := time.Now().UnixMilli()
+	age := now - ts
+	if age < 0 {
+		age = -age
+	}
+	if age > w.toleranceMs {
+		return nil, &WebhookVerificationError{
+			Message: fmt.Sprintf("Webhook timestamp too old (%ds ago, tolerance: %ds)",
+				age/1000, w.toleranceMs/1000),
+		}
+	}
+
+	// Verify HMAC signature
+	if !w.VerifySignature(payload, signature) {
+		return nil, &WebhookVerificationError{Message: "Webhook signature verification failed"}
+	}
+
+	// Parse payload
+	var parsed map[string]any
+	if err := json.Unmarshal(payload, &parsed); err != nil {
+		return nil, &WebhookVerificationError{Message: "Webhook payload is not valid JSON"}
+	}
+
+	// Determine event type from header or payload
+	eventType := headers.Get(EventTypeHeader)
+	if eventType == "" {
+		if t, ok := parsed["type"].(string); ok {
+			eventType = t
+		} else {
+			eventType = "unknown"
+		}
+	}
+
+	// Get event ID from payload
+	eventID := ""
+	if id, ok := parsed["id"].(string); ok {
+		eventID = id
+	}
+
+	return &WebhookEvent{
+		ID:        eventID,
+		Type:      eventType,
+		Timestamp: ts,
+		Payload:   parsed,
+	}, nil
+}
+
+// VerifySignature verifies the signature only (without timestamp check).
+func (w *Webhook) VerifySignature(payload []byte, signatureHeader string) bool {
+	if !strings.HasPrefix(signatureHeader, "sha256=") {
+		return false
+	}
+
+	expectedSig := strings.TrimPrefix(signatureHeader, "sha256=")
+	actualSig := w.computeHMAC(payload)
+
+	// Constant-time comparison
+	expectedBytes, err := hex.DecodeString(expectedSig)
+	if err != nil {
+		return false
+	}
+	actualBytes, err := hex.DecodeString(actualSig)
+	if err != nil {
+		return false
+	}
+
+	return hmac.Equal(expectedBytes, actualBytes)
+}
+
+// computeHMAC computes the HMAC-SHA256 of the payload.
+func (w *Webhook) computeHMAC(payload []byte) string {
+	h := hmac.New(sha256.New, []byte(w.secret))
+	h.Write(payload)
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/packages/go-sdk/webhook_test.go
+++ b/packages/go-sdk/webhook_test.go
@@ -1,0 +1,263 @@
+package hookwing
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func computeHMAC(secret, payload string) string {
+	h := hmac.New(sha256.New, []byte(secret))
+	h.Write([]byte(payload))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func TestWebhook_NewWebhook(t *testing.T) {
+	tests := []struct {
+		name     string
+		secret   string
+		expected string
+	}{
+		{"with whsec_ prefix", "whsec_testsecret", "testsecret"},
+		{"without whsec_ prefix", "testsecret", "testsecret"},
+		{"empty prefix", "whsec_", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := NewWebhook(tt.secret)
+			if w.secret != tt.expected {
+				t.Errorf("expected secret %q, got %q", tt.expected, w.secret)
+			}
+		})
+	}
+}
+
+func TestWebhook_VerifySignature(t *testing.T) {
+	secret := "testsecret"
+	payload := `{"event":"test","data":{"id":"123"}}`
+	signature := computeHMAC(secret, payload)
+
+	w := NewWebhook(secret)
+
+	tests := []struct {
+		name           string
+		payload        []byte
+		signature      string
+		expectedValid  bool
+	}{
+		{"valid signature", []byte(payload), "sha256=" + signature, true},
+		{"invalid signature", []byte(payload), "sha256=invalid", false},
+		{"wrong payload", []byte("wrong payload"), "sha256=" + signature, false},
+		{"missing sha256 prefix", []byte(payload), signature, false},
+		{"empty signature", []byte(payload), "", false},
+		{"invalid hex", []byte(payload), "sha256=nothex!!!", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			valid := w.VerifySignature(tt.payload, tt.signature)
+			if valid != tt.expectedValid {
+				t.Errorf("expected valid=%v, got %v", tt.expectedValid, valid)
+			}
+		})
+	}
+}
+
+func TestWebhook_Verify(t *testing.T) {
+	secret := "testsecret"
+	payload := []byte(`{"id":"evt_123","type":"order.created","data":{"order_id":"ord_456"}}`)
+	timestamp := time.Now().UnixMilli()
+	signature := computeHMAC(secret, string(payload))
+
+	w := NewWebhook(secret)
+
+	t.Run("valid verification", func(t *testing.T) {
+		headers := http.Header{
+			"X-Hookwing-Signature": {"sha256=" + signature},
+			"X-Hookwing-Timestamp": {string(rune(timestamp))},
+		}
+		headers.Set("X-Hookwing-Timestamp", string(rune(timestamp)))
+
+		headers = http.Header{}
+		headers.Set("X-Hookwing-Signature", "sha256="+signature)
+		headers.Set("X-Hookwing-Timestamp", string(rune(timestamp)))
+
+		// Need to use proper int64 to string conversion
+		headers["X-Hookwing-Timestamp"] = []string{fmt.Sprintf("%d", timestamp)}
+
+		event, err := w.Verify(payload, headers)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if event.ID != "evt_123" {
+			t.Errorf("expected id evt_123, got %s", event.ID)
+		}
+		if event.Type != "order.created" {
+			t.Errorf("expected type order.created, got %s", event.Type)
+		}
+	})
+
+	t.Run("missing signature header", func(t *testing.T) {
+		headers := http.Header{}
+		headers.Set("X-Hookwing-Timestamp", fmt.Sprintf("%d", timestamp))
+
+		_, err := w.Verify(payload, headers)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if err.Error() != "Missing X-Hookwing-Signature header" {
+			t.Errorf("unexpected error message: %v", err)
+		}
+	})
+
+	t.Run("missing timestamp header", func(t *testing.T) {
+		headers := http.Header{}
+		headers.Set("X-Hookwing-Signature", "sha256="+signature)
+
+		_, err := w.Verify(payload, headers)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if err.Error() != "Missing X-Hookwing-Timestamp header" {
+			t.Errorf("unexpected error message: %v", err)
+		}
+	})
+
+	t.Run("invalid timestamp format", func(t *testing.T) {
+		headers := http.Header{}
+		headers.Set("X-Hookwing-Signature", "sha256="+signature)
+		headers.Set("X-Hookwing-Timestamp", "not-a-number")
+
+		_, err := w.Verify(payload, headers)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if err.Error() != "Invalid X-Hookwing-Timestamp header" {
+			t.Errorf("unexpected error message: %v", err)
+		}
+	})
+
+	t.Run("stale timestamp", func(t *testing.T) {
+		oldTimestamp := time.Now().Add(-10 * time.Minute).UnixMilli()
+		headers := http.Header{}
+		headers.Set("X-Hookwing-Signature", "sha256="+signature)
+		headers.Set("X-Hookwing-Timestamp", fmt.Sprintf("%d", oldTimestamp))
+
+		_, err := w.Verify(payload, headers)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if err.Error()[:27] != "Webhook timestamp too old" {
+			t.Errorf("unexpected error message: %v", err)
+		}
+	})
+
+	t.Run("invalid signature", func(t *testing.T) {
+		headers := http.Header{}
+		headers.Set("X-Hookwing-Signature", "sha256=invalidsignature")
+		headers.Set("X-Hookwing-Timestamp", fmt.Sprintf("%d", timestamp))
+
+		_, err := w.Verify(payload, headers)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if err.Error() != "Webhook signature verification failed" {
+			t.Errorf("unexpected error message: %v", err)
+		}
+	})
+
+	t.Run("invalid JSON payload", func(t *testing.T) {
+		invalidPayload := []byte("not valid json")
+		headers := http.Header{}
+		headers.Set("X-Hookwing-Signature", "sha256="+computeHMAC(secret, string(invalidPayload)))
+		headers.Set("X-Hookwing-Timestamp", fmt.Sprintf("%d", timestamp))
+
+		_, err := w.Verify(invalidPayload, headers)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if err.Error() != "Webhook payload is not valid JSON" {
+			t.Errorf("unexpected error message: %v", err)
+		}
+	})
+}
+
+func TestWebhook_WithToleranceMs(t *testing.T) {
+	secret := "testsecret"
+	payload := []byte(`{"id":"evt_123","type":"test"}`)
+	timestamp := time.Now().Add(-6 * time.Minute).UnixMilli() // 6 minutes ago
+	signature := computeHMAC(secret, string(payload))
+
+	// Default tolerance is 5 minutes, so this should fail
+	w1 := NewWebhook(secret)
+	headers := http.Header{}
+	headers.Set("X-Hookwing-Signature", "sha256="+signature)
+	headers.Set("X-Hookwing-Timestamp", fmt.Sprintf("%d", timestamp))
+
+	_, err := w1.Verify(payload, headers)
+	if err == nil {
+		t.Error("expected error for stale timestamp with default tolerance")
+	}
+
+	// With 10 minute tolerance, it should succeed
+	w2 := NewWebhook(secret, WithToleranceMs(10*60*1000))
+	_, err = w2.Verify(payload, headers)
+	if err != nil {
+		t.Errorf("unexpected error with extended tolerance: %v", err)
+	}
+}
+
+func TestWebhook_EventTypeFromHeader(t *testing.T) {
+	secret := "testsecret"
+	payload := []byte(`{"id":"evt_123"}`) // No type in payload
+	timestamp := time.Now().UnixMilli()
+	signature := computeHMAC(secret, string(payload))
+
+	w := NewWebhook(secret)
+
+	headers := http.Header{}
+	headers.Set("X-Hookwing-Signature", "sha256="+signature)
+	headers.Set("X-Hookwing-Timestamp", fmt.Sprintf("%d", timestamp))
+	headers.Set("X-Event-Type", "custom.event")
+
+	event, err := w.Verify(payload, headers)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event.Type != "custom.event" {
+		t.Errorf("expected type custom.event, got %s", event.Type)
+	}
+}
+
+func TestWebhook_EventTypeFallback(t *testing.T) {
+	secret := "testsecret"
+	payload := []byte(`{"id":"evt_123","type":"payload.event"}`)
+	timestamp := time.Now().UnixMilli()
+	signature := computeHMAC(secret, string(payload))
+
+	w := NewWebhook(secret)
+
+	headers := http.Header{}
+	headers.Set("X-Hookwing-Signature", "sha256="+signature)
+	headers.Set("X-Hookwing-Timestamp", fmt.Sprintf("%d", timestamp))
+	// No X-Event-Type header
+
+	event, err := w.Verify(payload, headers)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event.Type != "payload.event" {
+		t.Errorf("expected type payload.event, got %s", event.Type)
+	}
+}
+
+func TestWebhook_DefaultTolerance(t *testing.T) {
+	if DefaultToleranceMs != 5*60*1000 {
+		t.Errorf("expected default tolerance 300000, got %d", DefaultToleranceMs)
+	}
+}


### PR DESCRIPTION
Idiomatic Go SDK at packages/go-sdk/. HMAC-SHA256 webhook verification with constant-time comparison (hmac.Equal), typed HTTP client for all API endpoints. Tests included.