### PR TITLE
feat(PROD-155): custom domains — data model, routes, tier-gated

### DIFF
--- a/migrations/0008_add_custom_domains.sql
+++ b/migrations/0008_add_custom_domains.sql
@@ -1,0 +1,17 @@
+-- Migration: Add Custom Domains table
+-- For PROD-155: Custom domains for webhook endpoints
+
+CREATE TABLE IF NOT EXISTS custom_domains (
+  id TEXT PRIMARY KEY NOT NULL,
+  workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  domain TEXT NOT NULL UNIQUE,
+  status TEXT NOT NULL DEFAULT 'pending',
+  verified_at INTEGER,
+  created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_custom_domains_workspace
+  ON custom_domains(workspace_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_custom_domains_domain
+  ON custom_domains(domain);

--- a/packages/api/src/__tests__/custom-domains.test.ts
+++ b/packages/api/src/__tests__/custom-domains.test.ts
@@ -1,0 +1,201 @@
+import { Hono } from 'hono';
+import type { Context, MiddlewareHandler } from 'hono';
+import { describe, expect, it } from 'vitest';
+import { requireApiKeyScopes } from '../middleware/auth';
+
+/**
+ * Create a mock auth middleware that bypasses actual auth but sets the apiKey context.
+ */
+function createMockAuthMiddleware(
+  scopes: string[] | null,
+  tierSlug = 'fighter-jet',
+): MiddlewareHandler {
+  return async (c: Context, next: () => Promise<void>) => {
+    c.set('apiKey', {
+      id: 'test_key_123',
+      name: 'Test Key',
+      keyPrefix: 'test_key_',
+      scopes,
+    });
+    c.set('workspace', {
+      id: 'ws_test_123',
+      name: 'Test Workspace',
+      tierSlug,
+      email: 'test@example.com',
+      slug: 'test-workspace',
+      isPlayground: 0,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    await next();
+  };
+}
+
+describe('custom domains routes scope enforcement', () => {
+  /**
+   * Test requireApiKeyScopes directly with a mock app.
+   * This tests the scope enforcement for custom domain routes.
+   */
+  const createApp = (scopes: string[] | null, tierSlug = 'fighter-jet') => {
+    const app = new Hono<{ Bindings: { DB: D1Database; DELIVERY_QUEUE?: Queue } }>();
+    app.use('*', createMockAuthMiddleware(scopes, tierSlug));
+    // Read routes - require domains:read
+    app.get('/domains', requireApiKeyScopes(['domains:read']), (c) => c.json({ ok: true }));
+    app.get('/domains/:id', requireApiKeyScopes(['domains:read']), (c) => c.json({ ok: true }));
+    // Write routes - require domains:write
+    app.post('/domains', requireApiKeyScopes(['domains:write']), (c) => c.json({ ok: true }));
+    app.delete('/domains/:id', requireApiKeyScopes(['domains:write']), (c) =>
+      c.json({ ok: true }),
+    );
+    return app;
+  };
+
+  describe('read operations (domains:read)', () => {
+    it('should allow requests from legacy keys (no scopes)', async () => {
+      const app = createApp(null);
+      const res = await app.request('/domains');
+      expect(res.status).toBe(200);
+    });
+
+    it('should allow requests from keys with matching scopes', async () => {
+      const app = createApp(['domains:read']);
+      const res = await app.request('/domains');
+      expect(res.status).toBe(200);
+    });
+
+    it('should allow requests from keys with domains:read on single item', async () => {
+      const app = createApp(['domains:read']);
+      const res = await app.request('/domains/cd_123');
+      expect(res.status).toBe(200);
+    });
+
+    it('should deny requests from keys with wrong scopes (write-only key trying read)', async () => {
+      const app = createApp(['domains:write']);
+      const res = await app.request('/domains');
+      expect(res.status).toBe(403);
+      const json = (await res.json()) as { error: string; requiredScopes?: string[] };
+      expect(json.error).toBe('Forbidden');
+      expect(json.requiredScopes).toContain('domains:read');
+    });
+
+    it('should deny requests from keys with unrelated scopes', async () => {
+      const app = createApp(['endpoints:read']);
+      const res = await app.request('/domains');
+      expect(res.status).toBe(403);
+    });
+
+    it('should allow requests with empty scopes array (legacy behavior)', async () => {
+      const app = createApp([]);
+      const res = await app.request('/domains');
+      // Empty array is treated as legacy (no scopes)
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('write operations (domains:write)', () => {
+    it('should allow requests from legacy keys (no scopes)', async () => {
+      const app = createApp(null);
+      const res = await app.request('/domains', { method: 'POST' });
+      expect(res.status).toBe(200);
+    });
+
+    it('should allow requests from keys with domains:write scope', async () => {
+      const app = createApp(['domains:write']);
+      const res = await app.request('/domains', { method: 'POST' });
+      expect(res.status).toBe(200);
+    });
+
+    it('should deny requests from keys without domains:write', async () => {
+      const app = createApp(['domains:read']);
+      const res = await app.request('/domains', { method: 'POST' });
+      expect(res.status).toBe(403);
+    });
+
+    it('should allow delete with domains:write', async () => {
+      const app = createApp(['domains:write']);
+      const res = await app.request('/domains/cd_123', { method: 'DELETE' });
+      expect(res.status).toBe(200);
+    });
+
+    it('should deny delete without domains:write', async () => {
+      const app = createApp(['domains:read']);
+      const res = await app.request('/domains/cd_123', { method: 'DELETE' });
+      expect(res.status).toBe(403);
+    });
+  });
+});
+
+describe('tier gating for custom domains feature', () => {
+  /**
+   * Test that custom domains feature gating works correctly.
+   * Fighter Jet tier only should have access.
+   */
+  const createCustomDomainApp = (tierSlug: string) => {
+    const app = new Hono<{ Variables: { workspace: { tierSlug: string } } }>();
+    app.use('*', createMockAuthMiddleware(['domains:read', 'domains:write'], tierSlug));
+
+    // This simulates the tier check in custom-domains routes
+    app.get('/domains', async (c, next): Promise<Response> => {
+      const workspace = c.get('workspace') as { tierSlug: string };
+      const { getTierBySlug, isFeatureEnabled } = await import('@hookwing/shared');
+      const tier = getTierBySlug(workspace.tierSlug);
+
+      if (!tier || !isFeatureEnabled(tier, 'custom_domains')) {
+        return c.json(
+          {
+            error: 'Custom domains require Fighter Jet tier',
+            currentTier: workspace.tierSlug,
+            requiredTier: 'fighter-jet',
+          },
+          403,
+        );
+      }
+
+      await next();
+      return c.json({ ok: true });
+    });
+
+    return app;
+  };
+
+  it('should block custom domains for Paper Plane tier', async () => {
+    const app = createCustomDomainApp('paper-plane');
+    const res = await app.request('/domains');
+    expect(res.status).toBe(403);
+    const json = (await res.json()) as {
+      error: string;
+      currentTier?: string;
+      requiredTier?: string;
+    };
+    expect(json.error).toBe('Custom domains require Fighter Jet tier');
+    expect(json.currentTier).toBe('paper-plane');
+    expect(json.requiredTier).toBe('fighter-jet');
+  });
+
+  it('should block custom domains for Warbird tier', async () => {
+    const app = createCustomDomainApp('warbird');
+    const res = await app.request('/domains');
+    expect(res.status).toBe(403);
+    const json = (await res.json()) as {
+      error: string;
+      currentTier?: string;
+      requiredTier?: string;
+    };
+    expect(json.error).toBe('Custom domains require Fighter Jet tier');
+    expect(json.currentTier).toBe('warbird');
+    expect(json.requiredTier).toBe('fighter-jet');
+  });
+
+  it('should allow custom domains for Fighter Jet tier', async () => {
+    const app = createCustomDomainApp('fighter-jet');
+    const res = await app.request('/domains');
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('module exports', () => {
+  it('should export customDomainRoutes', async () => {
+    const mod = await import('../routes/custom-domains');
+    expect(mod.default).toBeDefined();
+  });
+});

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -3,6 +3,7 @@ import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import analyticsRoutes from './routes/analytics';
 import authRoutes from './routes/auth';
+import customDomainRoutes from './routes/custom-domains';
 import deadLetterRoutes from './routes/dead-letter';
 import deliveryRoutes from './routes/deliveries';
 import endpointRoutes from './routes/endpoints';
@@ -139,6 +140,9 @@ app.route('/v1/deliveries', deliveryRoutes);
 
 // Mount dead letter routes at /v1/dead-letter/* (authenticated)
 app.route('/v1/dead-letter', deadLetterRoutes);
+
+// Mount custom domain routes at /v1/domains/* (authenticated, Fighter Jet tier)
+app.route('/v1/domains', customDomainRoutes);
 
 // Mount playground routes at /v1/playground/* (no auth required)
 app.route('/v1/playground', playgroundRoutes);

--- a/packages/api/src/routes/custom-domains.ts
+++ b/packages/api/src/routes/custom-domains.ts
@@ -1,0 +1,173 @@
+import {
+  customDomains,
+  generateId,
+  getTierBySlug,
+  isFeatureEnabled,
+} from '@hookwing/shared';
+import { eq } from 'drizzle-orm';
+import { Hono } from 'hono';
+import { createDb } from '../db';
+import { authMiddleware, getWorkspace, requireApiKeyScopes } from '../middleware/auth';
+
+const customDomainRoutes = new Hono<{ Bindings: { DB: D1Database } }>();
+
+// All routes require auth
+customDomainRoutes.use('/*', authMiddleware);
+
+// ============================================================================
+// Tier check middleware - Fighter Jet only
+// ============================================================================
+
+async function requireCustomDomainsTier(c: any, next: () => Promise<void>) {
+  const workspace = getWorkspace(c);
+  const tier = getTierBySlug(workspace.tierSlug);
+
+  if (!tier || !isFeatureEnabled(tier, 'custom_domains')) {
+    return c.json(
+      {
+        error: 'Custom domains require Fighter Jet tier',
+        currentTier: workspace.tierSlug,
+        requiredTier: 'fighter-jet',
+      },
+      403,
+    );
+  }
+
+  await next();
+}
+
+customDomainRoutes.use('/*', requireCustomDomainsTier);
+
+// ============================================================================
+// POST /v1/domains — Register a custom domain
+// ============================================================================
+
+customDomainRoutes.post('/', requireApiKeyScopes(['domains:write']), async (c) => {
+  const workspace = getWorkspace(c);
+  const db = createDb(c.env.DB);
+  const body = await c.req.json();
+
+  const { domain } = body as { domain?: unknown };
+  if (!domain || typeof domain !== 'string') {
+    return c.json({ error: 'Domain is required' }, 400);
+  }
+
+  // Basic domain validation
+  const domainRegex = /^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+  if (!domainRegex.test(domain)) {
+    return c.json({ error: 'Invalid domain format' }, 400);
+  }
+
+  const now = Date.now();
+  const domainId = generateId('cd');
+
+  try {
+    await db.insert(customDomains).values({
+      id: domainId,
+      workspaceId: workspace.id,
+      domain,
+      status: 'pending',
+      verifiedAt: null,
+      createdAt: now,
+    });
+  } catch (error: any) {
+    if (error?.message?.includes('UNIQUE constraint failed') || error?.code === 'SQLITE_CONSTRAINT_UNIQUE') {
+      return c.json({ error: 'Domain already in use' }, 409);
+    }
+    throw error;
+  }
+
+  return c.json(
+    {
+      id: domainId,
+      workspaceId: workspace.id,
+      domain,
+      status: 'pending',
+      verifiedAt: null,
+      createdAt: now,
+    },
+    201,
+  );
+});
+
+// ============================================================================
+// GET /v1/domains — List workspace custom domains
+// ============================================================================
+
+customDomainRoutes.get('/', requireApiKeyScopes(['domains:read']), async (c) => {
+  const workspace = getWorkspace(c);
+  const db = createDb(c.env.DB);
+
+  const domainList = await db
+    .select()
+    .from(customDomains)
+    .where(eq(customDomains.workspaceId, workspace.id));
+
+  return c.json({
+    domains: domainList.map((d) => ({
+      id: d.id,
+      workspaceId: d.workspaceId,
+      domain: d.domain,
+      status: d.status,
+      verifiedAt: d.verifiedAt,
+      createdAt: d.createdAt,
+    })),
+  });
+});
+
+// ============================================================================
+// GET /v1/domains/:id — Get single domain
+// ============================================================================
+
+customDomainRoutes.get('/:id', requireApiKeyScopes(['domains:read']), async (c) => {
+  const workspace = getWorkspace(c);
+  const db = createDb(c.env.DB);
+  const domainId = c.req.param('id');
+
+  const domain = await db
+    .select()
+    .from(customDomains)
+    .where(eq(customDomains.id, domainId))
+    .limit(1)
+    .then((rows) => rows[0]);
+
+  if (!domain || domain.workspaceId !== workspace.id) {
+    return c.json({ error: 'Domain not found' }, 404);
+  }
+
+  return c.json({
+    id: domain.id,
+    workspaceId: domain.workspaceId,
+    domain: domain.domain,
+    status: domain.status,
+    verifiedAt: domain.verifiedAt,
+    createdAt: domain.createdAt,
+  });
+});
+
+// ============================================================================
+// DELETE /v1/domains/:id — Remove custom domain
+// ============================================================================
+
+customDomainRoutes.delete('/:id', requireApiKeyScopes(['domains:write']), async (c) => {
+  const workspace = getWorkspace(c);
+  const db = createDb(c.env.DB);
+  const domainId = c.req.param('id');
+
+  const existing = await db
+    .select()
+    .from(customDomains)
+    .where(eq(customDomains.id, domainId))
+    .limit(1)
+    .then((rows) => rows[0]);
+
+  if (!existing || existing.workspaceId !== workspace.id) {
+    return c.json({ error: 'Domain not found' }, 404);
+  }
+
+  await db.delete(customDomains).where(eq(customDomains.id, domainId));
+
+  return c.status(204);
+});
+
+export default customDomainRoutes;

--- a/packages/shared/src/db/index.ts
+++ b/packages/shared/src/db/index.ts
@@ -23,4 +23,7 @@ export {
   deadLetterItems,
   type DeadLetterItem,
   type NewDeadLetterItem,
+  customDomains,
+  type CustomDomain,
+  type NewCustomDomain,
 } from './schema';

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -71,6 +71,7 @@ export const endpoints = sqliteTable(
     fanoutEnabled: integer('fanout_enabled').notNull().default(1), // Opt-out of receiving fan-out events
     rateLimitPerSecond: integer('rate_limit_per_second'),
     metadata: text('metadata'), // JSON object
+    customHeaders: text('custom_headers'), // JSON object of { "Header-Name": "value" }
     createdAt: integer('created_at').notNull(),
     updatedAt: integer('updated_at').notNull(),
   },
@@ -255,3 +256,30 @@ export const deadLetterItems = sqliteTable(
 
 export type DeadLetterItem = typeof deadLetterItems.$inferSelect;
 export type NewDeadLetterItem = typeof deadLetterItems.$inferInsert;
+
+// ============================================================================
+// Custom Domains - custom domains for webhook ingest URLs
+// ============================================================================
+
+export const customDomains = sqliteTable(
+  'custom_domains',
+  {
+    id: text('id').primaryKey(),
+    workspaceId: text('workspace_id')
+      .notNull()
+      .references(() => workspaces.id, { onDelete: 'cascade' }),
+    domain: text('domain').notNull(),
+    status: text('status').notNull().default('pending'), // pending, verified, failed
+    verifiedAt: integer('verified_at'),
+    createdAt: integer('created_at').notNull(),
+  },
+  (table) => {
+    return {
+      workspaceIdIdx: index('custom_domains_workspace_id_idx').on(table.workspaceId),
+      domainIdx: uniqueIndex('custom_domains_domain_idx').on(table.domain),
+    };
+  },
+);
+
+export type CustomDomain = typeof customDomains.$inferSelect;
+export type NewCustomDomain = typeof customDomains.$inferInsert;


### PR DESCRIPTION
Custom domain registration for webhook ingest URLs. CRUD routes at /v1/domains, D1 migration, tier-gated to Fighter Jet. DNS verification deferred to follow-up.