### PR TITLE
feat(PROD-158): priority delivery queue for higher tiers

### DIFF
--- a/migrations/0011_add_delivery_priority.sql
+++ b/migrations/0011_add_delivery_priority.sql
@@ -1,0 +1,5 @@
+-- Migration: 0011_add_delivery_priority.sql
+-- Description: Add priority column to deliveries table for tier-based priority processing
+-- Date: 2026-03-19
+
+ALTER TABLE deliveries ADD COLUMN priority INTEGER NOT NULL DEFAULT 0;

--- a/packages/api/src/routes/ingest.ts
+++ b/packages/api/src/routes/ingest.ts
@@ -3,6 +3,7 @@ import {
   endpoints,
   generateId,
   getTierBySlug,
+  isFeatureEnabled,
   verifyWebhookSignature,
   workspaces,
 } from '@hookwing/shared';
@@ -141,12 +142,22 @@ ingestRoutes.post('/:endpointId', async (c) => {
     status: 'pending',
   });
 
+  // Calculate priority based on workspace tier (Warbird+ get priority 1)
+  let priority = 0;
+  if (workspace) {
+    const tier = getTierBySlug(workspace.tierSlug);
+    if (tier && isFeatureEnabled(tier, 'priority_delivery')) {
+      priority = 1;
+    }
+  }
+
   // 8. Fan-out to all eligible endpoints
   const fanoutResult = await fanoutEvent(
     db,
     c.env.DELIVERY_QUEUE,
     { id: eventId, workspaceId: endpoint.workspaceId, eventType },
     endpointId,
+    priority,
   );
 
   // 9. Track usage (fire-and-forget, don't fail the request)

--- a/packages/api/src/services/fanout.ts
+++ b/packages/api/src/services/fanout.ts
@@ -44,6 +44,7 @@ function shouldEndpointReceiveEvent(endpoint: Endpoint, eventType: string): bool
  * @param queue - Optional Cloudflare Queue for async delivery
  * @param event - Event details (id, workspaceId, eventType)
  * @param receivingEndpointId - The endpoint that originally received the webhook (optional for replay)
+ * @param priority - Priority level for delivery (higher = more priority, Warbird+ get 1)
  * @returns FanoutResult with delivery details
  */
 export async function fanoutEvent(
@@ -51,6 +52,7 @@ export async function fanoutEvent(
   queue: Queue | undefined,
   event: { id: string; workspaceId: string; eventType: string },
   receivingEndpointId?: string,
+  priority = 0,
 ): Promise<FanoutResult> {
   const { id: eventId, workspaceId, eventType } = event;
 
@@ -95,6 +97,7 @@ export async function fanoutEvent(
       workspaceId,
       attemptNumber: 1,
       status: 'pending',
+      priority,
       createdAt: now,
     });
 
@@ -106,6 +109,7 @@ export async function fanoutEvent(
         endpointId: endpoint.id,
         workspaceId,
         attempt: 1,
+        priority,
       });
     }
 
@@ -129,6 +133,7 @@ export async function fanoutEvent(
         workspaceId,
         attemptNumber: 1,
         status: 'pending',
+        priority,
         createdAt: now,
       });
 
@@ -139,6 +144,7 @@ export async function fanoutEvent(
           endpointId: receivingEndpointId,
           workspaceId,
           attempt: 1,
+          priority,
         });
       }
 

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -72,6 +72,7 @@ export const endpoints = sqliteTable(
     rateLimitPerSecond: integer('rate_limit_per_second'),
     metadata: text('metadata'), // JSON object
     customHeaders: text('custom_headers'), // JSON object of custom headers
+    ipWhitelist: text('ip_whitelist'), // JSON array of allowed IPs/CIDRs
     createdAt: integer('created_at').notNull(),
     updatedAt: integer('updated_at').notNull(),
   },
@@ -137,6 +138,7 @@ export const deliveries = sqliteTable(
       .references(() => workspaces.id, { onDelete: 'cascade' }),
     attemptNumber: integer('attempt_number').notNull().default(1),
     status: text('status').notNull().default('pending'), // pending, success, failed, retrying
+    priority: integer('priority').notNull().default(0), // Higher = more priority (Warbird+ get priority 1)
     responseStatusCode: integer('response_status_code'),
     responseBody: text('response_body'), // First 1KB
     responseHeaders: text('response_headers'), // JSON


### PR DESCRIPTION
Priority field added to deliveries. Warbird+ workspaces (priority_delivery: true) get priority=1. Fanout and ingest updated to pass priority. Migration included.