### PR TITLE
fix(PROD-159): fix docs page blank content — missing patterns.css

### DIFF
--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -21,6 +21,7 @@
   <link rel="stylesheet" href="/styles/tokens.css?v=7" />
   <link rel="stylesheet" href="/styles/base.css?v=7" />
   <link rel="stylesheet" href="/styles/components.css?v=7" />
+  <link rel="stylesheet" href="/styles/patterns.css?v=9" />
   <style>
     .docs-layout { display: grid; grid-template-columns: 220px 1fr; gap: var(--space-8); max-width: 1100px; margin: 0 auto; padding: var(--space-6) var(--space-5); }
     .docs-sidebar { position: sticky; top: var(--space-6); align-self: start; }


### PR DESCRIPTION
The /docs/ page was missing the patterns.css stylesheet, causing content to be invisible. Added the missing link tag.