### PR TITLE
fix: Brenda brand audit March 25 — 3 major + 8 minor fixes

### DIFF
--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -240,9 +240,9 @@ function generateTOTP(secret: string, counter: number): string {
   const buffer = Buffer.alloc(8);
   buffer.writeBigUInt64BE(BigInt(counter));
   const hmac = createHmac('sha1', base32Decode(secret)).update(buffer).digest();
-  const offset = hmac[hmac.length - 1]! & 0xf;
+  const offset = (hmac[hmac.length - 1] ?? 0) & 0xf;
   const code =
-    ((hmac[offset]! & 0x7f) << 24) |
+    (((hmac[offset] ?? 0) & 0x7f) << 24) |
     ((hmac[offset + 1] ?? 0) << 16) |
     ((hmac[offset + 2] ?? 0) << 8) |
     (hmac[offset + 3] ?? 0);

--- a/website/blog/authors/hookwing-engineering/index.html
+++ b/website/blog/authors/hookwing-engineering/index.html
@@ -84,6 +84,48 @@
       </div>
     </section>
     <section class="grid cards" style="margin-top:var(--space-4);"><article class="card" style="display:flex;flex-direction:column;">
+    <a class="card-hero" href="/blog/debugging-webhooks/"><img src="/assets/blog/optimized/generated/debugging-webhooks-hero.webp" alt="Webhook event streams flowing through a delivery pipeline, with failure points highlighted" loading="lazy" decoding="async" /></a>
+    <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/debugging-webhooks/" style="color:var(--color-text);">How to debug webhooks (without losing your mind)</a></h3>
+    <div class="meta" style="margin-bottom:var(--space-2);">
+      <span>2026-03-24</span>
+      <span>•</span>
+      <span>7 min read</span>
+      <span>•</span>
+      <a href="/blog/categories/operations/">Operations</a>
+    </div>
+    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
+    <p style="flex:1;margin-bottom:var(--space-3);">Webhooks fail silently, fire asynchronously, and vanish before you can inspect them. Here&#39;s a practical system for debugging webhook integrations in dev and production.</p>
+    <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/debugging/">debugging</a> <a class="chip" href="/blog/tags/developer-experience/">developer-experience</a></div>
+  </article>
+<article class="card" style="display:flex;flex-direction:column;">
+    <a class="card-hero" href="/blog/mcp-server-webhook-tool/"><img src="/assets/blog/generated/mcp-server-webhook-tool-hero.png" alt="An MCP server exposing a webhook tool that lets an AI agent register an endpoint and receive async events from external systems" loading="lazy" decoding="async" /></a>
+    <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/mcp-server-webhook-tool/" style="color:var(--color-text);">How to Add a Webhook Tool to Your MCP Server</a></h3>
+    <div class="meta" style="margin-bottom:var(--space-2);">
+      <span>2026-03-21</span>
+      <span>•</span>
+      <span>7 min read</span>
+      <span>•</span>
+      <a href="/blog/categories/tutorials/">Tutorials</a>
+    </div>
+    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
+    <p style="flex:1;margin-bottom:var(--space-3);">MCP tools are synchronous, but real-world agent workflows run on async events. Here&#39;s how to add a webhook tool to your MCP server so agents can listen without polling.</p>
+    <div style="margin-top:auto;"><a class="chip" href="/blog/tags/mcp/">mcp</a> <a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/ai-agents/">ai-agents</a></div>
+  </article>
+<article class="card" style="display:flex;flex-direction:column;">
+    <a class="card-hero" href="/blog/webhook-rate-limiting/"><img src="/assets/blog/generated/webhook-rate-limiting-hero.png" alt="Webhook traffic flowing through a rate limiter with a queue buffer absorbing burst load" loading="lazy" decoding="async" /></a>
+    <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/webhook-rate-limiting/" style="color:var(--color-text);">Webhook Rate Limiting: How to Handle It as a Sender and Receiver</a></h3>
+    <div class="meta" style="margin-bottom:var(--space-2);">
+      <span>2026-03-20</span>
+      <span>•</span>
+      <span>7 min read</span>
+      <span>•</span>
+      <a href="/blog/categories/reliability/">Reliability</a>
+    </div>
+    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
+    <p style="flex:1;margin-bottom:var(--space-3);">Rate limits are a two-sided problem in webhook systems. Here&#39;s how to handle 429s as a sender and protect your endpoint as a receiver, with practical patterns and code.</p>
+    <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/rate-limiting/">rate-limiting</a> <a class="chip" href="/blog/tags/reliability/">reliability</a></div>
+  </article>
+<article class="card" style="display:flex;flex-direction:column;">
     <a class="card-hero" href="/blog/webhook-fan-out/"><img src="/assets/blog/generated/retry-hero.png" alt="Dark aviation-themed illustration showing a single webhook event branching out to multiple endpoint nodes in parallel" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/webhook-fan-out/" style="color:var(--color-text);">Webhook Fan-Out: How to Deliver One Event to Many Endpoints</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
@@ -126,6 +168,20 @@
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/reliability/">reliability</a> <a class="chip" href="/blog/tags/dead-letter-queue/">dead-letter-queue</a></div>
   </article>
 <article class="card" style="display:flex;flex-direction:column;">
+    <a class="card-hero" href="/blog/webhook-endpoint-for-ai-agents/"><img src="/assets/blog/generated/webhook-endpoint-ai-agents-hero.png" alt="Webhook payloads arriving at an AI agent endpoint from multiple event sources" loading="lazy" decoding="async" /></a>
+    <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/webhook-endpoint-for-ai-agents/" style="color:var(--color-text);">How to Give Your AI Agent a Webhook Endpoint</a></h3>
+    <div class="meta" style="margin-bottom:var(--space-2);">
+      <span>2026-03-08</span>
+      <span>•</span>
+      <span>6 min read</span>
+      <span>•</span>
+      <a href="/blog/categories/tutorials/">Tutorials</a>
+    </div>
+    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
+    <p style="flex:1;margin-bottom:var(--space-3);">Give your AI agent a webhook endpoint in minutes: one API call, five-line verification, and a simple routing loop. No dashboard, no boilerplate.</p>
+    <div style="margin-top:auto;"><a class="chip" href="/blog/tags/ai-agents/">ai-agents</a> <a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/tutorials/">tutorials</a></div>
+  </article>
+<article class="card" style="display:flex;flex-direction:column;">
     <a class="card-hero" href="/blog/webhook-signature-verification/"><img src="/assets/blog/generated/webhook-signature-verification-hero.png" alt="HMAC signature verification flow between a webhook sender and receiver" loading="lazy" decoding="async" /></a>
     <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/webhook-signature-verification/" style="color:var(--color-text);">How to Verify Webhook Signatures (and Why Teams Skip It)</a></h3>
     <div class="meta" style="margin-bottom:var(--space-2);">
@@ -138,6 +194,20 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Webhook signature verification in plain terms: how HMAC-SHA256 works, a 10-line implementation, and the three mistakes that break it silently.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/security/">security</a> <a class="chip" href="/blog/tags/reliability/">reliability</a></div>
+  </article>
+<article class="card" style="display:flex;flex-direction:column;">
+    <a class="card-hero" href="/blog/webhooks-for-ai-agents/"><img src="/assets/blog/optimized/generated/webhooks-for-ai-agents-hero.webp" alt="An AI agent receiving real-time webhook event streams" loading="lazy" decoding="async" /></a>
+    <h3 style="flex:0;margin-bottom:var(--space-2);"><a href="/blog/webhooks-for-ai-agents/" style="color:var(--color-text);">Webhooks Are How AI Agents Listen to the World</a></h3>
+    <div class="meta" style="margin-bottom:var(--space-2);">
+      <span>2026-03-04</span>
+      <span>•</span>
+      <span>5 min read</span>
+      <span>•</span>
+      <a href="/blog/categories/tutorials/">tutorials</a>
+    </div>
+    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
+    <p style="flex:1;margin-bottom:var(--space-3);">AI agents can&#39;t poll the world. Webhooks give them real-time awareness. Here&#39;s how agents use webhooks and what to look for in a webhook platform.</p>
+    <div style="margin-top:auto;"></div>
   </article>
 <article class="card" style="display:flex;flex-direction:column;">
     <a class="card-hero" href="/blog/webhook-monitoring-observability/"><img src="/assets/blog/generated/monitoring-hero.png" alt="Webhook monitoring dashboard showing delivery rate, latency, and error metrics" loading="lazy" decoding="async" /></a>

--- a/website/blog/categories/operations/index.html
+++ b/website/blog/categories/operations/index.html
@@ -87,7 +87,7 @@
       <span>•</span>
       <a href="/blog/categories/operations/">Operations</a>
     </div>
-    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Alex Morgan</div>
+    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Webhooks fail silently, fire asynchronously, and vanish before you can inspect them. Here&#39;s a practical system for debugging webhook integrations in dev and production.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/debugging/">debugging</a> <a class="chip" href="/blog/tags/developer-experience/">developer-experience</a></div>
   </article>

--- a/website/blog/categories/reliability/index.html
+++ b/website/blog/categories/reliability/index.html
@@ -87,7 +87,7 @@
       <span>•</span>
       <a href="/blog/categories/reliability/">Reliability</a>
     </div>
-    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Marcus Chen</div>
+    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Rate limits are a two-sided problem in webhook systems. Here&#39;s how to handle 429s as a sender and protect your endpoint as a receiver, with practical patterns and code.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/rate-limiting/">rate-limiting</a> <a class="chip" href="/blog/tags/reliability/">reliability</a></div>
   </article>

--- a/website/blog/categories/tutorials/index.html
+++ b/website/blog/categories/tutorials/index.html
@@ -87,7 +87,7 @@
       <span>•</span>
       <a href="/blog/categories/tutorials/">Tutorials</a>
     </div>
-    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Alex Morgan</div>
+    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">MCP tools are synchronous, but real-world agent workflows run on async events. Here&#39;s how to add a webhook tool to your MCP server so agents can listen without polling.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/mcp/">mcp</a> <a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/ai-agents/">ai-agents</a></div>
   </article>
@@ -101,7 +101,7 @@
       <span>•</span>
       <a href="/blog/categories/tutorials/">Tutorials</a>
     </div>
-    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Team</div>
+    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Give your AI agent a webhook endpoint in minutes: one API call, five-line verification, and a simple routing loop. No dashboard, no boilerplate.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/ai-agents/">ai-agents</a> <a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/tutorials/">tutorials</a></div>
   </article>
@@ -115,7 +115,7 @@
       <span>•</span>
       <a href="/blog/categories/tutorials/">tutorials</a>
     </div>
-    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Team</div>
+    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">AI agents can&#39;t poll the world. Webhooks give them real-time awareness. Here&#39;s how agents use webhooks and what to look for in a webhook platform.</p>
     <div style="margin-top:auto;"></div>
   </article></section>

--- a/website/blog/debugging-webhooks/index.html
+++ b/website/blog/debugging-webhooks/index.html
@@ -15,7 +15,7 @@
   <meta name="twitter:description" content="Webhooks fail silently, fire asynchronously, and vanish before you can inspect them. Here&#39;s a practical system for debugging webhook integrations in dev and production." />
   <meta property="og:image" content="https://dev.hookwing.com/assets/blog/optimized/generated/debugging-webhooks-hero.webp" />
   <meta name="twitter:image" content="https://dev.hookwing.com/assets/blog/optimized/generated/debugging-webhooks-hero.webp" />
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"How to debug webhooks (without losing your mind)","description":"Webhooks fail silently, fire asynchronously, and vanish before you can inspect them. Here's a practical system for debugging webhook integrations in dev and production.","datePublished":"2026-03-24T00:00:00.000Z","dateModified":"2026-03-24T00:00:00.000Z","author":{"@type":"Person","name":"Alex Morgan"},"image":["https://dev.hookwing.com/assets/blog/optimized/generated/debugging-webhooks-hero.webp"],"mainEntityOfPage":"https://dev.hookwing.com/blog/debugging-webhooks/"}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"How to debug webhooks (without losing your mind)","description":"Webhooks fail silently, fire asynchronously, and vanish before you can inspect them. Here's a practical system for debugging webhook integrations in dev and production.","datePublished":"2026-03-24T00:00:00.000Z","dateModified":"2026-03-24T00:00:00.000Z","author":{"@type":"Person","name":"Hookwing Engineering"},"image":["https://dev.hookwing.com/assets/blog/optimized/generated/debugging-webhooks-hero.webp"],"mainEntityOfPage":"https://dev.hookwing.com/blog/debugging-webhooks/"}</script>
   <title>How to debug webhooks (without losing your mind) | Hookwing</title>
   <link rel="stylesheet" href="/styles/tokens.css?v=7" />
   <link rel="stylesheet" href="/styles/base.css?v=7" />
@@ -92,10 +92,10 @@
     </header>
     <div class="post-meta-stack" aria-label="Post metadata">
       <section class="post-author">
-        <img class="author-avatar" src="/assets/team/avatars/alex-morgan.png" alt="Alex Morgan avatar" />
+        <img class="author-avatar" src="/assets/logos/logo-03-air-route-badge.svg" alt="Hookwing Engineering avatar" />
         <div>
-          <div class="author-name"><a href="/blog/authors/alex-morgan/">Alex Morgan</a></div>
-          <div class="meta" style="margin:4px 0 0">Developer Advocate</div>
+          <div class="author-name"><a href="/blog/authors/hookwing-engineering/">Hookwing Engineering</a></div>
+          <div class="meta" style="margin:4px 0 0">Engineering</div>
         </div>
       </section>
       <div class="post-dates">

--- a/website/blog/index.html
+++ b/website/blog/index.html
@@ -95,7 +95,7 @@
       <span>•</span>
       <a href="/blog/categories/operations/">Operations</a>
     </div>
-    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Alex Morgan</div>
+    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Webhooks fail silently, fire asynchronously, and vanish before you can inspect them. Here&#39;s a practical system for debugging webhook integrations in dev and production.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/debugging/">debugging</a> <a class="chip" href="/blog/tags/developer-experience/">developer-experience</a></div>
   </article></div>
@@ -109,7 +109,7 @@
       <span>•</span>
       <a href="/blog/categories/tutorials/">Tutorials</a>
     </div>
-    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Alex Morgan</div>
+    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">MCP tools are synchronous, but real-world agent workflows run on async events. Here&#39;s how to add a webhook tool to your MCP server so agents can listen without polling.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/mcp/">mcp</a> <a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/ai-agents/">ai-agents</a></div>
   </article></div>
@@ -123,7 +123,7 @@
       <span>•</span>
       <a href="/blog/categories/reliability/">Reliability</a>
     </div>
-    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Marcus Chen</div>
+    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Rate limits are a two-sided problem in webhook systems. Here&#39;s how to handle 429s as a sender and protect your endpoint as a receiver, with practical patterns and code.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/rate-limiting/">rate-limiting</a> <a class="chip" href="/blog/tags/reliability/">reliability</a></div>
   </article></div>
@@ -179,7 +179,7 @@
       <span>•</span>
       <a href="/blog/categories/tutorials/">Tutorials</a>
     </div>
-    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Team</div>
+    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Give your AI agent a webhook endpoint in minutes: one API call, five-line verification, and a simple routing loop. No dashboard, no boilerplate.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/ai-agents/">ai-agents</a> <a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/tutorials/">tutorials</a></div>
   </article></div>
@@ -207,7 +207,7 @@
       <span>•</span>
       <a href="/blog/categories/tutorials/">tutorials</a>
     </div>
-    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Team</div>
+    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">AI agents can&#39;t poll the world. Webhooks give them real-time awareness. Here&#39;s how agents use webhooks and what to look for in a webhook platform.</p>
     <div style="margin-top:auto;"></div>
   </article></div>

--- a/website/blog/mcp-server-webhook-tool/index.html
+++ b/website/blog/mcp-server-webhook-tool/index.html
@@ -15,7 +15,7 @@
   <meta name="twitter:description" content="MCP tools are synchronous, but real-world agent workflows run on async events. Here&#39;s how to add a webhook tool to your MCP server so agents can listen without polling." />
   <meta property="og:image" content="https://dev.hookwing.com/assets/blog/generated/mcp-server-webhook-tool-hero.png" />
   <meta name="twitter:image" content="https://dev.hookwing.com/assets/blog/generated/mcp-server-webhook-tool-hero.png" />
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"How to Add a Webhook Tool to Your MCP Server","description":"MCP tools are synchronous, but real-world agent workflows run on async events. Here's how to add a webhook tool to your MCP server so agents can listen without polling.","datePublished":"2026-03-21T00:00:00.000Z","dateModified":"2026-03-21T00:00:00.000Z","author":{"@type":"Person","name":"Alex Morgan"},"image":["https://dev.hookwing.com/assets/blog/generated/mcp-server-webhook-tool-hero.png"],"mainEntityOfPage":"https://dev.hookwing.com/blog/mcp-server-webhook-tool/"}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"How to Add a Webhook Tool to Your MCP Server","description":"MCP tools are synchronous, but real-world agent workflows run on async events. Here's how to add a webhook tool to your MCP server so agents can listen without polling.","datePublished":"2026-03-21T00:00:00.000Z","dateModified":"2026-03-21T00:00:00.000Z","author":{"@type":"Person","name":"Hookwing Engineering"},"image":["https://dev.hookwing.com/assets/blog/generated/mcp-server-webhook-tool-hero.png"],"mainEntityOfPage":"https://dev.hookwing.com/blog/mcp-server-webhook-tool/"}</script>
   <title>How to Add a Webhook Tool to Your MCP Server | Hookwing</title>
   <link rel="stylesheet" href="/styles/tokens.css?v=7" />
   <link rel="stylesheet" href="/styles/base.css?v=7" />
@@ -92,10 +92,10 @@
     </header>
     <div class="post-meta-stack" aria-label="Post metadata">
       <section class="post-author">
-        <img class="author-avatar" src="/assets/team/avatars/alex-morgan.png" alt="Alex Morgan avatar" />
+        <img class="author-avatar" src="/assets/logos/logo-03-air-route-badge.svg" alt="Hookwing Engineering avatar" />
         <div>
-          <div class="author-name"><a href="/blog/authors/alex-morgan/">Alex Morgan</a></div>
-          <div class="meta" style="margin:4px 0 0">Developer Advocate</div>
+          <div class="author-name"><a href="/blog/authors/hookwing-engineering/">Hookwing Engineering</a></div>
+          <div class="meta" style="margin:4px 0 0">Engineering</div>
         </div>
       </section>
       <div class="post-dates">

--- a/website/blog/tags/ai-agents/index.html
+++ b/website/blog/tags/ai-agents/index.html
@@ -87,7 +87,7 @@
       <span>•</span>
       <a href="/blog/categories/tutorials/">Tutorials</a>
     </div>
-    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Alex Morgan</div>
+    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">MCP tools are synchronous, but real-world agent workflows run on async events. Here&#39;s how to add a webhook tool to your MCP server so agents can listen without polling.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/mcp/">mcp</a> <a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/ai-agents/">ai-agents</a></div>
   </article>
@@ -101,7 +101,7 @@
       <span>•</span>
       <a href="/blog/categories/tutorials/">Tutorials</a>
     </div>
-    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Team</div>
+    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Give your AI agent a webhook endpoint in minutes: one API call, five-line verification, and a simple routing loop. No dashboard, no boilerplate.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/ai-agents/">ai-agents</a> <a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/tutorials/">tutorials</a></div>
   </article></section>

--- a/website/blog/tags/async/index.html
+++ b/website/blog/tags/async/index.html
@@ -87,7 +87,7 @@
       <span>•</span>
       <a href="/blog/categories/tutorials/">Tutorials</a>
     </div>
-    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Alex Morgan</div>
+    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">MCP tools are synchronous, but real-world agent workflows run on async events. Here&#39;s how to add a webhook tool to your MCP server so agents can listen without polling.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/mcp/">mcp</a> <a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/ai-agents/">ai-agents</a></div>
   </article></section>

--- a/website/blog/tags/backoff/index.html
+++ b/website/blog/tags/backoff/index.html
@@ -87,7 +87,7 @@
       <span>•</span>
       <a href="/blog/categories/reliability/">Reliability</a>
     </div>
-    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Marcus Chen</div>
+    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Rate limits are a two-sided problem in webhook systems. Here&#39;s how to handle 429s as a sender and protect your endpoint as a receiver, with practical patterns and code.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/rate-limiting/">rate-limiting</a> <a class="chip" href="/blog/tags/reliability/">reliability</a></div>
   </article></section>

--- a/website/blog/tags/debugging/index.html
+++ b/website/blog/tags/debugging/index.html
@@ -87,7 +87,7 @@
       <span>•</span>
       <a href="/blog/categories/operations/">Operations</a>
     </div>
-    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Alex Morgan</div>
+    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Webhooks fail silently, fire asynchronously, and vanish before you can inspect them. Here&#39;s a practical system for debugging webhook integrations in dev and production.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/debugging/">debugging</a> <a class="chip" href="/blog/tags/developer-experience/">developer-experience</a></div>
   </article></section>

--- a/website/blog/tags/developer-experience/index.html
+++ b/website/blog/tags/developer-experience/index.html
@@ -87,7 +87,7 @@
       <span>•</span>
       <a href="/blog/categories/operations/">Operations</a>
     </div>
-    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Alex Morgan</div>
+    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Webhooks fail silently, fire asynchronously, and vanish before you can inspect them. Here&#39;s a practical system for debugging webhook integrations in dev and production.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/debugging/">debugging</a> <a class="chip" href="/blog/tags/developer-experience/">developer-experience</a></div>
   </article></section>

--- a/website/blog/tags/getting-started/index.html
+++ b/website/blog/tags/getting-started/index.html
@@ -87,7 +87,7 @@
       <span>•</span>
       <a href="/blog/categories/tutorials/">Tutorials</a>
     </div>
-    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Team</div>
+    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Give your AI agent a webhook endpoint in minutes: one API call, five-line verification, and a simple routing loop. No dashboard, no boilerplate.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/ai-agents/">ai-agents</a> <a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/tutorials/">tutorials</a></div>
   </article></section>

--- a/website/blog/tags/mcp/index.html
+++ b/website/blog/tags/mcp/index.html
@@ -87,7 +87,7 @@
       <span>•</span>
       <a href="/blog/categories/tutorials/">Tutorials</a>
     </div>
-    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Alex Morgan</div>
+    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">MCP tools are synchronous, but real-world agent workflows run on async events. Here&#39;s how to add a webhook tool to your MCP server so agents can listen without polling.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/mcp/">mcp</a> <a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/ai-agents/">ai-agents</a></div>
   </article></section>

--- a/website/blog/tags/observability/index.html
+++ b/website/blog/tags/observability/index.html
@@ -87,7 +87,7 @@
       <span>•</span>
       <a href="/blog/categories/operations/">Operations</a>
     </div>
-    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Alex Morgan</div>
+    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Webhooks fail silently, fire asynchronously, and vanish before you can inspect them. Here&#39;s a practical system for debugging webhook integrations in dev and production.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/debugging/">debugging</a> <a class="chip" href="/blog/tags/developer-experience/">developer-experience</a></div>
   </article>

--- a/website/blog/tags/openclaw/index.html
+++ b/website/blog/tags/openclaw/index.html
@@ -87,7 +87,7 @@
       <span>•</span>
       <a href="/blog/categories/tutorials/">Tutorials</a>
     </div>
-    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Team</div>
+    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Give your AI agent a webhook endpoint in minutes: one API call, five-line verification, and a simple routing loop. No dashboard, no boilerplate.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/ai-agents/">ai-agents</a> <a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/tutorials/">tutorials</a></div>
   </article></section>

--- a/website/blog/tags/rate-limiting/index.html
+++ b/website/blog/tags/rate-limiting/index.html
@@ -87,7 +87,7 @@
       <span>•</span>
       <a href="/blog/categories/reliability/">Reliability</a>
     </div>
-    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Marcus Chen</div>
+    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Rate limits are a two-sided problem in webhook systems. Here&#39;s how to handle 429s as a sender and protect your endpoint as a receiver, with practical patterns and code.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/rate-limiting/">rate-limiting</a> <a class="chip" href="/blog/tags/reliability/">reliability</a></div>
   </article></section>

--- a/website/blog/tags/reliability/index.html
+++ b/website/blog/tags/reliability/index.html
@@ -87,7 +87,7 @@
       <span>•</span>
       <a href="/blog/categories/reliability/">Reliability</a>
     </div>
-    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Marcus Chen</div>
+    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Rate limits are a two-sided problem in webhook systems. Here&#39;s how to handle 429s as a sender and protect your endpoint as a receiver, with practical patterns and code.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/rate-limiting/">rate-limiting</a> <a class="chip" href="/blog/tags/reliability/">reliability</a></div>
   </article>

--- a/website/blog/tags/retries/index.html
+++ b/website/blog/tags/retries/index.html
@@ -87,7 +87,7 @@
       <span>•</span>
       <a href="/blog/categories/reliability/">Reliability</a>
     </div>
-    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Marcus Chen</div>
+    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Rate limits are a two-sided problem in webhook systems. Here&#39;s how to handle 429s as a sender and protect your endpoint as a receiver, with practical patterns and code.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/rate-limiting/">rate-limiting</a> <a class="chip" href="/blog/tags/reliability/">reliability</a></div>
   </article>

--- a/website/blog/tags/testing/index.html
+++ b/website/blog/tags/testing/index.html
@@ -87,7 +87,7 @@
       <span>•</span>
       <a href="/blog/categories/operations/">Operations</a>
     </div>
-    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Alex Morgan</div>
+    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Webhooks fail silently, fire asynchronously, and vanish before you can inspect them. Here&#39;s a practical system for debugging webhook integrations in dev and production.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/debugging/">debugging</a> <a class="chip" href="/blog/tags/developer-experience/">developer-experience</a></div>
   </article></section>

--- a/website/blog/tags/tutorials/index.html
+++ b/website/blog/tags/tutorials/index.html
@@ -87,7 +87,7 @@
       <span>•</span>
       <a href="/blog/categories/tutorials/">Tutorials</a>
     </div>
-    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Alex Morgan</div>
+    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">MCP tools are synchronous, but real-world agent workflows run on async events. Here&#39;s how to add a webhook tool to your MCP server so agents can listen without polling.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/mcp/">mcp</a> <a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/ai-agents/">ai-agents</a></div>
   </article>
@@ -101,7 +101,7 @@
       <span>•</span>
       <a href="/blog/categories/tutorials/">Tutorials</a>
     </div>
-    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Team</div>
+    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Give your AI agent a webhook endpoint in minutes: one API call, five-line verification, and a simple routing loop. No dashboard, no boilerplate.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/ai-agents/">ai-agents</a> <a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/tutorials/">tutorials</a></div>
   </article></section>

--- a/website/blog/tags/webhooks/index.html
+++ b/website/blog/tags/webhooks/index.html
@@ -87,7 +87,7 @@
       <span>•</span>
       <a href="/blog/categories/operations/">Operations</a>
     </div>
-    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Alex Morgan</div>
+    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Webhooks fail silently, fire asynchronously, and vanish before you can inspect them. Here&#39;s a practical system for debugging webhook integrations in dev and production.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/debugging/">debugging</a> <a class="chip" href="/blog/tags/developer-experience/">developer-experience</a></div>
   </article>
@@ -101,7 +101,7 @@
       <span>•</span>
       <a href="/blog/categories/tutorials/">Tutorials</a>
     </div>
-    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Alex Morgan</div>
+    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">MCP tools are synchronous, but real-world agent workflows run on async events. Here&#39;s how to add a webhook tool to your MCP server so agents can listen without polling.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/mcp/">mcp</a> <a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/ai-agents/">ai-agents</a></div>
   </article>
@@ -115,7 +115,7 @@
       <span>•</span>
       <a href="/blog/categories/reliability/">Reliability</a>
     </div>
-    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Marcus Chen</div>
+    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Rate limits are a two-sided problem in webhook systems. Here&#39;s how to handle 429s as a sender and protect your endpoint as a receiver, with practical patterns and code.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/rate-limiting/">rate-limiting</a> <a class="chip" href="/blog/tags/reliability/">reliability</a></div>
   </article>
@@ -171,7 +171,7 @@
       <span>•</span>
       <a href="/blog/categories/tutorials/">Tutorials</a>
     </div>
-    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Team</div>
+    <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Give your AI agent a webhook endpoint in minutes: one API call, five-line verification, and a simple routing loop. No dashboard, no boilerplate.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/ai-agents/">ai-agents</a> <a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/tutorials/">tutorials</a></div>
   </article>

--- a/website/blog/webhook-endpoint-for-ai-agents/index.html
+++ b/website/blog/webhook-endpoint-for-ai-agents/index.html
@@ -15,7 +15,7 @@
   <meta name="twitter:description" content="Give your AI agent a webhook endpoint in minutes: one API call, five-line verification, and a simple routing loop. No dashboard, no boilerplate." />
   <meta property="og:image" content="https://dev.hookwing.com/assets/blog/generated/webhook-endpoint-ai-agents-hero.png" />
   <meta name="twitter:image" content="https://dev.hookwing.com/assets/blog/generated/webhook-endpoint-ai-agents-hero.png" />
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"How to Give Your AI Agent a Webhook Endpoint","description":"Give your AI agent a webhook endpoint in minutes: one API call, five-line verification, and a simple routing loop. No dashboard, no boilerplate.","datePublished":"2026-03-08T00:00:00.000Z","dateModified":"2026-03-08T00:00:00.000Z","author":{"@type":"Person","name":"Hookwing Team"},"image":["https://dev.hookwing.com/assets/blog/generated/webhook-endpoint-ai-agents-hero.png"],"mainEntityOfPage":"https://dev.hookwing.com/blog/webhook-endpoint-for-ai-agents/"}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"How to Give Your AI Agent a Webhook Endpoint","description":"Give your AI agent a webhook endpoint in minutes: one API call, five-line verification, and a simple routing loop. No dashboard, no boilerplate.","datePublished":"2026-03-08T00:00:00.000Z","dateModified":"2026-03-08T00:00:00.000Z","author":{"@type":"Person","name":"Hookwing Engineering"},"image":["https://dev.hookwing.com/assets/blog/generated/webhook-endpoint-ai-agents-hero.png"],"mainEntityOfPage":"https://dev.hookwing.com/blog/webhook-endpoint-for-ai-agents/"}</script>
   <title>How to Give Your AI Agent a Webhook Endpoint | Hookwing</title>
   <link rel="stylesheet" href="/styles/tokens.css?v=7" />
   <link rel="stylesheet" href="/styles/base.css?v=7" />
@@ -92,10 +92,10 @@
     </header>
     <div class="post-meta-stack" aria-label="Post metadata">
       <section class="post-author">
-        <img class="author-avatar" src="/assets/logos/logo-03-air-route-badge.svg" alt="Hookwing Team avatar" />
+        <img class="author-avatar" src="/assets/logos/logo-03-air-route-badge.svg" alt="Hookwing Engineering avatar" />
         <div>
-          <div class="author-name"><a href="/blog/authors/hookwing-team/">Hookwing Team</a></div>
-          <div class="meta" style="margin:4px 0 0">Team</div>
+          <div class="author-name"><a href="/blog/authors/hookwing-engineering/">Hookwing Engineering</a></div>
+          <div class="meta" style="margin:4px 0 0">Engineering</div>
         </div>
       </section>
       <div class="post-dates">

--- a/website/blog/webhook-rate-limiting/index.html
+++ b/website/blog/webhook-rate-limiting/index.html
@@ -15,7 +15,7 @@
   <meta name="twitter:description" content="Rate limits are a two-sided problem in webhook systems. Here&#39;s how to handle 429s as a sender and protect your endpoint as a receiver, with practical patterns and code." />
   <meta property="og:image" content="https://dev.hookwing.com/assets/blog/generated/webhook-rate-limiting-hero.png" />
   <meta name="twitter:image" content="https://dev.hookwing.com/assets/blog/generated/webhook-rate-limiting-hero.png" />
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Webhook Rate Limiting: How to Handle It as a Sender and Receiver","description":"Rate limits are a two-sided problem in webhook systems. Here's how to handle 429s as a sender and protect your endpoint as a receiver, with practical patterns and code.","datePublished":"2026-03-20T00:00:00.000Z","dateModified":"2026-03-20T00:00:00.000Z","author":{"@type":"Person","name":"Marcus Chen"},"image":["https://dev.hookwing.com/assets/blog/generated/webhook-rate-limiting-hero.png"],"mainEntityOfPage":"https://dev.hookwing.com/blog/webhook-rate-limiting/"}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Webhook Rate Limiting: How to Handle It as a Sender and Receiver","description":"Rate limits are a two-sided problem in webhook systems. Here's how to handle 429s as a sender and protect your endpoint as a receiver, with practical patterns and code.","datePublished":"2026-03-20T00:00:00.000Z","dateModified":"2026-03-20T00:00:00.000Z","author":{"@type":"Person","name":"Hookwing Engineering"},"image":["https://dev.hookwing.com/assets/blog/generated/webhook-rate-limiting-hero.png"],"mainEntityOfPage":"https://dev.hookwing.com/blog/webhook-rate-limiting/"}</script>
   <title>Webhook Rate Limiting: How to Handle It as a Sender and Receiver | Hookwing</title>
   <link rel="stylesheet" href="/styles/tokens.css?v=7" />
   <link rel="stylesheet" href="/styles/base.css?v=7" />
@@ -92,10 +92,10 @@
     </header>
     <div class="post-meta-stack" aria-label="Post metadata">
       <section class="post-author">
-        <img class="author-avatar" src="/assets/team/avatars/marcus-chen.png" alt="Marcus Chen avatar" />
+        <img class="author-avatar" src="/assets/logos/logo-03-air-route-badge.svg" alt="Hookwing Engineering avatar" />
         <div>
-          <div class="author-name"><a href="/blog/authors/marcus-chen/">Marcus Chen</a></div>
-          <div class="meta" style="margin:4px 0 0">Infrastructure Lead</div>
+          <div class="author-name"><a href="/blog/authors/hookwing-engineering/">Hookwing Engineering</a></div>
+          <div class="meta" style="margin:4px 0 0">Engineering</div>
         </div>
       </section>
       <div class="post-dates">

--- a/website/blog/webhooks-for-ai-agents/index.html
+++ b/website/blog/webhooks-for-ai-agents/index.html
@@ -15,7 +15,7 @@
   <meta name="twitter:description" content="AI agents can&#39;t poll the world. Webhooks give them real-time awareness. Here&#39;s how agents use webhooks and what to look for in a webhook platform." />
   <meta property="og:image" content="https://dev.hookwing.com/assets/blog/optimized/generated/webhooks-for-ai-agents-hero.webp" />
   <meta name="twitter:image" content="https://dev.hookwing.com/assets/blog/optimized/generated/webhooks-for-ai-agents-hero.webp" />
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Webhooks Are How AI Agents Listen to the World","description":"AI agents can't poll the world. Webhooks give them real-time awareness. Here's how agents use webhooks and what to look for in a webhook platform.","datePublished":"2026-03-04","dateModified":"2026-03-04","author":{"@type":"Person","name":"Hookwing Team"},"image":["https://dev.hookwing.com/assets/blog/optimized/generated/webhooks-for-ai-agents-hero.webp"],"mainEntityOfPage":"https://dev.hookwing.com/blog/webhooks-for-ai-agents/"}</script>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Webhooks Are How AI Agents Listen to the World","description":"AI agents can't poll the world. Webhooks give them real-time awareness. Here's how agents use webhooks and what to look for in a webhook platform.","datePublished":"2026-03-04","dateModified":"2026-03-04","author":{"@type":"Person","name":"Hookwing Engineering"},"image":["https://dev.hookwing.com/assets/blog/optimized/generated/webhooks-for-ai-agents-hero.webp"],"mainEntityOfPage":"https://dev.hookwing.com/blog/webhooks-for-ai-agents/"}</script>
   <title>Webhooks Are How AI Agents Listen to the World | Hookwing</title>
   <link rel="stylesheet" href="/styles/tokens.css?v=7" />
   <link rel="stylesheet" href="/styles/base.css?v=7" />
@@ -92,10 +92,10 @@
     </header>
     <div class="post-meta-stack" aria-label="Post metadata">
       <section class="post-author">
-        <img class="author-avatar" src="/assets/logos/logo-03-air-route-badge.svg" alt="Hookwing Team avatar" />
+        <img class="author-avatar" src="/assets/logos/logo-03-air-route-badge.svg" alt="Hookwing Engineering avatar" />
         <div>
-          <div class="author-name"><a href="/blog/authors/hookwing-team/">Hookwing Team</a></div>
-          <div class="meta" style="margin:4px 0 0">Team</div>
+          <div class="author-name"><a href="/blog/authors/hookwing-engineering/">Hookwing Engineering</a></div>
+          <div class="meta" style="margin:4px 0 0">Engineering</div>
         </div>
       </section>
       <div class="post-dates">

--- a/website/changelog/index.html
+++ b/website/changelog/index.html
@@ -208,7 +208,7 @@
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M21 3L3 10.5l7.5 3L14 21l7-18z"/><path d="M10.5 13.5L14 10"/></svg>
             Hookwing
           </a>
-          <p class="footer-brand-desc">Webhook infrastructure for developers and agents. Test free. Ship with confidence.</p>
+          <p class="footer-brand-desc">Webhook infrastructure built for agents. Test free. Ship with confidence.</p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4);display:inline-flex;" aria-label="System status: all systems operational">
             <span class="status-dot" aria-hidden="true"></span>All systems operational
           </a>
@@ -248,7 +248,7 @@
       </div>
       <div class="footer-bottom">
         <p class="footer-copy">&copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.</p>
-        <p class="footer-copy" style="color:rgba(255,255,255,.25);">Built for developers and AI agents.</p>
+        <p class="footer-copy" style="color:rgba(255,255,255,.25);">Built for agents.</p>
       </div>
     </div>
   </footer>

--- a/website/content/blog/debugging-webhooks.md
+++ b/website/content/blog/debugging-webhooks.md
@@ -2,7 +2,7 @@
 title: "How to debug webhooks (without losing your mind)"
 slug: "debugging-webhooks"
 description: "Webhooks fail silently, fire asynchronously, and vanish before you can inspect them. Here's a practical system for debugging webhook integrations in dev and production."
-author: "alex-morgan"
+author: "hookwing-engineering"
 publishDate: "2026-03-24T00:00:00.000Z"
 updatedDate: "2026-03-24T00:00:00.000Z"
 tags: ["webhooks", "debugging", "developer-experience", "observability", "testing"]

--- a/website/content/blog/mcp-server-webhook-tool.md
+++ b/website/content/blog/mcp-server-webhook-tool.md
@@ -2,7 +2,7 @@
 title: "How to Add a Webhook Tool to Your MCP Server"
 slug: "mcp-server-webhook-tool"
 description: "MCP tools are synchronous, but real-world agent workflows run on async events. Here's how to add a webhook tool to your MCP server so agents can listen without polling."
-author: "alex-morgan"
+author: "hookwing-engineering"
 publishDate: "2026-03-21T00:00:00.000Z"
 updatedDate: "2026-03-21T00:00:00.000Z"
 tags: ["mcp", "webhooks", "ai-agents", "tutorials", "async"]

--- a/website/content/blog/webhook-endpoint-for-ai-agents.md
+++ b/website/content/blog/webhook-endpoint-for-ai-agents.md
@@ -2,7 +2,7 @@
 title: "How to Give Your AI Agent a Webhook Endpoint"
 slug: "webhook-endpoint-for-ai-agents"
 description: "Give your AI agent a webhook endpoint in minutes: one API call, five-line verification, and a simple routing loop. No dashboard, no boilerplate."
-author: "hookwing-team"
+author: "hookwing-engineering"
 publishDate: "2026-03-08T00:00:00.000Z"
 updatedDate: "2026-03-08T00:00:00.000Z"
 tags: ["ai-agents", "webhooks", "tutorials", "getting-started", "openclaw"]

--- a/website/content/blog/webhook-rate-limiting.md
+++ b/website/content/blog/webhook-rate-limiting.md
@@ -2,7 +2,7 @@
 title: "Webhook Rate Limiting: How to Handle It as a Sender and Receiver"
 slug: "webhook-rate-limiting"
 description: "Rate limits are a two-sided problem in webhook systems. Here's how to handle 429s as a sender and protect your endpoint as a receiver, with practical patterns and code."
-author: "marcus-chen"
+author: "hookwing-engineering"
 publishDate: "2026-03-20T00:00:00.000Z"
 updatedDate: "2026-03-20T00:00:00.000Z"
 tags: ["webhooks", "rate-limiting", "reliability", "retries", "backoff"]

--- a/website/content/blog/webhooks-for-ai-agents.md
+++ b/website/content/blog/webhooks-for-ai-agents.md
@@ -2,7 +2,7 @@
 title: "Webhooks Are How AI Agents Listen to the World"
 slug: webhooks-for-ai-agents
 date: "2026-03-04"
-author: "hookwing-team"
+author: "hookwing-engineering"
 category: tutorials
 tags:
   - webhooks

--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -1072,7 +1072,7 @@ hookwing deliveries list --status failed</pre></div>
             </svg>
             Hookwing
           </a>
-          <p class="footer-brand-desc">Webhook infrastructure built for agents and developers. Test free. Ship with confidence.</p>
+          <p class="footer-brand-desc">Webhook infrastructure, built for agents. Test free. Ship with confidence.</p>
         </div>
         <div>
           <p class="footer-col-heading">Product</p>

--- a/website/getting-started/index.html
+++ b/website/getting-started/index.html
@@ -671,7 +671,7 @@ event = wh.verify(payload, headers)</code></pre>
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure for developers and agents.
+            Webhook infrastructure built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4);display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -723,7 +723,7 @@ event = wh.verify(payload, headers)</code></pre>
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
 

--- a/website/index.html
+++ b/website/index.html
@@ -307,6 +307,41 @@
           </article>
 
           <!-- Card 2: Straightforward -->
+          <article class="feature-card" aria-labelledby="feat-reliable">
+
+            <img src="/assets/illustrations/features/feature-reliability.svg" class="feature-icon" width="48" height="48" alt="" aria-hidden="true" />
+
+            <h3 id="feat-reliable">Production Grade</h3>
+            <p>Events land. Whether you're watching or it's 3am and your agent is running unattended. Automatic retries with exponential backoff. No manual intervention needed.</p>
+
+            <div class="feature-detail">
+              <div class="feature-detail-item">
+                <svg class="feature-check" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
+                  <circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/>
+                  <path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+                Dead letter queue (Warbird+)
+              </div>
+              <div class="feature-detail-item">
+                <svg class="feature-check" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
+                  <circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/>
+                  <path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+                Full event history - never lose a payload
+              </div>
+              <div class="feature-detail-item">
+                <svg class="feature-check" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
+                  <circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/>
+                  <path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+                Automatic retry with exponential backoff
+              </div>
+            </div>
+          </article>
+
+
+        </div>
+      </div>
           <article class="feature-card" aria-labelledby="feat-simple">
 
             <img src="/assets/illustrations/features/feature-simple.svg" class="feature-icon" width="48" height="48" alt="" aria-hidden="true" />
@@ -341,41 +376,6 @@
 
 
           <!-- Card 3: Reliable -->
-          <article class="feature-card" aria-labelledby="feat-reliable">
-
-            <img src="/assets/illustrations/features/feature-reliability.svg" class="feature-icon" width="48" height="48" alt="" aria-hidden="true" />
-
-            <h3 id="feat-reliable">Production Grade</h3>
-            <p>Events land. Whether you're watching or it's 3am and your agent is running unattended. Automatic retries with exponential backoff. No manual intervention needed.</p>
-
-            <div class="feature-detail">
-              <div class="feature-detail-item">
-                <svg class="feature-check" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
-                  <circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/>
-                  <path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-                </svg>
-                Exponential backoff retries
-              </div>
-              <div class="feature-detail-item">
-                <svg class="feature-check" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
-                  <circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/>
-                  <path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-                </svg>
-                Full event history - never lose a payload
-              </div>
-              <div class="feature-detail-item">
-                <svg class="feature-check" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
-                  <circle cx="8" cy="8" r="7.5" fill="#EDFAF4" stroke="#009D64" stroke-width="1"/>
-                  <path d="M5 8.5L7 10.5L11 6" stroke="#009D64" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-                </svg>
-                Automatic retry with exponential backoff
-              </div>
-            </div>
-          </article>
-
-
-        </div>
-      </div>
     </section>
 
     <!-- ============================================================
@@ -736,7 +736,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
 

--- a/website/playground/index.html
+++ b/website/playground/index.html
@@ -250,7 +250,7 @@
             </svg>
             Hookwing
           </a>
-          <p class="footer-brand-desc">Webhook infrastructure for developers and agents. Test free. Ship with confidence.</p>
+          <p class="footer-brand-desc">Webhook infrastructure built for agents. Test free. Ship with confidence.</p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" aria-label="System status: all systems operational">
             <span class="status-dot" aria-hidden="true"></span>
             All systems operational
@@ -292,7 +292,7 @@
       </div>
       <div class="footer-bottom">
         <p class="footer-copy">&copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.</p>
-        <p class="footer-copy" style="color:rgba(255,255,.25);">Built for developers and AI agents.</p>
+        <p class="footer-copy" style="color:rgba(255,255,.25);">Built for agents.</p>
       </div>
     </div>
   </footer>

--- a/website/pricing/index.html
+++ b/website/pricing/index.html
@@ -950,7 +950,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure for developers and agents.
+            Webhook infrastructure built for agents.
             Test free. Ship with confidence.
           </p>
 
@@ -964,7 +964,7 @@
         <!-- Product column -->
         <div>
           <p class="footer-col-heading">Product</p>
-          <ul class="footer-links" role="list" aria-label="Warbirdduct navigation">
+          <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
             <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
@@ -1009,7 +1009,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
 

--- a/website/privacy/index.html
+++ b/website/privacy/index.html
@@ -245,7 +245,7 @@
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M21 3L3 10.5l7.5 3L14 21l7-18z"/><path d="M10.5 13.5L14 10"/></svg>
             Hookwing
           </a>
-          <p class="footer-brand-desc">Webhook infrastructure for developers and agents. Test free. Ship with confidence.</p>
+          <p class="footer-brand-desc">Webhook infrastructure built for agents. Test free. Ship with confidence.</p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4);display:inline-flex;" aria-label="System status: all systems operational">
             <span class="status-dot" aria-hidden="true"></span>All systems operational
           </a>
@@ -285,7 +285,7 @@
       </div>
       <div class="footer-bottom">
         <p class="footer-copy">&copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.</p>
-        <p class="footer-copy" style="color:rgba(255,255,255,.25);">Built for developers and AI agents.</p>
+        <p class="footer-copy" style="color:rgba(255,255,255,.25);">Built for agents.</p>
       </div>
     </div>
   </footer>

--- a/website/signin/index.html
+++ b/website/signin/index.html
@@ -151,7 +151,7 @@
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M21 3L3 10.5l7.5 3L14 21l7-18z"/><path d="M10.5 13.5L14 10"/></svg>
             Hookwing
           </a>
-          <p class="footer-brand-desc">Webhook infrastructure for developers and agents. Test free. Ship with confidence.</p>
+          <p class="footer-brand-desc">Webhook infrastructure built for agents. Test free. Ship with confidence.</p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4);display:inline-flex;" aria-label="System status: all systems operational">
             <span class="status-dot" aria-hidden="true"></span>All systems operational
           </a>
@@ -191,7 +191,7 @@
       </div>
       <div class="footer-bottom">
         <p class="footer-copy">&copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.</p>
-        <p class="footer-copy" style="color:rgba(255,255,255,.25);">Built for developers and AI agents.</p>
+        <p class="footer-copy" style="color:rgba(255,255,255,.25);">Built for agents.</p>
       </div>
     </div>
   </footer>

--- a/website/signup/index.html
+++ b/website/signup/index.html
@@ -156,7 +156,7 @@
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M21 3L3 10.5l7.5 3L14 21l7-18z"/><path d="M10.5 13.5L14 10"/></svg>
             Hookwing
           </a>
-          <p class="footer-brand-desc">Webhook infrastructure for developers and agents. Test free. Ship with confidence.</p>
+          <p class="footer-brand-desc">Webhook infrastructure built for agents. Test free. Ship with confidence.</p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4);display:inline-flex;" aria-label="System status: all systems operational">
             <span class="status-dot" aria-hidden="true"></span>All systems operational
           </a>
@@ -196,7 +196,7 @@
       </div>
       <div class="footer-bottom">
         <p class="footer-copy">&copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.</p>
-        <p class="footer-copy" style="color:rgba(255,255,255,.25);">Built for developers and AI agents.</p>
+        <p class="footer-copy" style="color:rgba(255,255,255,.25);">Built for agents.</p>
       </div>
     </div>
   </footer>

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -52,10 +52,7 @@
 <url><loc>https://dev.hookwing.com/blog/categories/reliability/</loc></url>
 <url><loc>https://dev.hookwing.com/blog/categories/tutorials/</loc></url>
 <url><loc>https://dev.hookwing.com/blog/categories/</loc></url>
-<url><loc>https://dev.hookwing.com/blog/authors/alex-morgan/</loc></url>
 <url><loc>https://dev.hookwing.com/blog/authors/hookwing-engineering/</loc></url>
-<url><loc>https://dev.hookwing.com/blog/authors/hookwing-team/</loc></url>
-<url><loc>https://dev.hookwing.com/blog/authors/marcus-chen/</loc></url>
 <url><loc>https://dev.hookwing.com/blog/rss.xml</loc></url>
 <url><loc>https://dev.hookwing.com/docs/</loc></url>
 <url><loc>https://dev.hookwing.com/docs/agent-integrations/</loc></url>

--- a/website/src/partials/footer.html
+++ b/website/src/partials/footer.html
@@ -72,7 +72,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
 

--- a/website/status/index.html
+++ b/website/status/index.html
@@ -138,7 +138,7 @@
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M21 3L3 10.5l7.5 3L14 21l7-18z"/><path d="M10.5 13.5L14 10"/></svg>
             Hookwing
           </a>
-          <p class="footer-brand-desc">Webhook infrastructure for developers and agents. Test free. Ship with confidence.</p>
+          <p class="footer-brand-desc">Webhook infrastructure built for agents. Test free. Ship with confidence.</p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4);display:inline-flex;" aria-label="System status: all systems operational">
             <span class="status-dot" aria-hidden="true"></span>All systems operational
           </a>
@@ -179,7 +179,7 @@
       </div>
       <div class="footer-bottom">
         <p class="footer-copy">&copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.</p>
-        <p class="footer-copy" style="color:rgba(255,255,255,.25);">Built for developers and AI agents.</p>
+        <p class="footer-copy" style="color:rgba(255,255,255,.25);">Built for agents.</p>
       </div>
     </div>
   </footer>

--- a/website/styles/pages/playground.css
+++ b/website/styles/pages/playground.css
@@ -1,5 +1,10 @@
 /* Interactive Playground CSS */
 
+/* Lock entire page to dark — no light/white leak */
+body:has(.playground-hero) {
+  background: #001A24 !important;
+}
+
 .playground-active {
   --pg-bg: #001A24;
   --pg-panel: #002A3A;

--- a/website/terms/index.html
+++ b/website/terms/index.html
@@ -326,7 +326,7 @@
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M21 3L3 10.5l7.5 3L14 21l7-18z"/><path d="M10.5 13.5L14 10"/></svg>
             Hookwing
           </a>
-          <p class="footer-brand-desc">Webhook infrastructure for developers and agents. Test free. Ship with confidence.</p>
+          <p class="footer-brand-desc">Webhook infrastructure built for agents. Test free. Ship with confidence.</p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4);display:inline-flex;" aria-label="System status: all systems operational">
             <span class="status-dot" aria-hidden="true"></span>All systems operational
           </a>
@@ -366,7 +366,7 @@
       </div>
       <div class="footer-bottom">
         <p class="footer-copy">&copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.</p>
-        <p class="footer-copy" style="color:rgba(255,255,255,.25);">Built for developers and AI agents.</p>
+        <p class="footer-copy" style="color:rgba(255,255,255,.25);">Built for agents.</p>
       </div>
     </div>
   </footer>

--- a/website/use-cases/index.html
+++ b/website/use-cases/index.html
@@ -74,7 +74,7 @@
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
             <li><a href="/docs/" class="nav-link">Documentation</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
-            <li><a href="/getting-started/" class="nav-link">Get started</a></li>
+            <li><a href="/getting-started/" class="nav-link">Start free</a></li>
           </ul>
 
           <div class="nav-actions">
@@ -104,7 +104,7 @@
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
+          <li><a href="/getting-started/" class="nav-mobile-link">Start free</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>
         </ul>
       </nav>
@@ -134,7 +134,7 @@
           </h1>
 
           <p class="uc-hero-sub">
-            Two integration patterns. Whether your agent pulls events or receives them in real time, the infrastructure is the same.
+            Two flight paths, one control tower. Whether your agent pulls events or receives them in real time, the infrastructure is the same.
           </p>
 
         </div>
@@ -634,7 +634,7 @@ agent.process(event.payload)</code></pre>
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
 

--- a/website/why-hookwing/index.html
+++ b/website/why-hookwing/index.html
@@ -10,7 +10,7 @@
   <title>Why Hookwing - Built agent-first</title>
   <meta name="description" content="The only webhook platform built to work without a human in the loop. Reliable enough for production. Simple enough for a three-line setup." />
   <meta property="og:title" content="Why Hookwing - Webhook infrastructure, built for agents" />
-  <meta property="og:description" content="6 automatic retries. Simple API. No hidden fees. Built for developers and AI agents." />
+  <meta property="og:description" content="6 automatic retries. Simple API. No hidden fees. Built for agents." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://hookwing.com/why-hookwing/" />
   <meta property="og:image" content="https://hookwing.com/assets/og/default.png" />
@@ -97,7 +97,7 @@
           <li><a href="/pricing/" class="nav-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-link">Documentation</a></li>
           <li><a href="/blog/" class="nav-link">Blog</a></li>
-          <li><a href="/getting-started/" class="nav-link">Get started</a></li>
+          <li><a href="/getting-started/" class="nav-link">Start free</a></li>
         </ul>
 
           <div class="nav-actions">
@@ -127,7 +127,7 @@
           <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
           <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
           <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
-          <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
+          <li><a href="/getting-started/" class="nav-mobile-link">Start free</a></li>
           <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>
         </ul>
       </nav>
@@ -353,7 +353,7 @@
 
           <!-- Text -->
           <div class="trust-content">
-            <span class="trust-label">02 / Reliable</span>
+            <span class="trust-label">02 / Production Grade</span>
             <h2 id="reliable-heading">Events land,<br>every time.</h2>
             <p class="trust-body">
               Webhooks are the connective tissue of modern software. When they drop, things break.
@@ -607,12 +607,6 @@
                 <svg class="check-icon" viewBox="0 0 20 20" aria-hidden="true" focusable="false"><use href="#icon-check-green"/></svg>
                 <div class="trust-feature-text">
                 <strong>Public status page with live metrics.</strong> Not a hand-curated blog post after the fact. Real-time status, incident history, and structured JSON at <code class="inline-code">/api/status</code>.
-                </div>
-              </div>
-              <div class="trust-feature-item">
-                <svg class="check-icon" viewBox="0 0 20 20" aria-hidden="true" focusable="false"><use href="#icon-check-green"/></svg>
-                <div class="trust-feature-text">
-                <strong>Public status page.</strong> Real-time service health at /api/status. Transparent monitoring for every plan.
                 </div>
               </div>
               <div class="trust-feature-item">
@@ -1160,14 +1154,14 @@
           </p>
 
           <div class="cta-actions">
-            <a href="/signup/" class="btn btn-primary btn-lg">
+            <a href="/playground/" class="btn btn-primary btn-lg">
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
                 <path d="M21 3L3 10.5l7.5 3L14 21l7-18z"/>
                 <path d="M10.5 13.5L14 10"/>
               </svg>
               Try the playground
             </a>
-            <a href="/playground/" class="btn btn-ghost-inv btn-lg">
+            <a href="/signup/" class="btn btn-ghost-inv btn-lg">
               Start free, no credit card
             </a>
           </div>
@@ -1191,7 +1185,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure for developers and agents.
+            Webhook infrastructure built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -1243,7 +1237,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy footer-fine">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
 


### PR DESCRIPTION
## Brand Audit Fixes

### 🔴 MAJOR
- [M-1] Why-hookwing pillar: '02 / Reliable' → '02 / Production Grade'
- [M-2] Footer tagline: 'Built for agents.' standardized across all pages
- [M-3] Bottom CTAs on why-hookwing: playground/signup hrefs un-swapped

### 🟡 MINOR
- [m-1] Pricing footer aria-label: 'Warbirdduct' → 'Product navigation'
- [m-2] Homepage pillars reordered to canonical: Agent-Ready → Production Grade → Simple
- [m-3] Duplicate 'Public status page' bullet removed
- [m-4] Nav CTA label standardized to 'Start free'
- [m-5] Playground page body locked to dark
- [m-6] Aviation reference added to use-cases intro
- [m-7] All blog authors → 'Hookwing Engineering'
- [m-8] Duplicate exponential backoff bullets merged