### PR TITLE
fix(copy): honest billing copy — remove false claims (#128)

### DIFF
--- a/website/pricing/index.html
+++ b/website/pricing/index.html
@@ -102,7 +102,7 @@
           "name": "What payment methods do you accept?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "All major credit and debit cards (Visa, Mastercard, Amex). Bank transfers available on annual Stealth Jet plans. Agents can trigger upgrades via API using a stored payment method."
+            "text": "All major credit and debit cards (Visa, Mastercard, Amex). API-first billing coming soon — agents will be able to manage plans programmatically."
           }
         }
       ]
@@ -543,7 +543,7 @@
               </tr>
 
               <tr>
-                <td scope="row">HTTP-native billing (agents can upgrade)</td>
+                <td scope="row">API-first billing (coming soon)</td>
                 <td><span class="tbl-cross">—</span></td>
                 <td><span class="tbl-check">✓</span></td>
                 <td class="col-featured"><span class="tbl-check">✓</span></td>
@@ -889,7 +889,7 @@
             </button>
             <div class="faq-answer" id="faq-answer-8" role="region" aria-labelledby="faq-q8" hidden>
               <div class="faq-answer-inner">
-                All major credit and debit cards - Visa, Mastercard, American Express. Bank transfers (ACH/SEPA) are available on annual Stealth Jet plans. Agents can trigger plan upgrades via API using a stored payment method. No check payments.
+                All major credit and debit cards — Visa, Mastercard, American Express. API-first billing coming soon: agents will be able to manage plans programmatically after initial payment setup.
               </div>
             </div>
           </div>

--- a/website/why-hookwing/index.html
+++ b/website/why-hookwing/index.html
@@ -259,7 +259,7 @@
               <div class="trust-feature-item">
                 <svg class="check-icon" viewBox="0 0 20 20" aria-hidden="true" focusable="false"><use href="#icon-check-amber"/></svg>
                 <div class="trust-feature-text">
-                <strong>HTTP-native billing. Agents can pay.</strong> Agents can upgrade plans via API. POST to /v1/billing/upgrade. No browser. No form. No credit card flow. Stored payment method, single call.
+                <strong>API-first billing.</strong> Add a payment method once, then agents can manage plans via API. Upgrade, downgrade, check status — all with a single HTTP call. Workspace owners control whether agents can change plans.
                 </div>
               </div>
               <div class="trust-feature-item">
@@ -1033,7 +1033,7 @@
                 <td><span class="compare-partial">Not documented</span></td>
                 </tr>
                 <tr>
-                <td>HTTP-native billing (agents pay)</td>
+                <td>API-first billing (coming soon)</td>
                 <td class="col-hookwing"><span class="compare-check">✓</span></td>
                 <td><span class="compare-cross">✗</span></td>
                 <td><span class="compare-cross">✗</span></td>


### PR DESCRIPTION
Replaces misleading 'HTTP-native billing. Agents can pay.' and 'POST to /v1/billing/upgrade' claims with honest 'API-first billing (coming soon)' framing. The billing API doesn't exist yet — these claims were aspirational. Fixed on why-hookwing + pricing pages. Will update to active claims once #120 (billing) ships.