### PR TITLE
fix(playground): pre-fill curl snippet with realistic payload

### DIFF
--- a/website/playground/index.html
+++ b/website/playground/index.html
@@ -297,7 +297,7 @@
     </div>
   </footer>
 
-  <script src="/playground/playground.js?v=61"></script>
+  <script src="/playground/playground.js?v=62"></script>
   <script>
     // Mobile nav toggle
     const navToggle = document.getElementById('nav-toggle');

--- a/website/playground/playground.js
+++ b/website/playground/playground.js
@@ -344,12 +344,24 @@
   // Update curl command
   function updateCurlCommand() {
     const fullUrl = `${window.location.origin}${state.endpointUrl}`;
-    const samplePayload = generateRandomPayload(elements.eventTypeSelect?.value || 'custom');
+    const samplePayload = {
+      event: 'order.completed',
+      data: {
+        id: 'ord_123',
+        amount: 49.99,
+        currency: 'usd',
+        customer: 'cus_abc123',
+        items: [
+          { name: 'Webhook Guide', quantity: 1, price: 2999 },
+        ],
+      },
+      timestamp: new Date().toISOString(),
+    };
     const payloadStr = JSON.stringify(samplePayload, null, 2).replace(/\n/g, ' \\\n  ');
 
     const curl = `curl -X POST ${fullUrl} \\
   -H "Content-Type: application/json" \\
-  -H "X-Event-Type: ${elements.eventTypeSelect?.value || 'custom'}" \\
+  -H "X-Event-Type: order.completed" \\
   -d '${JSON.stringify(samplePayload).replace(/'/g, "\\'")}'`;
 
     elements.curlCommand.textContent = curl;


### PR DESCRIPTION
## Summary
- Updates the playground curl snippet to use a realistic sample payload (`order.completed` event) instead of randomly generated data
- The curl command now shows the actual endpoint URL, proper Content-Type header, and a consistent sample payload after the endpoint is created
- One-click copy button already exists with "Copied!" visual feedback

## Test plan
- [ ] Visit the playground page
- [ ] Wait for endpoint to generate
- [ ] Verify curl snippet appears below with realistic payload
- [ ] Click copy button and verify "Copied!" feedback

🤎 Generated with [Claude Code](https://claude.com/claude-code)