### PR TITLE
fix: dashboard overview broken — syntax error in overview.js

### DIFF
--- a/website/app/overview/overview.js
+++ b/website/app/overview/overview.js
@@ -30,7 +30,7 @@
   function setActiveNav() {
     document.querySelectorAll('.sidebar-nav-link').forEach(link => {
       link.classList.remove('active');
-      if (link.getAttribute('href')?.includes('/app') && (link.getAttribute('href')?.endsWith('/') || link.getAttribute('href')?.endsWith('/app') || link.getAttribute('href')?.endsWith('/app/')))) {
+      if (link.getAttribute('href')?.includes('/app') && (link.getAttribute('href')?.endsWith('/') || link.getAttribute('href')?.endsWith('/app') || link.getAttribute('href')?.endsWith('/app/'))) {
         link.classList.add('active');
         link.setAttribute('aria-current', 'page');
       }


### PR DESCRIPTION
## QA Report — Dashboard MVP

### 🔴 CRITICAL (this PR fixes)
**overview.js line 33 — SyntaxError kills entire overview page**
- Extra closing paren `)))` when only `((` opens
- Result: overview page shows 'Loading dashboard...' spinner forever
- The entire overview.js IIFE fails to parse, so `init()` never runs
- **Impact: dashboard homepage is completely broken for all users**

### 🟡 BUGS FOUND (separate tickets needed)

**B-1: `/app/keys/` returns 404**
- Sidebar links to `/app/keys/` but the directory doesn't exist
- API Keys section works fine on the Settings page (`/app/settings/`)
- Options: (a) create a keys/ page, or (b) remove from sidebar and keep keys in Settings

**B-2: Settings link missing from overview sidebar**
- Overview sidebar has only 5 items (Dashboard, Endpoints, Events, Deliveries, API Keys)
- Other pages have 6 items (includes Settings)
- Overview's sidebar HTML is missing the Settings `<li>` block

**B-3: Deliveries page shows 'Invalid Date'**
- Deliveries list renders 'Invalid Date' for the timestamp column
- Likely the JS is reading a different field name than what the API returns

**B-4: Deliveries page shows 'pending' for all statuses**
- Mock data has success/failed statuses but UI renders 'pending' for all
- The status badge logic may not be reading the status field correctly

**B-5: Stats grid layout — 3rd card wraps**
- Overview has 3 stat cards (Endpoints, Events, Deliveries)
- The 3rd card wraps to a second row instead of fitting in a 3-column grid
- CSS grid/flex issue on the stats container

### ✅ WORKING
- Endpoints page — clean, correct data, delete button present
- Events page — event list with pagination, clean layout
- Settings page — workspace info, API keys CRUD, plan & billing all render correctly
- Topbar — workspace name + tier badge + sign out all work
- Sidebar navigation highlighting works on all sub-pages
- Sign in/sign out flow works correctly

### QA Method
- Local static server (`npx serve`) with mock fetch API injected before `api.js`
- VPS headless browser screenshots of all 6 dashboard views
- Syntax validation of all JS files via `node -c`