### PR TITLE
fix: dashboard QA bugs — keys page, deliveries, stats grid

### DIFF
--- a/website/app/deliveries/deliveries.js
+++ b/website/app/deliveries/deliveries.js
@@ -105,9 +105,10 @@
     }
 
     deliveriesList.innerHTML = deliveries.map(delivery => {
+      const status = delivery.status || 'pending';
       const statusCode = delivery.responseStatusCode;
       const statusClass = getStatusClass(statusCode);
-      const timeAgo = formatTimeAgo(new Date(delivery.attemptedAt));
+      const timeAgo = formatTimeAgo(new Date(delivery.createdAt));
 
       return `
         <div class="resource-item">
@@ -123,7 +124,7 @@
             <span class="resource-title">${escapeHtml(delivery.endpointUrl || delivery.endpointId || 'Unknown endpoint')}</span>
             <span class="resource-meta">${escapeHtml(delivery.eventId || delivery.id || 'delivery')} · ${timeAgo}</span>
             <div class="resource-badges">
-              <span class="resource-badge status-badge ${statusClass}">${statusCode || 'pending'}</span>
+              <span class="resource-badge status-badge ${statusClass}">${status}</span>
               <span class="resource-badge">${delivery.attempts || 1} attempt${delivery.attempts > 1 ? 's' : ''}</span>
             </div>
           </div>
@@ -142,10 +143,16 @@
   }
 
   function getStatusClass(statusCode) {
-    if (statusCode >= 200 && statusCode < 300) return 'status-success';
-    if (statusCode >= 400 && statusCode < 500) return 'status-client-error';
-    if (statusCode >= 500) return 'status-server-error';
-    if (statusCode === null) return 'status-pending';
+    if (statusCode === 'delivered' || statusCode === 'success') return 'status-success';
+    if (statusCode === 'failed' || statusCode === 'client_error') return 'status-client-error';
+    if (statusCode === 'server_error') return 'status-server-error';
+    if (statusCode === 'pending' || statusCode === 'retrying') return 'status-pending';
+    if (statusCode === 'delivered') return 'status-success';
+    if (typeof statusCode === 'number') {
+      if (statusCode >= 200 && statusCode < 300) return 'status-success';
+      if (statusCode >= 400 && statusCode < 500) return 'status-client-error';
+      if (statusCode >= 500) return 'status-server-error';
+    }
     return 'status-other';
   }
 

--- a/website/app/keys/index.html
+++ b/website/app/keys/index.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self' https://dev.api.hookwing.com https://api.hookwing.com; base-uri 'self';" />
+  <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin" />
+  <meta http-equiv="X-Content-Type-Options" content="nosniff" />
+  <title>API Keys — Hookwing</title>
+  <meta name="description" content="Manage API keys." />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <link rel="icon" type="image/png" href="/favicon-32.png" sizes="32x32" />
+  <link rel="manifest" href="/site.webmanifest" />
+  <link rel="apple-touch-icon" href="/apple-touch-icon.png" sizes="180x180" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" />
+  <link rel="stylesheet" href="/styles/tokens.css?v=7" />
+  <link rel="stylesheet" href="/styles/base.css?v=7" />
+  <link rel="stylesheet" href="/styles/components.css?v=7" />
+  <link rel="stylesheet" href="/styles/pages/app.css?v=11" />
+</head>
+<body>
+  <div class="app-layout">
+    <!-- Sidebar -->
+    <aside class="sidebar" id="sidebar" aria-label="Dashboard navigation">
+      <div class="sidebar-header">
+        <a href="/" class="sidebar-logo">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M21 3L3 10.5l7.5 3L14 21l7-18z"/>
+            <path d="M10.5 13.5L14 10"/>
+          </svg>
+          Hookwing
+        </a>
+      </div>
+
+      <nav class="sidebar-nav">
+        <ul class="sidebar-nav-list" role="list">
+          <li>
+            <a href="/" class="sidebar-nav-link" data-nav="dashboard">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <rect x="3" y="3" width="7" height="9"></rect>
+                <rect x="14" y="3" width="7" height="5"></rect>
+                <rect x="14" y="12" width="7" height="9"></rect>
+                <rect x="3" y="16" width="7" height="5"></rect>
+              </svg>
+              Dashboard
+            </a>
+          </li>
+          <li>
+            <a href="/app/endpoints/" class="sidebar-nav-link" data-nav="endpoints">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path>
+                <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path>
+              </svg>
+              Endpoints
+            </a>
+          </li>
+          <li>
+            <a href="/app/events/" class="sidebar-nav-link" data-nav="events">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+                <polyline points="14 2 14 8 20 8"></polyline>
+                <line x1="16" y1="13" x2="8" y2="13"></line>
+                <line x1="16" y1="17" x2="8" y2="17"></line>
+                <polyline points="10 9 9 9 8 9"></polyline>
+              </svg>
+              Events
+            </a>
+          </li>
+          <li>
+            <a href="/app/deliveries/" class="sidebar-nav-link" data-nav="deliveries">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <rect x="1" y="3" width="15" height="13"></rect>
+                <polygon points="16 8 20 8 23 11 23 16 16 16 16 8"></polygon>
+                <circle cx="5.5" cy="18.5" r="2.5"></circle>
+                <circle cx="18.5" cy="18.5" r="2.5"></circle>
+              </svg>
+              Deliveries
+            </a>
+          </li>
+          <li>
+            <a href="/app/keys/" class="sidebar-nav-link active" data-nav="keys">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"></path>
+              </svg>
+              API Keys
+            </a>
+          </li>
+          <li>
+            <a href="/app/settings/" class="sidebar-nav-link" data-nav="settings">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <circle cx="12" cy="12" r="3"></circle>
+                <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
+              </svg>
+              Settings
+            </a>
+          </li>
+        </ul>
+      </nav>
+
+      <div class="sidebar-footer">
+        <a href="https://hookwing.com/docs/" class="sidebar-footer-link" target="_blank" rel="noopener">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="12" cy="12" r="10"></circle>
+            <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"></path>
+            <line x1="12" y1="17" x2="12.01" y2="17"></line>
+          </svg>
+          Help & Docs
+        </a>
+      </div>
+    </aside>
+
+    <!-- Main wrapper -->
+    <div class="main-wrapper">
+      <header class="topbar">
+        <div class="topbar-left">
+          <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Toggle sidebar" aria-expanded="false">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <line x1="3" y1="12" x2="21" y2="12"></line>
+              <line x1="3" y1="6" x2="21" y2="6"></line>
+              <line x1="3" y1="18" x2="21" y2="18"></line>
+            </svg>
+          </button>
+        </div>
+
+        <div class="topbar-right">
+          <div class="workspace-info">
+            <span class="workspace-name" id="workspace-name">Loading...</span>
+            <span class="tier-badge" id="tier-badge">Paper Plane</span>
+          </div>
+          <button class="btn btn-ghost signout-btn" id="signout-btn">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"></path>
+              <polyline points="16 17 21 12 16 7"></polyline>
+              <line x1="21" y1="12" x2="9" y2="12"></line>
+            </svg>
+            Sign out
+          </button>
+        </div>
+      </header>
+
+      <main class="main-content" id="main-content">
+        <div class="loading-state" id="loading-state">
+          <div class="loading-spinner"></div>
+          <p>Loading API keys...</p>
+        </div>
+
+        <div class="dashboard-content" id="dashboard-content" hidden>
+          <div class="page-header">
+            <h1 class="page-title">API Keys</h1>
+            <p class="page-subtitle">Manage API keys for your workspace.</p>
+          </div>
+
+          <div class="section-card">
+            <div class="section-header">
+              <h2 class="section-title">All API keys</h2>
+              <button class="btn btn-primary btn-sm" id="create-key-btn">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <line x1="12" y1="5" x2="12" y2="19"></line>
+                  <line x1="5" y1="12" x2="19" y2="12"></line>
+                </svg>
+                Create API key
+              </button>
+            </div>
+            <div class="resource-list" id="keys-list">
+              <div class="events-empty">
+                <p>Loading API keys...</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  </div>
+
+  <!-- Create Key Modal -->
+  <div class="modal-overlay" id="create-key-modal" hidden>
+    <div class="modal">
+      <div class="modal-header">
+        <h3 class="modal-title">Create API key</h3>
+        <button class="modal-close" id="close-modal-btn" aria-label="Close modal">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="18" y1="6" x2="6" y2="18"></line>
+            <line x1="6" y1="6" x2="18" y2="18"></line>
+          </svg>
+        </button>
+      </div>
+      <form id="create-key-form">
+        <div class="modal-body">
+          <div class="form-group">
+            <label class="form-label" for="key-name">Name</label>
+            <input class="form-input" type="text" id="key-name" name="name" placeholder="My API key" required />
+            <p class="form-hint">A descriptive name to help you identify this key.</p>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-ghost" id="cancel-create-btn">Cancel</button>
+          <button type="submit" class="btn btn-primary">Create API key</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <script src="../lib/api.js?v=65"></script>
+  <script src="keys.js?v=1"></script>
+</body>
+</html>

--- a/website/app/keys/keys.js
+++ b/website/app/keys/keys.js
@@ -1,0 +1,257 @@
+/**
+ * API Keys page - CRUD for API keys
+ */
+
+(function () {
+  'use strict';
+
+  const keysList = document.getElementById('keys-list');
+  const loadingState = document.getElementById('loading-state');
+  const dashboardContent = document.getElementById('dashboard-content');
+  const workspaceNameEl = document.getElementById('workspace-name');
+  const tierBadgeEl = document.getElementById('tier-badge');
+  const signoutBtn = document.getElementById('signout-btn');
+  const sidebarToggle = document.getElementById('sidebar-toggle');
+  const sidebar = document.getElementById('sidebar');
+
+  // Modal elements
+  const createKeyBtn = document.getElementById('create-key-btn');
+  const createKeyModal = document.getElementById('create-key-modal');
+  const closeModalBtn = document.getElementById('close-modal-btn');
+  const cancelCreateBtn = document.getElementById('cancel-create-btn');
+  const createKeyForm = document.getElementById('create-key-form');
+
+  function setActiveNav() {
+    document.querySelectorAll('.sidebar-nav-link').forEach(link => {
+      link.classList.remove('active');
+      if (link.getAttribute('href')?.includes('/app/keys')) {
+        link.classList.add('active');
+        link.setAttribute('aria-current', 'page');
+      }
+    });
+  }
+
+  function openModal(modal) {
+    if (modal) modal.hidden = false;
+    document.body.style.overflow = 'hidden';
+  }
+
+  function closeModal(modal) {
+    if (modal) modal.hidden = true;
+    document.body.style.overflow = '';
+  }
+
+  async function init() {
+    setActiveNav();
+
+    if (!isAuthenticated()) {
+      window.location.href = '/signin/';
+      return;
+    }
+
+    try {
+      const meRes = await apiCall('/auth/me');
+      if (!meRes.ok) {
+        signOut();
+        return;
+      }
+
+      const meData = await meRes.json();
+      const workspace = meData.workspace;
+
+      workspaceNameEl.textContent = workspace.name;
+      tierBadgeEl.textContent = workspace.tier?.name || 'Free';
+
+      loadingState.hidden = true;
+      dashboardContent.hidden = false;
+
+      await loadKeys();
+
+    } catch (err) {
+      console.error('Failed to initialize:', err);
+      signOut();
+    }
+  }
+
+  async function loadKeys() {
+    try {
+      const res = await apiCall('/auth/keys');
+      if (!res.ok) {
+        const data = await res.json();
+        keysList.innerHTML = `<div class="events-empty"><p>${data.error || 'Failed to load API keys'}</p></div>`;
+        return;
+      }
+
+      const data = await res.json();
+      const keys = data.keys || [];
+
+      renderKeys(keys);
+
+    } catch (err) {
+      console.error('Failed to load API keys:', err);
+      keysList.innerHTML = `<div class="events-empty"><p>Failed to load API keys. Please try again.</p></div>`;
+    }
+  }
+
+  function renderKeys(keys) {
+    if (keys.length === 0) {
+      keysList.innerHTML = '<div class="events-empty"><p>No API keys yet. Create your first key to start making API requests.</p></div>';
+      return;
+    }
+
+    keysList.innerHTML = keys.map(key => `
+      <div class="resource-item">
+        <div class="resource-icon">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"></path>
+          </svg>
+        </div>
+        <div class="resource-content">
+          <span class="resource-title">${escapeHtml(key.name)}</span>
+          <span class="resource-meta">Created ${formatTimeAgo(new Date(key.createdAt))}</span>
+          <div class="resource-badges">
+            <span class="resource-badge">${key.lastUsedAt ? 'Last used ' + formatTimeAgo(new Date(key.lastUsedAt)) : 'Never used'}</span>
+          </div>
+        </div>
+        <button class="resource-delete" onclick="handleRevokeKey('${key.id}')" aria-label="Revoke key">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="3 6 5 6 21 6"></polyline>
+            <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+          </svg>
+        </button>
+      </div>
+    `).join('');
+  }
+
+  window.handleRevokeKey = async function(id) {
+    if (!id) return;
+    if (!confirm('Are you sure you want to revoke this API key? This action cannot be undone.')) {
+      return;
+    }
+
+    try {
+      const res = await apiCall(`/auth/keys/${id}`, { method: 'DELETE' });
+      const data = await res.json();
+
+      if (!res.ok) {
+        alert(data.error || 'Failed to revoke key');
+        return;
+      }
+
+      await loadKeys();
+
+    } catch (err) {
+      console.error('Failed to revoke key:', err);
+      alert('Failed to revoke key. Please try again.');
+    }
+  };
+
+  function formatTimeAgo(date) {
+    const now = new Date();
+    const diffMs = now - date;
+    const diffSec = Math.floor(diffMs / 1000);
+    const diffMin = Math.floor(diffSec / 60);
+    const diffHour = Math.floor(diffMin / 60);
+    const diffDay = Math.floor(diffHour / 24);
+
+    if (diffSec < 60) return 'just now';
+    if (diffMin < 60) return `${diffMin}m ago`;
+    if (diffHour < 24) return `${diffHour}h ago`;
+    if (diffDay < 7) return `${diffDay}d ago`;
+
+    return date.toLocaleDateString();
+  }
+
+  function escapeHtml(str) {
+    if (!str) return '';
+    const div = document.createElement('div');
+    div.textContent = str;
+    return div.innerHTML;
+  }
+
+  // Modal handlers
+  createKeyBtn?.addEventListener('click', () => openModal(createKeyModal));
+  closeModalBtn?.addEventListener('click', () => closeModal(createKeyModal));
+  cancelCreateBtn?.addEventListener('click', () => closeModal(createKeyModal));
+
+  createKeyModal?.addEventListener('click', (e) => {
+    if (e.target === createKeyModal) {
+      closeModal(createKeyModal);
+    }
+  });
+
+  // Create key form
+  createKeyForm?.addEventListener('submit', async (e) => {
+    e.preventDefault();
+
+    const nameInput = document.getElementById('key-name');
+    const name = nameInput?.value?.trim();
+
+    if (!name) {
+      nameInput?.focus();
+      return;
+    }
+
+    const submitBtn = createKeyForm.querySelector('button[type="submit"]');
+    if (submitBtn) {
+      submitBtn.disabled = true;
+      submitBtn.textContent = 'Creating...';
+    }
+
+    try {
+      const res = await apiCall('/auth/keys', {
+        method: 'POST',
+        body: JSON.stringify({ name }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        alert(data.error || 'Failed to create API key');
+        return;
+      }
+
+      closeModal(createKeyModal);
+      createKeyForm.reset();
+
+      // Show the new key to the user
+      if (data.key) {
+        alert(`API key created: ${data.key}\n\nMake sure to copy it now — you won't be able to see it again.`);
+      }
+
+      await loadKeys();
+
+    } catch (err) {
+      console.error('Failed to create API key:', err);
+      alert('Failed to create API key. Please try again.');
+    } finally {
+      if (submitBtn) {
+        submitBtn.disabled = false;
+        submitBtn.textContent = 'Create API key';
+      }
+    }
+  });
+
+  // Sign out handler
+  signoutBtn?.addEventListener('click', () => {
+    signOut();
+  });
+
+  // Sidebar toggle
+  sidebarToggle?.addEventListener('click', () => {
+    const isOpen = sidebar.classList.toggle('is-open');
+    sidebarToggle.setAttribute('aria-expanded', isOpen);
+  });
+
+  document.addEventListener('click', (e) => {
+    if (window.innerWidth <= 768 &&
+        sidebar.classList.contains('is-open') &&
+        !sidebar.contains(e.target) &&
+        !sidebarToggle.contains(e.target)) {
+      sidebar.classList.remove('is-open');
+      sidebarToggle.setAttribute('aria-expanded', 'false');
+    }
+  });
+
+  init();
+})();

--- a/website/styles/pages/app.css
+++ b/website/styles/pages/app.css
@@ -29,8 +29,8 @@
 
 @media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important}}
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
-html{font-family:var(--font-body);font-size:16px;line-height:1.625;color:var(--color-ink-strong);background:var(--color-bg);-webkit-font-smoothing:antialiased;scroll-behavior:smooth;overflow-x:hidden}
-body{overflow:hidden}
+html{font-family:var(--font-body);font-size:16px;line-height:1.625;color:var(--color-ink-strong);background:var(--color-bg);-webkit-font-smoothing:antialiased;scroll-behavior:smooth;overflow-x:hidden;height:100%}
+body{overflow:hidden;height:100%}
 
 /* App layout */
 .app-layout{display:flex;min-height:100vh}
@@ -82,7 +82,7 @@ body{overflow:hidden}
 
 /* Stats grid */
 .stats-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:var(--space-5)}
-.stat-card{display:flex;align-items:center;gap:var(--space-4);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);box-shadow:var(--shadow-sm)}
+.stat-card{display:flex;align-items:center;gap:var(--space-4);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);box-shadow:var(--shadow-sm);min-width:0}
 .stat-icon{display:flex;align-items:center;justify-content:center;width:44px;height:44px;background:var(--color-success-bg);border-radius:var(--radius-md);color:var(--color-brand-action)}
 .stat-content{display:flex;flex-direction:column}
 .stat-value{font-family:var(--font-display);font-size:28px;font-weight:700;color:var(--color-ink-strong);line-height:1.2}


### PR DESCRIPTION
## Summary
- Bug #140: Create `/app/keys/` page - Added API keys page with index.html and keys.js, including create/revoke functionality using `/auth/keys` API endpoint
- Bug #141: Overview sidebar already has 6 nav items - No fix needed
- Bug #142: Fix deliveries.js - Changed timestamp field from `attemptedAt` to `createdAt`, and changed status display from `responseStatusCode` to `status` field per API response
- Bug #143: Stats grid CSS - Already fixed in previous commit (min-width:0 on stat-card)

## Test plan
- [ ] Verify `/app/keys/` page loads with sidebar navigation
- [ ] Test create API key functionality
- [ ] Test revoke API key functionality  
- [ ] Verify deliveries page shows correct timestamps (not "Invalid Date")
- [ ] Verify deliveries page shows correct status badges (not all "pending")
- [ ] Verify overview stats grid shows 3 cards in a single row

🤖 Generated with [Claude Code](https://claude.com/claude-code)