### PR TITLE
fix: UX audit quick wins — pricing images, CTAs, OAuth URLs, accessibility

### DIFF
--- a/website/playground/index.html
+++ b/website/playground/index.html
@@ -292,7 +292,7 @@
       </div>
       <div class="footer-bottom">
         <p class="footer-copy">&copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.</p>
-        <p class="footer-copy" style="color:rgba(255,255,.25);">Built for agents.</p>
+        <p class="footer-copy" style="color:rgba(255,255,255,.25);">Built for agents.</p>
       </div>
     </div>
   </footer>

--- a/website/pricing/index.html
+++ b/website/pricing/index.html
@@ -309,7 +309,7 @@
 
             <!-- Icon: Free - geometric SVG -->
             <div class="pricing-icon-wrap" style="background:transparent;" aria-hidden="true">
-              <img src="/assets/illustrations/tiers/tier-free.webp" width="72" alt="" />
+              <img src="/assets/illustrations/tiers/tier-paper-plane.webp" width="72" alt="" />
             </div>
 
             <p class="pricing-tier-name" aria-label="Tier: Paper Plane">Paper Plane</p>
@@ -366,7 +366,7 @@
 
             <!-- Icon: Pro - double wing geometric SVG -->
             <div class="pricing-icon-wrap" style="background:transparent;" aria-hidden="true">
-              <img src="/assets/illustrations/tiers/tier-pro.webp" width="72" alt="" />
+              <img src="/assets/illustrations/tiers/tier-warbird.webp" width="72" alt="" />
             </div>
 
             <p class="pricing-tier-name" aria-label="Tier: Warbird">Warbird</p>
@@ -408,7 +408,7 @@
               </li>
             </ul>
 
-            <a href="/signup/" class="btn btn-secondary btn-md pricing-card-cta" style="display:flex;">
+            <a href="/signup/" class="btn btn-primary btn-md pricing-card-cta" style="display:flex;">
               Sign up
             </a>
           </div>
@@ -418,7 +418,7 @@
 
             <!-- Icon: Stealth Jet - swept-wing fighter silhouette -->
             <div class="pricing-icon-wrap" style="background:transparent;" aria-hidden="true">
-              <img src="/assets/illustrations/tiers/tier-enterprise.webp" width="72" alt="" />
+              <img src="/assets/illustrations/tiers/tier-stealth-jet.webp" width="72" alt="" />
             </div>
 
             <p class="pricing-tier-name" aria-label="Tier: Stealth Jet">Stealth Jet</p>
@@ -456,7 +456,7 @@
               </li>
             </ul>
 
-            <a href="/signup/" class="btn btn-primary btn-md pricing-card-cta" style="display:flex;">
+            <a href="/signup/" class="btn btn-secondary btn-md pricing-card-cta" style="display:flex;">
               Sign up
             </a>
           </div>

--- a/website/signin/index.html
+++ b/website/signin/index.html
@@ -109,11 +109,11 @@
         <p class="signin-sub">Access your Hookwing dashboard.</p>
 
         <div class="oauth-buttons">
-          <a href="https://dev.api.hookwing.com/v1/auth/github" class="btn btn-oauth btn-lg" style="width:100%;justify-content:center;">
+          <a id="oauth-github" href="#" class="btn btn-oauth btn-lg" style="width:100%;justify-content:center;">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
             Continue with GitHub
           </a>
-          <a href="https://dev.api.hookwing.com/v1/auth/google" class="btn btn-oauth btn-lg" style="width:100%;justify-content:center;">
+          <a id="oauth-google" href="#" class="btn btn-oauth btn-lg" style="width:100%;justify-content:center;">
             <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden="true"><path fill="#4285F4" d="M23.745 12.27c0-.79-.07-1.54-.19-2.27h-11.3v4.51h6.47c-.29 1.48-1.14 2.73-2.4 3.6v3h3.9c2.28-2.1 3.6-5.2 3.6-8.84z"/><path fill="#34A853" d="M12.255 24c3.24 0 5.95-1.08 7.96-2.91l-3.91-3c-1.08.72-2.45 1.16-4.05 1.16-3.13 0-5.78-2.11-6.73-4.96h-4.19v3.24c1.99 3.96 6.09 6.47 10.92 6.47z"/><path fill="#FBBC05" d="M5.525 14.29c-.25-.72-.38-1.49-.38-2.29s.14-1.57.38-2.29V6.46h-4.19c-.82 1.64-1.29 3.5-1.29 5.54s.47 3.9 1.29 5.54l4.19-3.25z"/><path fill="#EA4335" d="M12.255 4.75c1.77 0 3.35.61 4.6 1.8l3.42-3.42C18.205 1.19 15.495 0 12.255 0c-4.83 0-8.93 2.51-10.92 6.46l4.19 3.25c.95-2.85 3.6-4.96 6.73-4.96z"/></svg>
             Continue with Google
           </a>

--- a/website/signin/signin.js
+++ b/website/signin/signin.js
@@ -122,3 +122,11 @@ const API_BASE = (window.location.hostname === 'hookwing.com' ? 'https://api.hoo
     submitBtn.textContent = 'Sign in';
   }
 })();
+
+// Set OAuth URLs dynamically based on environment
+(function setOAuthUrls() {
+  const github = document.getElementById('oauth-github');
+  const google = document.getElementById('oauth-google');
+  if (github) github.href = API_BASE + '/auth/github';
+  if (google) google.href = API_BASE + '/auth/google';
+})();

--- a/website/signup/index.html
+++ b/website/signup/index.html
@@ -109,11 +109,11 @@
         <p class="signup-sub">Start receiving webhooks in minutes.</p>
 
         <div class="oauth-buttons">
-          <a href="https://dev.api.hookwing.com/v1/auth/github" class="btn btn-oauth btn-lg" style="width:100%;justify-content:center;">
+          <a id="oauth-github" href="#" class="btn btn-oauth btn-lg" style="width:100%;justify-content:center;">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
             Continue with GitHub
           </a>
-          <a href="https://dev.api.hookwing.com/v1/auth/google" class="btn btn-oauth btn-lg" style="width:100%;justify-content:center;">
+          <a id="oauth-google" href="#" class="btn btn-oauth btn-lg" style="width:100%;justify-content:center;">
             <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden="true"><path fill="#4285F4" d="M23.745 12.27c0-.79-.07-1.54-.19-2.27h-11.3v4.51h6.47c-.29 1.48-1.14 2.73-2.4 3.6v3h3.9c2.28-2.1 3.6-5.2 3.6-8.84z"/><path fill="#34A853" d="M12.255 24c3.24 0 5.95-1.08 7.96-2.91l-3.91-3c-1.08.72-2.45 1.16-4.05 1.16-3.13 0-5.78-2.11-6.73-4.96h-4.19v3.24c1.99 3.96 6.09 6.47 10.92 6.47z"/><path fill="#FBBC05" d="M5.525 14.29c-.25-.72-.38-1.49-.38-2.29s.14-1.57.38-2.29V6.46h-4.19c-.82 1.64-1.29 3.5-1.29 5.54s.47 3.9 1.29 5.54l4.19-3.25z"/><path fill="#EA4335" d="M12.255 4.75c1.77 0 3.35.61 4.6 1.8l3.42-3.42C18.205 1.19 15.495 0 12.255 0c-4.83 0-8.93 2.51-10.92 6.46l4.19 3.25c.95-2.85 3.6-4.96 6.73-4.96z"/></svg>
             Continue with Google
           </a>

--- a/website/signup/signup.js
+++ b/website/signup/signup.js
@@ -147,3 +147,11 @@ const API_BASE = (window.location.hostname === 'hookwing.com' ? 'https://api.hoo
     submitBtn.textContent = 'Create account';
   }
 })();
+
+// Set OAuth URLs dynamically based on environment
+(function setOAuthUrls() {
+  const github = document.getElementById('oauth-github');
+  const google = document.getElementById('oauth-google');
+  if (github) github.href = API_BASE + '/auth/github';
+  if (google) google.href = API_BASE + '/auth/google';
+})();

--- a/website/use-cases/index.html
+++ b/website/use-cases/index.html
@@ -49,6 +49,7 @@
   <link rel="stylesheet" href="/styles/pages/use-cases.css?v=11" />
 </head>
 <body>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
 
 
   <!-- ============================================================


### PR DESCRIPTION
Fixes 5 items from Brenda's UX audit:

- **M-1:** Pricing tier images 404 — refs were `tier-free/pro/enterprise`, actual files are `tier-paper-plane/warbird/stealth-jet`
- **M-2:** Pricing CTA hierarchy — Warbird (featured/"Most popular") now gets `btn-primary`, Paper Plane + Stealth Jet get `btn-secondary`
- **M-3:** Use-cases page missing skip-to-content accessibility link
- **M-5:** OAuth buttons (GitHub/Google) were hardcoded to `dev.api.hookwing.com` — now set dynamically via JS using same API_BASE detection as login/signup forms
- **M-6:** Playground footer `rgba(255,255,.25)` missing third channel → `rgba(255,255,255,.25)`

Remaining from audit: M-4 (9 docs sub-pages need new layout) + 8 minors → separate PR via Cody.