### PR TITLE
fix: migrate 9 docs sub-pages to docs.css sidebar layout (M-4)

### DIFF
--- a/website/blog/authors/hookwing-engineering/index.html
+++ b/website/blog/authors/hookwing-engineering/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <div style="display:flex;align-items:flex-start;gap:14px;flex-wrap:wrap">
         <img src="/assets/logos/logo-03-air-route-badge.svg" alt="Hookwing Engineering avatar" style="width:60px;height:60px;border-radius:999px;border:1px solid var(--color-border);background:white;padding:8px" />
         <div>
@@ -217,7 +216,7 @@
       <span>•</span>
       <span>5 min read</span>
       <span>•</span>
-      <a href="/blog/categories/tutorials/">tutorials</a>
+      <a href="/blog/categories/tutorials/">Tutorials</a>
     </div>
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">AI agents can&#39;t poll the world. Webhooks give them real-time awareness. Here&#39;s how agents use webhooks and what to look for in a webhook platform.</p>
@@ -264,8 +263,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Retries help, but they are only one part of webhook reliability.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/retries/">retries</a> <a class="chip" href="/blog/tags/reliability/">reliability</a> <a class="chip" href="/blog/tags/incident-response/">incident-response</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -279,7 +277,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -291,6 +289,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -300,9 +299,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -325,7 +324,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/authors/maya-chen/index.html
+++ b/website/blog/authors/maya-chen/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <div style="display:flex;align-items:flex-start;gap:14px;flex-wrap:wrap">
         <img src="/assets/logos/logo-02-folded-wing-crest.svg" alt="Maya Chen avatar" style="width:60px;height:60px;border-radius:999px;border:1px solid var(--color-border);background:white;padding:8px" />
         <div>
@@ -96,8 +95,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Maya Chen</div>
     <p style="flex:1;margin-bottom:var(--space-3);">A practical deployment workflow for reviewing content updates safely before merge.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/cloudflare/">cloudflare</a> <a class="chip" href="/blog/tags/workflow/">workflow</a> <a class="chip" href="/blog/tags/preview/">preview</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -111,7 +109,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -123,6 +121,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -132,9 +131,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -157,7 +156,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/categories/architecture/index.html
+++ b/website/blog/categories/architecture/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Category: Architecture</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts in Architecture.</p>
     </section>
@@ -104,8 +103,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Webhooks push events to a URL. Event streams let consumers pull at their own pace. Neither is universally better. The choice depends on who consumes and how. Here&#39;s the practical decision framework.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/event-streams/">event-streams</a> <a class="chip" href="/blog/tags/kafka/">kafka</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -119,7 +117,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -131,6 +129,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -140,9 +139,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -165,7 +164,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/categories/index.html
+++ b/website/blog/categories/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1>All categories</h1>
       <p class="lede">Browse operational topics by category.</p>
     </section>
@@ -92,8 +91,7 @@
 <article class="card">
       <h3><a href="/blog/categories/tutorials/">Tutorials</a></h3>
       <p class="lede">3 posts</p>
-    </article></section>
-    </div>
+    </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -107,7 +105,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -119,6 +117,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -128,9 +127,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -153,7 +152,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/categories/operations/index.html
+++ b/website/blog/categories/operations/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Category: Operations</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts in Operations.</p>
     </section>
@@ -118,8 +117,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Maya Chen</div>
     <p style="flex:1;margin-bottom:var(--space-3);">A practical deployment workflow for reviewing content updates safely before merge.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/cloudflare/">cloudflare</a> <a class="chip" href="/blog/tags/workflow/">workflow</a> <a class="chip" href="/blog/tags/preview/">preview</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -133,7 +131,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -145,6 +143,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -154,9 +153,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -179,7 +178,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/categories/reliability/index.html
+++ b/website/blog/categories/reliability/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Category: Reliability</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts in Reliability.</p>
     </section>
@@ -160,8 +159,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Retries help, but they are only one part of webhook reliability.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/retries/">retries</a> <a class="chip" href="/blog/tags/reliability/">reliability</a> <a class="chip" href="/blog/tags/incident-response/">incident-response</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -175,7 +173,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -187,6 +185,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -196,9 +195,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -221,7 +220,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/categories/tutorials/index.html
+++ b/website/blog/categories/tutorials/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Category: Tutorials</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts in Tutorials.</p>
     </section>
@@ -113,13 +112,12 @@
       <span>•</span>
       <span>5 min read</span>
       <span>•</span>
-      <a href="/blog/categories/tutorials/">tutorials</a>
+      <a href="/blog/categories/tutorials/">Tutorials</a>
     </div>
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">AI agents can&#39;t poll the world. Webhooks give them real-time awareness. Here&#39;s how agents use webhooks and what to look for in a webhook platform.</p>
     <div style="margin-top:auto;"></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -133,7 +131,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -145,6 +143,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -154,9 +153,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -179,7 +178,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/cloudflare-preview-ops/index.html
+++ b/website/blog/cloudflare-preview-ops/index.html
@@ -75,8 +75,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <nav class="breadcrumb" aria-label="Breadcrumb">
+    <div class="shell"><nav class="breadcrumb" aria-label="Breadcrumb">
     <ol>
       <li><a href="/">Home</a></li>
       <li><a href="/blog/">Blog</a></li>
@@ -141,8 +140,7 @@
         <a class="btn btn-secondary btn-md" href="/docs/getting-started/">Read docs</a>
       </div>
     </section>
-  </article>
-    </div>
+  </article></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -156,7 +154,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -168,6 +166,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -177,9 +176,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -202,7 +201,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/debugging-webhooks/index.html
+++ b/website/blog/debugging-webhooks/index.html
@@ -75,8 +75,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <nav class="breadcrumb" aria-label="Breadcrumb">
+    <div class="shell"><nav class="breadcrumb" aria-label="Breadcrumb">
     <ol>
       <li><a href="/">Home</a></li>
       <li><a href="/blog/">Blog</a></li>
@@ -278,8 +277,7 @@ gh api /repos/org/repo/dispatches -f event_type=deploy</code></pre>
         <a class="btn btn-secondary btn-md" href="/docs/getting-started/">Read docs</a>
       </div>
     </section>
-  </article>
-    </div>
+  </article></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -293,7 +291,7 @@ gh api /repos/org/repo/dispatches -f event_type=deploy</code></pre>
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -305,6 +303,7 @@ gh api /repos/org/repo/dispatches -f event_type=deploy</code></pre>
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -314,9 +313,9 @@ gh api /repos/org/repo/dispatches -f event_type=deploy</code></pre>
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -339,7 +338,7 @@ gh api /repos/org/repo/dispatches -f event_type=deploy</code></pre>
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/index.html
+++ b/website/blog/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Hookwing Blog</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Clear operating guides for delivery reliability, incident response, and production-ready webhook systems.</p>
       <div class="search-box" role="search" style="margin-bottom:var(--space-4);">
@@ -219,7 +218,7 @@
       <span>•</span>
       <span>5 min read</span>
       <span>•</span>
-      <a href="/blog/categories/tutorials/">tutorials</a>
+      <a href="/blog/categories/tutorials/">Tutorials</a>
     </div>
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">AI agents can&#39;t poll the world. Webhooks give them real-time awareness. Here&#39;s how agents use webhooks and what to look for in a webhook platform.</p>
@@ -316,8 +315,7 @@
 
   input.addEventListener('input', filter);
 })();
-</script>
-    </div>
+</script></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -343,10 +341,11 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
-            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
+            <li><a href="/getting-started/" class="footer-link">Agent integrations</a></li>
           </ul>
         </div>
         <div>

--- a/website/blog/mcp-server-webhook-tool/index.html
+++ b/website/blog/mcp-server-webhook-tool/index.html
@@ -75,8 +75,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <nav class="breadcrumb" aria-label="Breadcrumb">
+    <div class="shell"><nav class="breadcrumb" aria-label="Breadcrumb">
     <ol>
       <li><a href="/">Home</a></li>
       <li><a href="/blog/">Blog</a></li>
@@ -295,8 +294,7 @@ server.<span class="hljs-title function_">tool</span>(<span class="hljs-string">
         <a class="btn btn-secondary btn-md" href="/docs/getting-started/">Read docs</a>
       </div>
     </section>
-  </article>
-    </div>
+  </article></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -310,7 +308,7 @@ server.<span class="hljs-title function_">tool</span>(<span class="hljs-string">
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -322,6 +320,7 @@ server.<span class="hljs-title function_">tool</span>(<span class="hljs-string">
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -331,9 +330,9 @@ server.<span class="hljs-title function_">tool</span>(<span class="hljs-string">
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -356,7 +355,7 @@ server.<span class="hljs-title function_">tool</span>(<span class="hljs-string">
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/tags/agents/index.html
+++ b/website/blog/tags/agents/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Tag: agents</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with agents.</p>
     </section>
@@ -90,8 +89,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">One incoming event, multiple consumers. Here&#39;s how webhook fan-out works, when you need it, and the patterns that hold up in production.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/architecture/">architecture</a> <a class="chip" href="/blog/tags/fan-out/">fan-out</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -105,7 +103,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -117,6 +115,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -126,9 +125,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -151,7 +150,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/tags/ai-agents/index.html
+++ b/website/blog/tags/ai-agents/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Tag: ai-agents</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with ai-agents.</p>
     </section>
@@ -104,8 +103,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Give your AI agent a webhook endpoint in minutes: one API call, five-line verification, and a simple routing loop. No dashboard, no boilerplate.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/ai-agents/">ai-agents</a> <a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/tutorials/">tutorials</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -119,7 +117,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -131,6 +129,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -140,9 +139,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -165,7 +164,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/tags/architecture/index.html
+++ b/website/blog/tags/architecture/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Tag: architecture</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with architecture.</p>
     </section>
@@ -104,8 +103,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Webhooks push events to a URL. Event streams let consumers pull at their own pace. Neither is universally better. The choice depends on who consumes and how. Here&#39;s the practical decision framework.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/event-streams/">event-streams</a> <a class="chip" href="/blog/tags/kafka/">kafka</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -119,7 +117,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -131,6 +129,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -140,9 +139,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -165,7 +164,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/tags/async/index.html
+++ b/website/blog/tags/async/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Tag: async</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with async.</p>
     </section>
@@ -90,8 +89,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">MCP tools are synchronous, but real-world agent workflows run on async events. Here&#39;s how to add a webhook tool to your MCP server so agents can listen without polling.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/mcp/">mcp</a> <a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/ai-agents/">ai-agents</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -105,7 +103,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -117,6 +115,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -126,9 +125,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -151,7 +150,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/tags/backoff/index.html
+++ b/website/blog/tags/backoff/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Tag: backoff</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with backoff.</p>
     </section>
@@ -90,8 +89,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Rate limits are a two-sided problem in webhook systems. Here&#39;s how to handle 429s as a sender and protect your endpoint as a receiver, with practical patterns and code.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/rate-limiting/">rate-limiting</a> <a class="chip" href="/blog/tags/reliability/">reliability</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -105,7 +103,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -117,6 +115,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -126,9 +125,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -151,7 +150,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/tags/cloudflare/index.html
+++ b/website/blog/tags/cloudflare/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Tag: cloudflare</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with cloudflare.</p>
     </section>
@@ -90,8 +89,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Maya Chen</div>
     <p style="flex:1;margin-bottom:var(--space-3);">A practical deployment workflow for reviewing content updates safely before merge.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/cloudflare/">cloudflare</a> <a class="chip" href="/blog/tags/workflow/">workflow</a> <a class="chip" href="/blog/tags/preview/">preview</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -105,7 +103,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -117,6 +115,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -126,9 +125,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -151,7 +150,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/tags/dead-letter-queue/index.html
+++ b/website/blog/tags/dead-letter-queue/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Tag: dead-letter-queue</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with dead-letter-queue.</p>
     </section>
@@ -90,8 +89,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Retries handle transient failures. Dead letter queues handle everything else. How to build a DLQ that stores, alerts on, and replays failed webhook events.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/reliability/">reliability</a> <a class="chip" href="/blog/tags/dead-letter-queue/">dead-letter-queue</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -105,7 +103,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -117,6 +115,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -126,9 +125,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -151,7 +150,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/tags/debugging/index.html
+++ b/website/blog/tags/debugging/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Tag: debugging</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with debugging.</p>
     </section>
@@ -90,8 +89,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Webhooks fail silently, fire asynchronously, and vanish before you can inspect them. Here&#39;s a practical system for debugging webhook integrations in dev and production.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/debugging/">debugging</a> <a class="chip" href="/blog/tags/developer-experience/">developer-experience</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -105,7 +103,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -117,6 +115,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -126,9 +125,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -151,7 +150,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/tags/decision-making/index.html
+++ b/website/blog/tags/decision-making/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Tag: decision-making</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with decision-making.</p>
     </section>
@@ -90,8 +89,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Webhooks push events to a URL. Event streams let consumers pull at their own pace. Neither is universally better. The choice depends on who consumes and how. Here&#39;s the practical decision framework.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/event-streams/">event-streams</a> <a class="chip" href="/blog/tags/kafka/">kafka</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -105,7 +103,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -117,6 +115,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -126,9 +125,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -151,7 +150,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/tags/developer-experience/index.html
+++ b/website/blog/tags/developer-experience/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Tag: developer-experience</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with developer-experience.</p>
     </section>
@@ -90,8 +89,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Webhooks fail silently, fire asynchronously, and vanish before you can inspect them. Here&#39;s a practical system for debugging webhook integrations in dev and production.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/debugging/">debugging</a> <a class="chip" href="/blog/tags/developer-experience/">developer-experience</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -105,7 +103,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -117,6 +115,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -126,9 +125,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -151,7 +150,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/tags/event-handling/index.html
+++ b/website/blog/tags/event-handling/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Tag: event-handling</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with event-handling.</p>
     </section>
@@ -90,8 +89,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Webhooks make no ordering guarantees. Here&#39;s why events arrive out of sequence, what breaks when they do, and three receiver-side patterns that handle it correctly.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/reliability/">reliability</a> <a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/idempotency/">idempotency</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -105,7 +103,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -117,6 +115,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -126,9 +125,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -151,7 +150,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/tags/event-streams/index.html
+++ b/website/blog/tags/event-streams/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Tag: event-streams</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with event-streams.</p>
     </section>
@@ -90,8 +89,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Webhooks push events to a URL. Event streams let consumers pull at their own pace. Neither is universally better. The choice depends on who consumes and how. Here&#39;s the practical decision framework.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/event-streams/">event-streams</a> <a class="chip" href="/blog/tags/kafka/">kafka</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -105,7 +103,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -117,6 +115,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -126,9 +125,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -151,7 +150,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/tags/fan-out/index.html
+++ b/website/blog/tags/fan-out/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Tag: fan-out</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with fan-out.</p>
     </section>
@@ -90,8 +89,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">One incoming event, multiple consumers. Here&#39;s how webhook fan-out works, when you need it, and the patterns that hold up in production.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/architecture/">architecture</a> <a class="chip" href="/blog/tags/fan-out/">fan-out</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -105,7 +103,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -117,6 +115,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -126,9 +125,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -151,7 +150,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/tags/getting-started/index.html
+++ b/website/blog/tags/getting-started/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Tag: getting-started</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with getting-started.</p>
     </section>
@@ -90,8 +89,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Give your AI agent a webhook endpoint in minutes: one API call, five-line verification, and a simple routing loop. No dashboard, no boilerplate.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/ai-agents/">ai-agents</a> <a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/tutorials/">tutorials</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -105,7 +103,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -117,6 +115,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -126,9 +125,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -151,7 +150,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/tags/hmac/index.html
+++ b/website/blog/tags/hmac/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Tag: hmac</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with hmac.</p>
     </section>
@@ -90,8 +89,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Webhook signature verification in plain terms: how HMAC-SHA256 works, a 10-line implementation, and the three mistakes that break it silently.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/security/">security</a> <a class="chip" href="/blog/tags/reliability/">reliability</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -105,7 +103,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -117,6 +115,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -126,9 +125,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -151,7 +150,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/tags/idempotency/index.html
+++ b/website/blog/tags/idempotency/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Tag: idempotency</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with idempotency.</p>
     </section>
@@ -104,8 +103,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">A practical, empowering checklist to prevent duplicate side effects and keep webhook consumers safe in production.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/idempotency/">idempotency</a> <a class="chip" href="/blog/tags/reliability/">reliability</a> <a class="chip" href="/blog/tags/webhooks/">webhooks</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -119,7 +117,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -131,6 +129,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -140,9 +139,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -165,7 +164,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/tags/incident-response/index.html
+++ b/website/blog/tags/incident-response/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Tag: incident-response</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with incident-response.</p>
     </section>
@@ -90,8 +89,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Retries help, but they are only one part of webhook reliability.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/retries/">retries</a> <a class="chip" href="/blog/tags/reliability/">reliability</a> <a class="chip" href="/blog/tags/incident-response/">incident-response</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -105,7 +103,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -117,6 +115,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -126,9 +125,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -151,7 +150,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/tags/index.html
+++ b/website/blog/tags/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1>All tags</h1>
       <p class="lede">Browse topics across Hookwing blog posts.</p>
     </section>
@@ -220,8 +219,7 @@
 <article class="card">
       <h3><a href="/blog/tags/workflow/">workflow</a></h3>
       <p class="lede">1 post</p>
-    </article></section>
-    </div>
+    </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -235,7 +233,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -247,6 +245,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -256,9 +255,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -281,7 +280,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/tags/kafka/index.html
+++ b/website/blog/tags/kafka/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Tag: kafka</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with kafka.</p>
     </section>
@@ -90,8 +89,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Webhooks push events to a URL. Event streams let consumers pull at their own pace. Neither is universally better. The choice depends on who consumes and how. Here&#39;s the practical decision framework.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/event-streams/">event-streams</a> <a class="chip" href="/blog/tags/kafka/">kafka</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -105,7 +103,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -117,6 +115,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -126,9 +125,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -151,7 +150,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/tags/logging/index.html
+++ b/website/blog/tags/logging/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Tag: logging</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with logging.</p>
     </section>
@@ -90,8 +89,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Practical observability for webhook systems. Which metrics to monitor, how to structure logs, exact alert thresholds, and debugging patterns that catch 80% of production issues.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/monitoring/">monitoring</a> <a class="chip" href="/blog/tags/observability/">observability</a> <a class="chip" href="/blog/tags/reliability/">reliability</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -105,7 +103,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -117,6 +115,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -126,9 +125,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -151,7 +150,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/tags/mcp/index.html
+++ b/website/blog/tags/mcp/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Tag: mcp</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with mcp.</p>
     </section>
@@ -90,8 +89,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">MCP tools are synchronous, but real-world agent workflows run on async events. Here&#39;s how to add a webhook tool to your MCP server so agents can listen without polling.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/mcp/">mcp</a> <a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/ai-agents/">ai-agents</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -105,7 +103,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -117,6 +115,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -126,9 +125,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -151,7 +150,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/tags/monitoring/index.html
+++ b/website/blog/tags/monitoring/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Tag: monitoring</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with monitoring.</p>
     </section>
@@ -90,8 +89,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Practical observability for webhook systems. Which metrics to monitor, how to structure logs, exact alert thresholds, and debugging patterns that catch 80% of production issues.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/monitoring/">monitoring</a> <a class="chip" href="/blog/tags/observability/">observability</a> <a class="chip" href="/blog/tags/reliability/">reliability</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -105,7 +103,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -117,6 +115,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -126,9 +125,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -151,7 +150,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/tags/observability/index.html
+++ b/website/blog/tags/observability/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Tag: observability</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with observability.</p>
     </section>
@@ -104,8 +103,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Practical observability for webhook systems. Which metrics to monitor, how to structure logs, exact alert thresholds, and debugging patterns that catch 80% of production issues.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/monitoring/">monitoring</a> <a class="chip" href="/blog/tags/observability/">observability</a> <a class="chip" href="/blog/tags/reliability/">reliability</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -119,7 +117,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -131,6 +129,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -140,9 +139,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -165,7 +164,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/tags/openclaw/index.html
+++ b/website/blog/tags/openclaw/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Tag: openclaw</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with openclaw.</p>
     </section>
@@ -90,8 +89,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Give your AI agent a webhook endpoint in minutes: one API call, five-line verification, and a simple routing loop. No dashboard, no boilerplate.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/ai-agents/">ai-agents</a> <a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/tutorials/">tutorials</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -105,7 +103,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -117,6 +115,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -126,9 +125,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -151,7 +150,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/tags/operations/index.html
+++ b/website/blog/tags/operations/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Tag: operations</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with operations.</p>
     </section>
@@ -90,8 +89,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Retries handle transient failures. Dead letter queues handle everything else. How to build a DLQ that stores, alerts on, and replays failed webhook events.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/reliability/">reliability</a> <a class="chip" href="/blog/tags/dead-letter-queue/">dead-letter-queue</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -105,7 +103,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -117,6 +115,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -126,9 +125,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -151,7 +150,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/tags/preview/index.html
+++ b/website/blog/tags/preview/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Tag: preview</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with preview.</p>
     </section>
@@ -90,8 +89,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Maya Chen</div>
     <p style="flex:1;margin-bottom:var(--space-3);">A practical deployment workflow for reviewing content updates safely before merge.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/cloudflare/">cloudflare</a> <a class="chip" href="/blog/tags/workflow/">workflow</a> <a class="chip" href="/blog/tags/preview/">preview</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -105,7 +103,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -117,6 +115,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -126,9 +125,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -151,7 +150,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/tags/production/index.html
+++ b/website/blog/tags/production/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Tag: production</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with production.</p>
     </section>
@@ -90,8 +89,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Practical observability for webhook systems. Which metrics to monitor, how to structure logs, exact alert thresholds, and debugging patterns that catch 80% of production issues.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/monitoring/">monitoring</a> <a class="chip" href="/blog/tags/observability/">observability</a> <a class="chip" href="/blog/tags/reliability/">reliability</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -105,7 +103,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -117,6 +115,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -126,9 +125,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -151,7 +150,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/tags/rate-limiting/index.html
+++ b/website/blog/tags/rate-limiting/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Tag: rate-limiting</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with rate-limiting.</p>
     </section>
@@ -90,8 +89,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Rate limits are a two-sided problem in webhook systems. Here&#39;s how to handle 429s as a sender and protect your endpoint as a receiver, with practical patterns and code.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/rate-limiting/">rate-limiting</a> <a class="chip" href="/blog/tags/reliability/">reliability</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -105,7 +103,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -117,6 +115,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -126,9 +125,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -151,7 +150,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/tags/reliability/index.html
+++ b/website/blog/tags/reliability/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Tag: reliability</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with reliability.</p>
     </section>
@@ -174,8 +173,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Retries help, but they are only one part of webhook reliability.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/retries/">retries</a> <a class="chip" href="/blog/tags/reliability/">reliability</a> <a class="chip" href="/blog/tags/incident-response/">incident-response</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -189,7 +187,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -201,6 +199,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -210,9 +209,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -235,7 +234,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/tags/retries/index.html
+++ b/website/blog/tags/retries/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Tag: retries</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with retries.</p>
     </section>
@@ -118,8 +117,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Retries help, but they are only one part of webhook reliability.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/retries/">retries</a> <a class="chip" href="/blog/tags/reliability/">reliability</a> <a class="chip" href="/blog/tags/incident-response/">incident-response</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -133,7 +131,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -145,6 +143,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -154,9 +153,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -179,7 +178,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/tags/routing/index.html
+++ b/website/blog/tags/routing/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Tag: routing</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with routing.</p>
     </section>
@@ -90,8 +89,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">One incoming event, multiple consumers. Here&#39;s how webhook fan-out works, when you need it, and the patterns that hold up in production.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/architecture/">architecture</a> <a class="chip" href="/blog/tags/fan-out/">fan-out</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -105,7 +103,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -117,6 +115,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -126,9 +125,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -151,7 +150,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/tags/security/index.html
+++ b/website/blog/tags/security/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Tag: security</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with security.</p>
     </section>
@@ -90,8 +89,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Webhook signature verification in plain terms: how HMAC-SHA256 works, a 10-line implementation, and the three mistakes that break it silently.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/security/">security</a> <a class="chip" href="/blog/tags/reliability/">reliability</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -105,7 +103,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -117,6 +115,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -126,9 +125,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -151,7 +150,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/tags/testing/index.html
+++ b/website/blog/tags/testing/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Tag: testing</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with testing.</p>
     </section>
@@ -90,8 +89,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Webhooks fail silently, fire asynchronously, and vanish before you can inspect them. Here&#39;s a practical system for debugging webhook integrations in dev and production.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/debugging/">debugging</a> <a class="chip" href="/blog/tags/developer-experience/">developer-experience</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -105,7 +103,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -117,6 +115,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -126,9 +125,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -151,7 +150,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/tags/tutorials/index.html
+++ b/website/blog/tags/tutorials/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Tag: tutorials</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with tutorials.</p>
     </section>
@@ -104,8 +103,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Give your AI agent a webhook endpoint in minutes: one API call, five-line verification, and a simple routing loop. No dashboard, no boilerplate.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/ai-agents/">ai-agents</a> <a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/tutorials/">tutorials</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -119,7 +117,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -131,6 +129,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -140,9 +139,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -165,7 +164,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/tags/verification/index.html
+++ b/website/blog/tags/verification/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Tag: verification</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with verification.</p>
     </section>
@@ -90,8 +89,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">Webhook signature verification in plain terms: how HMAC-SHA256 works, a 10-line implementation, and the three mistakes that break it silently.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/webhooks/">webhooks</a> <a class="chip" href="/blog/tags/security/">security</a> <a class="chip" href="/blog/tags/reliability/">reliability</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -105,7 +103,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -117,6 +115,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -126,9 +125,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -151,7 +150,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/tags/webhooks/index.html
+++ b/website/blog/tags/webhooks/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Tag: webhooks</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with webhooks.</p>
     </section>
@@ -216,8 +215,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Hookwing Engineering</div>
     <p style="flex:1;margin-bottom:var(--space-3);">A practical, empowering checklist to prevent duplicate side effects and keep webhook consumers safe in production.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/idempotency/">idempotency</a> <a class="chip" href="/blog/tags/reliability/">reliability</a> <a class="chip" href="/blog/tags/webhooks/">webhooks</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -231,7 +229,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -243,6 +241,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -252,9 +251,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -277,7 +276,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/tags/workflow/index.html
+++ b/website/blog/tags/workflow/index.html
@@ -72,8 +72,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <section class="panel">
+    <div class="shell"><section class="panel">
       <h1 style="margin-bottom:var(--space-4);">Tag: workflow</h1>
       <p class="lede" style="margin-bottom:var(--space-4);">Posts tagged with workflow.</p>
     </section>
@@ -90,8 +89,7 @@
     <div style="font-size:.85rem;color:var(--color-ink-muted);margin-bottom:var(--space-3);">By Maya Chen</div>
     <p style="flex:1;margin-bottom:var(--space-3);">A practical deployment workflow for reviewing content updates safely before merge.</p>
     <div style="margin-top:auto;"><a class="chip" href="/blog/tags/cloudflare/">cloudflare</a> <a class="chip" href="/blog/tags/workflow/">workflow</a> <a class="chip" href="/blog/tags/preview/">preview</a></div>
-  </article></section>
-    </div>
+  </article></section></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -105,7 +103,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -117,6 +115,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -126,9 +125,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -151,7 +150,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/webhook-dead-letter-queues/index.html
+++ b/website/blog/webhook-dead-letter-queues/index.html
@@ -75,8 +75,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <nav class="breadcrumb" aria-label="Breadcrumb">
+    <div class="shell"><nav class="breadcrumb" aria-label="Breadcrumb">
     <ol>
       <li><a href="/">Home</a></li>
       <li><a href="/blog/">Blog</a></li>
@@ -213,8 +212,7 @@
         <a class="btn btn-secondary btn-md" href="/docs/getting-started/">Read docs</a>
       </div>
     </section>
-  </article>
-    </div>
+  </article></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -228,7 +226,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -240,6 +238,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -249,9 +248,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -274,7 +273,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/webhook-endpoint-for-ai-agents/index.html
+++ b/website/blog/webhook-endpoint-for-ai-agents/index.html
@@ -75,8 +75,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <nav class="breadcrumb" aria-label="Breadcrumb">
+    <div class="shell"><nav class="breadcrumb" aria-label="Breadcrumb">
     <ol>
       <li><a href="/">Home</a></li>
       <li><a href="/blog/">Blog</a></li>
@@ -224,8 +223,7 @@ WEBHOOK_SECRET = <span class="hljs-string">&quot;your-signing-secret&quot;</span
         <a class="btn btn-secondary btn-md" href="/docs/getting-started/">Read docs</a>
       </div>
     </section>
-  </article>
-    </div>
+  </article></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -239,7 +237,7 @@ WEBHOOK_SECRET = <span class="hljs-string">&quot;your-signing-secret&quot;</span
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -251,6 +249,7 @@ WEBHOOK_SECRET = <span class="hljs-string">&quot;your-signing-secret&quot;</span
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -260,9 +259,9 @@ WEBHOOK_SECRET = <span class="hljs-string">&quot;your-signing-secret&quot;</span
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -285,7 +284,7 @@ WEBHOOK_SECRET = <span class="hljs-string">&quot;your-signing-secret&quot;</span
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/webhook-event-ordering/index.html
+++ b/website/blog/webhook-event-ordering/index.html
@@ -75,8 +75,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <nav class="breadcrumb" aria-label="Breadcrumb">
+    <div class="shell"><nav class="breadcrumb" aria-label="Breadcrumb">
     <ol>
       <li><a href="/">Home</a></li>
       <li><a href="/blog/">Blog</a></li>
@@ -215,8 +214,7 @@ Event C (resource: order-123)  → Queue partition: order-123 → Consumer 1 (af
         <a class="btn btn-secondary btn-md" href="/docs/getting-started/">Read docs</a>
       </div>
     </section>
-  </article>
-    </div>
+  </article></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -230,7 +228,7 @@ Event C (resource: order-123)  → Queue partition: order-123 → Consumer 1 (af
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -242,6 +240,7 @@ Event C (resource: order-123)  → Queue partition: order-123 → Consumer 1 (af
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -251,9 +250,9 @@ Event C (resource: order-123)  → Queue partition: order-123 → Consumer 1 (af
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -276,7 +275,7 @@ Event C (resource: order-123)  → Queue partition: order-123 → Consumer 1 (af
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/webhook-fan-out/index.html
+++ b/website/blog/webhook-fan-out/index.html
@@ -75,8 +75,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <nav class="breadcrumb" aria-label="Breadcrumb">
+    <div class="shell"><nav class="breadcrumb" aria-label="Breadcrumb">
     <ol>
       <li><a href="/">Home</a></li>
       <li><a href="/blog/">Blog</a></li>
@@ -253,8 +252,7 @@ curl -X POST https://api.hookwing.com/v1/endpoints \
         <a class="btn btn-secondary btn-md" href="/docs/getting-started/">Read docs</a>
       </div>
     </section>
-  </article>
-    </div>
+  </article></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -268,7 +266,7 @@ curl -X POST https://api.hookwing.com/v1/endpoints \
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -280,6 +278,7 @@ curl -X POST https://api.hookwing.com/v1/endpoints \
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -289,9 +288,9 @@ curl -X POST https://api.hookwing.com/v1/endpoints \
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -314,7 +313,7 @@ curl -X POST https://api.hookwing.com/v1/endpoints \
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/webhook-idempotency-checklist/index.html
+++ b/website/blog/webhook-idempotency-checklist/index.html
@@ -75,8 +75,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <nav class="breadcrumb" aria-label="Breadcrumb">
+    <div class="shell"><nav class="breadcrumb" aria-label="Breadcrumb">
     <ol>
       <li><a href="/">Home</a></li>
       <li><a href="/blog/">Blog</a></li>
@@ -210,8 +209,7 @@
         <a class="btn btn-secondary btn-md" href="/docs/getting-started/">Read docs</a>
       </div>
     </section>
-  </article>
-    </div>
+  </article></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -225,7 +223,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -237,6 +235,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -246,9 +245,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -271,7 +270,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/webhook-monitoring-observability/index.html
+++ b/website/blog/webhook-monitoring-observability/index.html
@@ -75,8 +75,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <nav class="breadcrumb" aria-label="Breadcrumb">
+    <div class="shell"><nav class="breadcrumb" aria-label="Breadcrumb">
     <ol>
       <li><a href="/">Home</a></li>
       <li><a href="/blog/">Blog</a></li>
@@ -313,8 +312,7 @@
         <a class="btn btn-secondary btn-md" href="/docs/getting-started/">Read docs</a>
       </div>
     </section>
-  </article>
-    </div>
+  </article></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -328,7 +326,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -340,6 +338,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -349,9 +348,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -374,7 +373,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/webhook-rate-limiting/index.html
+++ b/website/blog/webhook-rate-limiting/index.html
@@ -75,8 +75,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <nav class="breadcrumb" aria-label="Breadcrumb">
+    <div class="shell"><nav class="breadcrumb" aria-label="Breadcrumb">
     <ol>
       <li><a href="/">Home</a></li>
       <li><a href="/blog/">Blog</a></li>
@@ -220,8 +219,7 @@ X-RateLimit-Reset: 1711020000</code></pre>
         <a class="btn btn-secondary btn-md" href="/docs/getting-started/">Read docs</a>
       </div>
     </section>
-  </article>
-    </div>
+  </article></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -235,7 +233,7 @@ X-RateLimit-Reset: 1711020000</code></pre>
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -247,6 +245,7 @@ X-RateLimit-Reset: 1711020000</code></pre>
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -256,9 +255,9 @@ X-RateLimit-Reset: 1711020000</code></pre>
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -281,7 +280,7 @@ X-RateLimit-Reset: 1711020000</code></pre>
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/webhook-retry-best-practices/index.html
+++ b/website/blog/webhook-retry-best-practices/index.html
@@ -75,8 +75,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <nav class="breadcrumb" aria-label="Breadcrumb">
+    <div class="shell"><nav class="breadcrumb" aria-label="Breadcrumb">
     <ol>
       <li><a href="/">Home</a></li>
       <li><a href="/blog/">Blog</a></li>
@@ -188,8 +187,7 @@
         <a class="btn btn-secondary btn-md" href="/docs/getting-started/">Read docs</a>
       </div>
     </section>
-  </article>
-    </div>
+  </article></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -203,7 +201,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -215,6 +213,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -224,9 +223,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -249,7 +248,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/webhook-signature-verification/index.html
+++ b/website/blog/webhook-signature-verification/index.html
@@ -75,8 +75,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <nav class="breadcrumb" aria-label="Breadcrumb">
+    <div class="shell"><nav class="breadcrumb" aria-label="Breadcrumb">
     <ol>
       <li><a href="/">Home</a></li>
       <li><a href="/blog/">Blog</a></li>
@@ -231,8 +230,7 @@ WEBHOOK_SECRET = <span class="hljs-string">&quot;your-signing-secret-from-hookwi
         <a class="btn btn-secondary btn-md" href="/docs/getting-started/">Read docs</a>
       </div>
     </section>
-  </article>
-    </div>
+  </article></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -246,7 +244,7 @@ WEBHOOK_SECRET = <span class="hljs-string">&quot;your-signing-secret-from-hookwi
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -258,6 +256,7 @@ WEBHOOK_SECRET = <span class="hljs-string">&quot;your-signing-secret-from-hookwi
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -267,9 +266,9 @@ WEBHOOK_SECRET = <span class="hljs-string">&quot;your-signing-secret-from-hookwi
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -292,7 +291,7 @@ WEBHOOK_SECRET = <span class="hljs-string">&quot;your-signing-secret-from-hookwi
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/webhooks-for-ai-agents/index.html
+++ b/website/blog/webhooks-for-ai-agents/index.html
@@ -75,8 +75,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <nav class="breadcrumb" aria-label="Breadcrumb">
+    <div class="shell"><nav class="breadcrumb" aria-label="Breadcrumb">
     <ol>
       <li><a href="/">Home</a></li>
       <li><a href="/blog/">Blog</a></li>
@@ -228,8 +227,7 @@ WEBHOOK_SECRET = <span class="hljs-string">&quot;your-signing-secret&quot;</span
         <a class="btn btn-secondary btn-md" href="/docs/getting-started/">Read docs</a>
       </div>
     </section>
-  </article>
-    </div>
+  </article></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -243,7 +241,7 @@ WEBHOOK_SECRET = <span class="hljs-string">&quot;your-signing-secret&quot;</span
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -255,6 +253,7 @@ WEBHOOK_SECRET = <span class="hljs-string">&quot;your-signing-secret&quot;</span
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -264,9 +263,9 @@ WEBHOOK_SECRET = <span class="hljs-string">&quot;your-signing-secret&quot;</span
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -289,7 +288,7 @@ WEBHOOK_SECRET = <span class="hljs-string">&quot;your-signing-secret&quot;</span
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/blog/webhooks-vs-event-streams/index.html
+++ b/website/blog/webhooks-vs-event-streams/index.html
@@ -75,8 +75,7 @@
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      <nav class="breadcrumb" aria-label="Breadcrumb">
+    <div class="shell"><nav class="breadcrumb" aria-label="Breadcrumb">
     <ol>
       <li><a href="/">Home</a></li>
       <li><a href="/blog/">Blog</a></li>
@@ -244,8 +243,7 @@
         <a class="btn btn-secondary btn-md" href="/docs/getting-started/">Read docs</a>
       </div>
     </section>
-  </article>
-    </div>
+  </article></div>
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -259,7 +257,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -271,6 +269,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -280,9 +279,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -305,7 +304,7 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>

--- a/website/docs/agent-integrations/index.html
+++ b/website/docs/agent-integrations/index.html
@@ -3,32 +3,25 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://hookwing.com; connect-src 'self' https://dev.api.hookwing.com https://api.hookwing.com; base-uri 'self'; form-action 'self';" />
   <meta name="description" content="How AI agents and coding assistants integrate with Hookwing — MCP server, API self-provisioning, and programmatic management." />
   <link rel="canonical" href="https://dev.hookwing.com/docs/agent-integrations/" />
   <meta property="og:site_name" content="Hookwing" />
   <meta property="og:type" content="website" />
-  <meta property="og:image" content="https://hookwing.com/assets/og/default.png" />
   <meta property="og:title" content="Agent Integrations | Hookwing" />
   <meta property="og:description" content="How AI agents and coding assistants integrate with Hookwing — MCP server, API self-provisioning, and programmatic management." />
   <meta property="og:url" content="https://dev.hookwing.com/docs/agent-integrations/" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Agent Integrations | Hookwing" />
+  <meta name="twitter:description" content="How AI agents and coding assistants integrate with Hookwing — MCP server, API self-provisioning, and programmatic management." />
   <title>Agent Integrations | Hookwing</title>
-  <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-  <link rel="icon" href="/favicon-32.png" sizes="32x32" type="image/png" />
-  <link rel="manifest" href="/site.webmanifest" />
-  <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" />
-  <link rel="stylesheet" href="/styles/tokens.css" />
-  <link rel="stylesheet" href="/styles/base.css" />
-  <link rel="stylesheet" href="/styles/components.css" />
-  <link rel="stylesheet" href="/styles/patterns.css" />
+  <link rel="stylesheet" href="/styles/tokens.css?v=7" />
+  <link rel="stylesheet" href="/styles/base.css?v=7" />
+  <link rel="stylesheet" href="/styles/components.css?v=7" />
+  <link rel="stylesheet" href="/styles/patterns.css?v=8" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css" />
   <link rel="stylesheet" href="/styles/docs.css" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css" />
 </head>
 <body>
-  <!-- Navigation (same as homepage) -->
   <header>
     <nav class="nav" aria-label="Main navigation">
       <div class="container">
@@ -45,7 +38,7 @@
             <li><a href="/use-cases/" class="nav-link">Use cases</a></li>
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
-            <li><a href="/docs/" class="nav-link is-active">Documentation</a></li>
+            <li><a href="/docs/" class="nav-link">Documentation</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/signup/" class="nav-link">Start free</a></li>
           </ul>
@@ -78,7 +71,8 @@
       </div>
     </div>
   </header>
-
+  <main id="main-content">
+    
   <!-- Mobile hamburger toggle -->
   <button class="docs-hamburger" id="docs-hamburger" aria-label="Toggle documentation menu" aria-expanded="false" aria-controls="docs-sidebar">
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -92,51 +86,37 @@
   <div class="docs-sidebar-backdrop" id="docs-sidebar-backdrop"></div>
 
   <div class="docs-layout">
-    <!-- Sidebar -->
-    <aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
-      <div class="docs-sidebar-inner">
-        <nav>
-          <div class="docs-nav-group">Overview</div>
-          <a href="/docs/" class="docs-nav-link">Introduction</a>
-          <a href="/docs/getting-started/" class="docs-nav-link docs-nav-link--nested">Getting Started</a>
-          <a href="/docs/authentication/" class="docs-nav-link docs-nav-link--nested">Authentication</a>
+    
+<aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
+  <div class="docs-sidebar-inner">
+    <nav>
+      <div class="docs-nav-group">Overview</div>
+      <a href="/docs/" class="docs-nav-link">Introduction</a>
+      <a href="/docs/getting-started/" class="docs-nav-link docs-nav-link--nested">Getting Started</a>
+      <a href="/docs/authentication/" class="docs-nav-link docs-nav-link--nested">Authentication</a>
 
-          <div class="docs-nav-group">API Reference</div>
-          <a href="/docs/endpoints/" class="docs-nav-link docs-nav-link--nested">Endpoints</a>
-          <a href="/docs/event-routing/" class="docs-nav-link docs-nav-link--nested">Event Routing</a>
+      <div class="docs-nav-group">API Reference</div>
+      <a href="/docs/endpoints/" class="docs-nav-link docs-nav-link--nested">Endpoints</a>
+      <a href="/docs/event-routing/" class="docs-nav-link docs-nav-link--nested">Event Routing</a>
 
-          <div class="docs-nav-group">Guides</div>
-          <a href="/docs/webhooks/" class="docs-nav-link docs-nav-link--nested">Webhook Signatures</a>
-          <a href="/docs/sdk-quickstart/" class="docs-nav-link docs-nav-link--nested">SDK Quickstart</a>
-          <a href="/docs/cli-reference/" class="docs-nav-link docs-nav-link--nested">CLI Reference</a>
-          <a href="/docs/error-codes/" class="docs-nav-link docs-nav-link--nested">Error Codes</a>
-          <a href="/docs/agent-integrations/" class="docs-nav-link docs-nav-link--nested is-active">Agent Integrations</a>
+      <div class="docs-nav-group">Guides</div>
+      <a href="/docs/webhooks/" class="docs-nav-link docs-nav-link--nested">Webhook Signatures</a>
+      <a href="/docs/sdk-quickstart/" class="docs-nav-link docs-nav-link--nested">SDK Quickstart</a>
+      <a href="/docs/cli-reference/" class="docs-nav-link docs-nav-link--nested">CLI Reference</a>
+      <a href="/docs/error-codes/" class="docs-nav-link docs-nav-link--nested">Error Codes</a>
+      <a href="/docs/agent-integrations/" class="docs-nav-link docs-nav-link--nested is-active">Agent Integrations</a>
 
-          <div class="docs-nav-group">Tools</div>
-          <a href="/docs/api/" class="docs-nav-link">API Explorer ↗</a>
-        </nav>
-      </div>
-    </aside>
-
+      <div class="docs-nav-group">Tools</div>
+      <a href="/docs/api/" class="docs-nav-link">API Explorer ↗</a>
+    </nav>
+  </div>
+</aside>
     <!-- Content -->
     <main id="main-content">
       <div class="docs-content-wrap">
         <div class="docs-content docs-main">
           <h1>Agent Integrations</h1>
           <p class="lede">How AI agents and coding assistants integrate with Hookwing — MCP server, API self-provisioning, and programmatic management.</p>
-
-          <nav class="docs-toc" aria-label="Table of contents">
-            <div class="docs-toc-label">On this page</div>
-            <ul class="docs-toc-list">
-              <li class="docs-toc-item"><a href="#hookwing-for-ai-agents" class="docs-toc-link">Hookwing for AI Agents</a></li>
-              <li class="docs-toc-item"><a href="#mcp-server" class="docs-toc-link">MCP Server</a></li>
-              <li class="docs-toc-item"><a href="#self-provisioning-via-api" class="docs-toc-link">Self-Provisioning via API</a></li>
-              <li class="docs-toc-item"><a href="#machine-readable-pricing" class="docs-toc-link">Machine-Readable Pricing</a></li>
-              <li class="docs-toc-item"><a href="#agent-code-examples" class="docs-toc-link">Agent Code Examples</a></li>
-              <li class="docs-toc-item"><a href="#full-api-reference" class="docs-toc-link">Full API Reference</a></li>
-            </ul>
-          </nav>
-
           <h2 id="hookwing-for-ai-agents">Hookwing for AI Agents</h2>
 <p>Hookwing is built for autonomous agents. No browser, no CAPTCHA, no human in the loop. Agents can create accounts, provision endpoints, manage billing, and inspect events — entirely via HTTP.</p>
 <h2 id="mcp-server">MCP Server</h2>
@@ -231,8 +211,7 @@ hookwing-mcp</code></pre>
       </div>
     </main>
   </div>
-
-  <!-- Footer (same as homepage) -->
+  </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
       <div class="footer-grid">
@@ -245,7 +224,7 @@ hookwing-mcp</code></pre>
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -257,6 +236,7 @@ hookwing-mcp</code></pre>
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -266,9 +246,9 @@ hookwing-mcp</code></pre>
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -291,18 +271,17 @@ hookwing-mcp</code></pre>
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>
   </footer>
-
   <script>
-    // Mobile nav toggle
     (function(){
       const toggle=document.getElementById('nav-toggle'),mobileNav=document.getElementById('nav-mobile');
       if(toggle&&mobileNav){toggle.addEventListener('click',function(){const e=this.getAttribute('aria-expanded')==='true';this.setAttribute('aria-expanded',String(!e));mobileNav.classList.toggle('is-open',!e);mobileNav.setAttribute('aria-hidden',String(e))});document.addEventListener('click',function(e){if(mobileNav.classList.contains('is-open')&&!mobileNav.contains(e.target)&&!toggle.contains(e.target)){toggle.setAttribute('aria-expanded','false');mobileNav.classList.remove('is-open');mobileNav.setAttribute('aria-hidden','true')}});document.addEventListener('keydown',function(e){if(e.key==='Escape'&&mobileNav.classList.contains('is-open')){toggle.setAttribute('aria-expanded','false');mobileNav.classList.remove('is-open');mobileNav.setAttribute('aria-hidden','true');toggle.focus()}});mobileNav.querySelectorAll('a').forEach(function(link){link.addEventListener('click',function(){toggle.setAttribute('aria-expanded','false');mobileNav.classList.remove('is-open');mobileNav.setAttribute('aria-hidden','true')})})}
-
+      const saved=localStorage.getItem('theme'),prefersDark=window.matchMedia('(prefers-color-scheme: dark)').matches;if(saved){document.documentElement.dataset.theme=saved}else if(prefersDark){document.documentElement.dataset.theme='dark'}
+      
       // Docs sidebar toggle
       const docsHamburger = document.getElementById('docs-hamburger');
       const docsSidebar = document.getElementById('docs-sidebar');
@@ -312,7 +291,7 @@ hookwing-mcp</code></pre>
         docsHamburger.addEventListener('click', function() {
           const isOpen = docsSidebar.classList.contains('is-open');
           docsSidebar.classList.toggle('is-open', !isOpen);
-          docsBackdrop.classList.toggle('is-open', !isOpen);
+          if (docsBackdrop) docsBackdrop.classList.toggle('is-open', !isOpen);
           docsHamburger.setAttribute('aria-expanded', String(!isOpen));
         });
 
@@ -324,12 +303,9 @@ hookwing-mcp</code></pre>
           });
         }
       }
-
-      // Theme
-      const saved=localStorage.getItem('theme'),prefersDark=window.matchMedia('(prefers-color-scheme: dark)').matches;if(saved){document.documentElement.dataset.theme=saved}else if(prefersDark){document.documentElement.dataset.theme='dark'}
     })();
   </script>
-  <script src="/shared/feedback-widget.js" defer></script>
-  <script src="/shared/code-copy.js" defer></script>
+<script src="/shared/feedback-widget.js" defer></script>
+<script src="/shared/code-copy.js" defer></script>
 </body>
 </html>

--- a/website/docs/authentication/index.html
+++ b/website/docs/authentication/index.html
@@ -10,19 +10,15 @@
   <meta property="og:title" content="Authentication | Hookwing" />
   <meta property="og:description" content="API keys, scopes, and auth flows. Everything you need to secure your Hookwing integration." />
   <meta property="og:url" content="https://dev.hookwing.com/docs/authentication/" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Authentication | Hookwing" />
+  <meta name="twitter:description" content="API keys, scopes, and auth flows. Everything you need to secure your Hookwing integration." />
   <title>Authentication | Hookwing</title>
-  <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-  <link rel="icon" href="/favicon-32.png" sizes="32x32" type="image/png" />
-  <link rel="manifest" href="/site.webmanifest" />
-  <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" />
-  <link rel="stylesheet" href="/styles/tokens.css" />
-  <link rel="stylesheet" href="/styles/base.css" />
-  <link rel="stylesheet" href="/styles/components.css" />
-  <link rel="stylesheet" href="/styles/patterns.css" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css" />
+  <link rel="stylesheet" href="/styles/tokens.css?v=7" />
+  <link rel="stylesheet" href="/styles/base.css?v=7" />
+  <link rel="stylesheet" href="/styles/components.css?v=7" />
+  <link rel="stylesheet" href="/styles/patterns.css?v=8" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css" />
   <link rel="stylesheet" href="/styles/docs.css" />
 </head>
 <body>
@@ -42,7 +38,7 @@
             <li><a href="/use-cases/" class="nav-link">Use cases</a></li>
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
-            <li><a href="/docs/" class="nav-link is-active">Documentation</a></li>
+            <li><a href="/docs/" class="nav-link">Documentation</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/signup/" class="nav-link">Start free</a></li>
           </ul>
@@ -75,7 +71,8 @@
       </div>
     </div>
   </header>
-
+  <main id="main-content">
+    
   <!-- Mobile hamburger toggle -->
   <button class="docs-hamburger" id="docs-hamburger" aria-label="Toggle documentation menu" aria-expanded="false" aria-controls="docs-sidebar">
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -89,53 +86,38 @@
   <div class="docs-sidebar-backdrop" id="docs-sidebar-backdrop"></div>
 
   <div class="docs-layout">
-    <!-- Sidebar -->
-    <aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
-      <div class="docs-sidebar-inner">
-        <nav>
-          <div class="docs-nav-group">Overview</div>
-          <a href="/docs/" class="docs-nav-link">Introduction</a>
-          <a href="/docs/getting-started/" class="docs-nav-link docs-nav-link--nested">Getting Started</a>
-          <a href="/docs/authentication/" class="docs-nav-link docs-nav-link--nested is-active">Authentication</a>
+    
+<aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
+  <div class="docs-sidebar-inner">
+    <nav>
+      <div class="docs-nav-group">Overview</div>
+      <a href="/docs/" class="docs-nav-link">Introduction</a>
+      <a href="/docs/getting-started/" class="docs-nav-link docs-nav-link--nested">Getting Started</a>
+      <a href="/docs/authentication/" class="docs-nav-link docs-nav-link--nested is-active">Authentication</a>
 
-          <div class="docs-nav-group">API Reference</div>
-          <a href="/docs/endpoints/" class="docs-nav-link docs-nav-link--nested">Endpoints</a>
-          <a href="/docs/event-routing/" class="docs-nav-link docs-nav-link--nested">Event Routing</a>
+      <div class="docs-nav-group">API Reference</div>
+      <a href="/docs/endpoints/" class="docs-nav-link docs-nav-link--nested">Endpoints</a>
+      <a href="/docs/event-routing/" class="docs-nav-link docs-nav-link--nested">Event Routing</a>
 
-          <div class="docs-nav-group">Guides</div>
-          <a href="/docs/webhooks/" class="docs-nav-link docs-nav-link--nested">Webhook Signatures</a>
-          <a href="/docs/sdk-quickstart/" class="docs-nav-link docs-nav-link--nested">SDK Quickstart</a>
-          <a href="/docs/cli-reference/" class="docs-nav-link docs-nav-link--nested">CLI Reference</a>
-          <a href="/docs/error-codes/" class="docs-nav-link docs-nav-link--nested">Error Codes</a>
-          <a href="/docs/agent-integrations/" class="docs-nav-link docs-nav-link--nested">Agent Integrations</a>
+      <div class="docs-nav-group">Guides</div>
+      <a href="/docs/webhooks/" class="docs-nav-link docs-nav-link--nested">Webhook Signatures</a>
+      <a href="/docs/sdk-quickstart/" class="docs-nav-link docs-nav-link--nested">SDK Quickstart</a>
+      <a href="/docs/cli-reference/" class="docs-nav-link docs-nav-link--nested">CLI Reference</a>
+      <a href="/docs/error-codes/" class="docs-nav-link docs-nav-link--nested">Error Codes</a>
+      <a href="/docs/agent-integrations/" class="docs-nav-link docs-nav-link--nested">Agent Integrations</a>
 
-          <div class="docs-nav-group">Tools</div>
-          <a href="/docs/api/" class="docs-nav-link">API Explorer ↗</a>
-        </nav>
-      </div>
-    </aside>
-
+      <div class="docs-nav-group">Tools</div>
+      <a href="/docs/api/" class="docs-nav-link">API Explorer ↗</a>
+    </nav>
+  </div>
+</aside>
     <!-- Content -->
     <main id="main-content">
       <div class="docs-content-wrap">
-        <div class="docs-content">
+        <div class="docs-content docs-main">
           <h1>Authentication</h1>
           <p class="lede">API keys, scopes, and auth flows. Everything you need to secure your Hookwing integration.</p>
-
-          <!-- On-page TOC -->
-          <nav class="docs-toc" aria-label="Table of contents">
-            <div class="docs-toc-label">On this page</div>
-            <ul class="docs-toc-list">
-              <li class="docs-toc-item"><a href="#api-key-authentication" class="docs-toc-link">API Key Authentication</a></li>
-              <li class="docs-toc-item"><a href="#creating-api-keys" class="docs-toc-link">Creating API keys</a></li>
-              <li class="docs-toc-item"><a href="#api-key-scopes" class="docs-toc-link">API Key Scopes</a></li>
-              <li class="docs-toc-item"><a href="#listing-keys" class="docs-toc-link">Listing keys</a></li>
-              <li class="docs-toc-item"><a href="#revoking-a-key" class="docs-toc-link">Revoking a key</a></li>
-              <li class="docs-toc-item"><a href="#rate-limiting" class="docs-toc-link">Rate limiting</a></li>
-            </ul>
-          </nav>
-
-<h2 id="api-key-authentication">API Key Authentication</h2>
+          <h2 id="api-key-authentication">API Key Authentication</h2>
 <p>Every authenticated request to the Hookwing API requires a Bearer token:</p>
 <pre><code class="hljs">Authorization: Bearer hk_live_your_api_key</code></pre>
 <h3 id="creating-api-keys">Creating API keys</h3>
@@ -160,16 +142,22 @@
 <h3 id="rate-limiting">Rate limiting</h3>
 <p>Auth endpoints are rate-limited to 5 requests per minute per IP. All authenticated endpoints include rate limit headers:</p>
 <ul>
-<li><code>X-RateLimit-Limit</code>: Maximum requests per minute</li>
-<li><code>X-RateLimit-Remaining</code>: Requests remaining in current window</li>
-<li><code>X-RateLimit-Reset</code>: Unix timestamp when the limit resets</li>
+<li><code>X-RateLimit-Limit</code>: Maximum requests per window</li>
+<li><code>X-RateLimit-Remaining</code>: Requests remaining</li>
+<li><code>X-RateLimit-Reset</code>: Unix timestamp when the window resets</li>
 </ul>
-<p>Exceeding the rate limit returns <code>429 Too Many Requests</code> with a <code>Retry-After</code> header.</p>
+<h2 id="social-login">Social Login</h2>
+<p>Hookwing supports GitHub and Google OAuth for browser-based login:</p>
+<ul>
+<li><code>GET /v1/auth/github</code> — redirects to GitHub OAuth</li>
+<li><code>GET /v1/auth/google</code> — redirects to Google OAuth</li>
+</ul>
+<p>Both create a workspace and return an API key on successful authentication.</p>
         </div>
       </div>
     </main>
   </div>
-
+  </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
       <div class="footer-grid">
@@ -182,7 +170,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -194,6 +182,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -203,9 +192,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -228,17 +217,17 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>
   </footer>
-
   <script>
     (function(){
       const toggle=document.getElementById('nav-toggle'),mobileNav=document.getElementById('nav-mobile');
       if(toggle&&mobileNav){toggle.addEventListener('click',function(){const e=this.getAttribute('aria-expanded')==='true';this.setAttribute('aria-expanded',String(!e));mobileNav.classList.toggle('is-open',!e);mobileNav.setAttribute('aria-hidden',String(e))});document.addEventListener('click',function(e){if(mobileNav.classList.contains('is-open')&&!mobileNav.contains(e.target)&&!toggle.contains(e.target)){toggle.setAttribute('aria-expanded','false');mobileNav.classList.remove('is-open');mobileNav.setAttribute('aria-hidden','true')}});document.addEventListener('keydown',function(e){if(e.key==='Escape'&&mobileNav.classList.contains('is-open')){toggle.setAttribute('aria-expanded','false');mobileNav.classList.remove('is-open');mobileNav.setAttribute('aria-hidden','true');toggle.focus()}});mobileNav.querySelectorAll('a').forEach(function(link){link.addEventListener('click',function(){toggle.setAttribute('aria-expanded','false');mobileNav.classList.remove('is-open');mobileNav.setAttribute('aria-hidden','true')})})}
-
+      const saved=localStorage.getItem('theme'),prefersDark=window.matchMedia('(prefers-color-scheme: dark)').matches;if(saved){document.documentElement.dataset.theme=saved}else if(prefersDark){document.documentElement.dataset.theme='dark'}
+      
       // Docs sidebar toggle
       const docsHamburger = document.getElementById('docs-hamburger');
       const docsSidebar = document.getElementById('docs-sidebar');
@@ -248,7 +237,7 @@
         docsHamburger.addEventListener('click', function() {
           const isOpen = docsSidebar.classList.contains('is-open');
           docsSidebar.classList.toggle('is-open', !isOpen);
-          docsBackdrop.classList.toggle('is-open', !isOpen);
+          if (docsBackdrop) docsBackdrop.classList.toggle('is-open', !isOpen);
           docsHamburger.setAttribute('aria-expanded', String(!isOpen));
         });
 
@@ -260,12 +249,9 @@
           });
         }
       }
-
-      // Theme
-      const saved=localStorage.getItem('theme'),prefersDark=window.matchMedia('(prefers-color-scheme: dark)').matches;if(saved){document.documentElement.dataset.theme=saved}else if(prefersDark){document.documentElement.dataset.theme='dark'}
     })();
   </script>
-  <script src="/shared/feedback-widget.js" defer></script>
-  <script src="/shared/code-copy.js" defer></script>
+<script src="/shared/feedback-widget.js" defer></script>
+<script src="/shared/code-copy.js" defer></script>
 </body>
 </html>

--- a/website/docs/cli-reference/index.html
+++ b/website/docs/cli-reference/index.html
@@ -3,32 +3,25 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://hookwing.com; connect-src 'self' https://dev.api.hookwing.com https://api.hookwing.com; base-uri 'self'; form-action 'self';" />
   <meta name="description" content="Complete command reference for the Hookwing CLI. Manage endpoints, events, deliveries, and API keys from the terminal." />
   <link rel="canonical" href="https://dev.hookwing.com/docs/cli-reference/" />
   <meta property="og:site_name" content="Hookwing" />
   <meta property="og:type" content="website" />
-  <meta property="og:image" content="https://hookwing.com/assets/og/default.png" />
   <meta property="og:title" content="CLI Reference | Hookwing" />
   <meta property="og:description" content="Complete command reference for the Hookwing CLI. Manage endpoints, events, deliveries, and API keys from the terminal." />
   <meta property="og:url" content="https://dev.hookwing.com/docs/cli-reference/" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="CLI Reference | Hookwing" />
+  <meta name="twitter:description" content="Complete command reference for the Hookwing CLI. Manage endpoints, events, deliveries, and API keys from the terminal." />
   <title>CLI Reference | Hookwing</title>
-  <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-  <link rel="icon" href="/favicon-32.png" sizes="32x32" type="image/png" />
-  <link rel="manifest" href="/site.webmanifest" />
-  <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" />
-  <link rel="stylesheet" href="/styles/tokens.css" />
-  <link rel="stylesheet" href="/styles/base.css" />
-  <link rel="stylesheet" href="/styles/components.css" />
-  <link rel="stylesheet" href="/styles/patterns.css" />
+  <link rel="stylesheet" href="/styles/tokens.css?v=7" />
+  <link rel="stylesheet" href="/styles/base.css?v=7" />
+  <link rel="stylesheet" href="/styles/components.css?v=7" />
+  <link rel="stylesheet" href="/styles/patterns.css?v=8" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css" />
   <link rel="stylesheet" href="/styles/docs.css" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css" />
 </head>
 <body>
-  <!-- Navigation (same as homepage) -->
   <header>
     <nav class="nav" aria-label="Main navigation">
       <div class="container">
@@ -45,7 +38,7 @@
             <li><a href="/use-cases/" class="nav-link">Use cases</a></li>
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
-            <li><a href="/docs/" class="nav-link is-active">Documentation</a></li>
+            <li><a href="/docs/" class="nav-link">Documentation</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/signup/" class="nav-link">Start free</a></li>
           </ul>
@@ -78,7 +71,8 @@
       </div>
     </div>
   </header>
-
+  <main id="main-content">
+    
   <!-- Mobile hamburger toggle -->
   <button class="docs-hamburger" id="docs-hamburger" aria-label="Toggle documentation menu" aria-expanded="false" aria-controls="docs-sidebar">
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -92,49 +86,37 @@
   <div class="docs-sidebar-backdrop" id="docs-sidebar-backdrop"></div>
 
   <div class="docs-layout">
-    <!-- Sidebar -->
-    <aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
-      <div class="docs-sidebar-inner">
-        <nav>
-          <div class="docs-nav-group">Overview</div>
-          <a href="/docs/" class="docs-nav-link">Introduction</a>
-          <a href="/docs/getting-started/" class="docs-nav-link docs-nav-link--nested">Getting Started</a>
-          <a href="/docs/authentication/" class="docs-nav-link docs-nav-link--nested">Authentication</a>
+    
+<aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
+  <div class="docs-sidebar-inner">
+    <nav>
+      <div class="docs-nav-group">Overview</div>
+      <a href="/docs/" class="docs-nav-link">Introduction</a>
+      <a href="/docs/getting-started/" class="docs-nav-link docs-nav-link--nested">Getting Started</a>
+      <a href="/docs/authentication/" class="docs-nav-link docs-nav-link--nested">Authentication</a>
 
-          <div class="docs-nav-group">API Reference</div>
-          <a href="/docs/endpoints/" class="docs-nav-link docs-nav-link--nested">Endpoints</a>
-          <a href="/docs/event-routing/" class="docs-nav-link docs-nav-link--nested">Event Routing</a>
+      <div class="docs-nav-group">API Reference</div>
+      <a href="/docs/endpoints/" class="docs-nav-link docs-nav-link--nested">Endpoints</a>
+      <a href="/docs/event-routing/" class="docs-nav-link docs-nav-link--nested">Event Routing</a>
 
-          <div class="docs-nav-group">Guides</div>
-          <a href="/docs/webhooks/" class="docs-nav-link docs-nav-link--nested">Webhook Signatures</a>
-          <a href="/docs/sdk-quickstart/" class="docs-nav-link docs-nav-link--nested">SDK Quickstart</a>
-          <a href="/docs/cli-reference/" class="docs-nav-link docs-nav-link--nested is-active">CLI Reference</a>
-          <a href="/docs/error-codes/" class="docs-nav-link docs-nav-link--nested">Error Codes</a>
-          <a href="/docs/agent-integrations/" class="docs-nav-link docs-nav-link--nested">Agent Integrations</a>
+      <div class="docs-nav-group">Guides</div>
+      <a href="/docs/webhooks/" class="docs-nav-link docs-nav-link--nested">Webhook Signatures</a>
+      <a href="/docs/sdk-quickstart/" class="docs-nav-link docs-nav-link--nested">SDK Quickstart</a>
+      <a href="/docs/cli-reference/" class="docs-nav-link docs-nav-link--nested is-active">CLI Reference</a>
+      <a href="/docs/error-codes/" class="docs-nav-link docs-nav-link--nested">Error Codes</a>
+      <a href="/docs/agent-integrations/" class="docs-nav-link docs-nav-link--nested">Agent Integrations</a>
 
-          <div class="docs-nav-group">Tools</div>
-          <a href="/docs/api/" class="docs-nav-link">API Explorer ↗</a>
-        </nav>
-      </div>
-    </aside>
-
+      <div class="docs-nav-group">Tools</div>
+      <a href="/docs/api/" class="docs-nav-link">API Explorer ↗</a>
+    </nav>
+  </div>
+</aside>
     <!-- Content -->
     <main id="main-content">
       <div class="docs-content-wrap">
         <div class="docs-content docs-main">
           <h1>CLI Reference</h1>
           <p class="lede">Complete command reference for the Hookwing CLI. Manage endpoints, events, deliveries, and API keys from the terminal.</p>
-
-          <nav class="docs-toc" aria-label="Table of contents">
-            <div class="docs-toc-label">On this page</div>
-            <ul class="docs-toc-list">
-              <li class="docs-toc-item"><a href="#installation" class="docs-toc-link">Installation</a></li>
-              <li class="docs-toc-item"><a href="#authentication" class="docs-toc-link">Authentication</a></li>
-              <li class="docs-toc-item"><a href="#commands" class="docs-toc-link">Commands</a></li>
-              <li class="docs-toc-item"><a href="#global-options" class="docs-toc-link">Global Options</a></li>
-            </ul>
-          </nav>
-
           <h2 id="installation">Installation</h2>
 <pre><code class="hljs language-bash">npm install -g @hookwing/cli</code></pre>
 <h2 id="authentication">Authentication</h2>
@@ -209,8 +191,7 @@
       </div>
     </main>
   </div>
-
-  <!-- Footer (same as homepage) -->
+  </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
       <div class="footer-grid">
@@ -223,7 +204,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -235,6 +216,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -244,9 +226,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -269,18 +251,17 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>
   </footer>
-
   <script>
-    // Mobile nav toggle
     (function(){
       const toggle=document.getElementById('nav-toggle'),mobileNav=document.getElementById('nav-mobile');
       if(toggle&&mobileNav){toggle.addEventListener('click',function(){const e=this.getAttribute('aria-expanded')==='true';this.setAttribute('aria-expanded',String(!e));mobileNav.classList.toggle('is-open',!e);mobileNav.setAttribute('aria-hidden',String(e))});document.addEventListener('click',function(e){if(mobileNav.classList.contains('is-open')&&!mobileNav.contains(e.target)&&!toggle.contains(e.target)){toggle.setAttribute('aria-expanded','false');mobileNav.classList.remove('is-open');mobileNav.setAttribute('aria-hidden','true')}});document.addEventListener('keydown',function(e){if(e.key==='Escape'&&mobileNav.classList.contains('is-open')){toggle.setAttribute('aria-expanded','false');mobileNav.classList.remove('is-open');mobileNav.setAttribute('aria-hidden','true');toggle.focus()}});mobileNav.querySelectorAll('a').forEach(function(link){link.addEventListener('click',function(){toggle.setAttribute('aria-expanded','false');mobileNav.classList.remove('is-open');mobileNav.setAttribute('aria-hidden','true')})})}
-
+      const saved=localStorage.getItem('theme'),prefersDark=window.matchMedia('(prefers-color-scheme: dark)').matches;if(saved){document.documentElement.dataset.theme=saved}else if(prefersDark){document.documentElement.dataset.theme='dark'}
+      
       // Docs sidebar toggle
       const docsHamburger = document.getElementById('docs-hamburger');
       const docsSidebar = document.getElementById('docs-sidebar');
@@ -290,7 +271,7 @@
         docsHamburger.addEventListener('click', function() {
           const isOpen = docsSidebar.classList.contains('is-open');
           docsSidebar.classList.toggle('is-open', !isOpen);
-          docsBackdrop.classList.toggle('is-open', !isOpen);
+          if (docsBackdrop) docsBackdrop.classList.toggle('is-open', !isOpen);
           docsHamburger.setAttribute('aria-expanded', String(!isOpen));
         });
 
@@ -302,12 +283,9 @@
           });
         }
       }
-
-      // Theme
-      const saved=localStorage.getItem('theme'),prefersDark=window.matchMedia('(prefers-color-scheme: dark)').matches;if(saved){document.documentElement.dataset.theme=saved}else if(prefersDark){document.documentElement.dataset.theme='dark'}
     })();
   </script>
-  <script src="/shared/feedback-widget.js" defer></script>
-  <script src="/shared/code-copy.js" defer></script>
+<script src="/shared/feedback-widget.js" defer></script>
+<script src="/shared/code-copy.js" defer></script>
 </body>
 </html>

--- a/website/docs/endpoints/index.html
+++ b/website/docs/endpoints/index.html
@@ -3,32 +3,25 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://hookwing.com; connect-src 'self' https://dev.api.hookwing.com https://api.hookwing.com; base-uri 'self'; form-action 'self';" />
   <meta name="description" content="Create, manage, and configure webhook endpoints. Event type routing, fan-out delivery, and custom headers." />
   <link rel="canonical" href="https://dev.hookwing.com/docs/endpoints/" />
   <meta property="og:site_name" content="Hookwing" />
   <meta property="og:type" content="website" />
-  <meta property="og:image" content="https://hookwing.com/assets/og/default.png" />
   <meta property="og:title" content="Endpoints | Hookwing" />
   <meta property="og:description" content="Create, manage, and configure webhook endpoints. Event type routing, fan-out delivery, and custom headers." />
   <meta property="og:url" content="https://dev.hookwing.com/docs/endpoints/" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Endpoints | Hookwing" />
+  <meta name="twitter:description" content="Create, manage, and configure webhook endpoints. Event type routing, fan-out delivery, and custom headers." />
   <title>Endpoints | Hookwing</title>
-  <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-  <link rel="icon" href="/favicon-32.png" sizes="32x32" type="image/png" />
-  <link rel="manifest" href="/site.webmanifest" />
-  <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" />
-  <link rel="stylesheet" href="/styles/tokens.css" />
-  <link rel="stylesheet" href="/styles/base.css" />
-  <link rel="stylesheet" href="/styles/components.css" />
-  <link rel="stylesheet" href="/styles/patterns.css" />
+  <link rel="stylesheet" href="/styles/tokens.css?v=7" />
+  <link rel="stylesheet" href="/styles/base.css?v=7" />
+  <link rel="stylesheet" href="/styles/components.css?v=7" />
+  <link rel="stylesheet" href="/styles/patterns.css?v=8" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css" />
   <link rel="stylesheet" href="/styles/docs.css" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css" />
 </head>
 <body>
-  <!-- Navigation (same as homepage) -->
   <header>
     <nav class="nav" aria-label="Main navigation">
       <div class="container">
@@ -45,7 +38,7 @@
             <li><a href="/use-cases/" class="nav-link">Use cases</a></li>
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
-            <li><a href="/docs/" class="nav-link is-active">Documentation</a></li>
+            <li><a href="/docs/" class="nav-link">Documentation</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/signup/" class="nav-link">Start free</a></li>
           </ul>
@@ -78,7 +71,8 @@
       </div>
     </div>
   </header>
-
+  <main id="main-content">
+    
   <!-- Mobile hamburger toggle -->
   <button class="docs-hamburger" id="docs-hamburger" aria-label="Toggle documentation menu" aria-expanded="false" aria-controls="docs-sidebar">
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -92,49 +86,37 @@
   <div class="docs-sidebar-backdrop" id="docs-sidebar-backdrop"></div>
 
   <div class="docs-layout">
-    <!-- Sidebar -->
-    <aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
-      <div class="docs-sidebar-inner">
-        <nav>
-          <div class="docs-nav-group">Overview</div>
-          <a href="/docs/" class="docs-nav-link">Introduction</a>
-          <a href="/docs/getting-started/" class="docs-nav-link docs-nav-link--nested">Getting Started</a>
-          <a href="/docs/authentication/" class="docs-nav-link docs-nav-link--nested">Authentication</a>
+    
+<aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
+  <div class="docs-sidebar-inner">
+    <nav>
+      <div class="docs-nav-group">Overview</div>
+      <a href="/docs/" class="docs-nav-link">Introduction</a>
+      <a href="/docs/getting-started/" class="docs-nav-link docs-nav-link--nested">Getting Started</a>
+      <a href="/docs/authentication/" class="docs-nav-link docs-nav-link--nested">Authentication</a>
 
-          <div class="docs-nav-group">API Reference</div>
-          <a href="/docs/endpoints/" class="docs-nav-link docs-nav-link--nested is-active">Endpoints</a>
-          <a href="/docs/event-routing/" class="docs-nav-link docs-nav-link--nested">Event Routing</a>
+      <div class="docs-nav-group">API Reference</div>
+      <a href="/docs/endpoints/" class="docs-nav-link docs-nav-link--nested is-active">Endpoints</a>
+      <a href="/docs/event-routing/" class="docs-nav-link docs-nav-link--nested">Event Routing</a>
 
-          <div class="docs-nav-group">Guides</div>
-          <a href="/docs/webhooks/" class="docs-nav-link docs-nav-link--nested">Webhook Signatures</a>
-          <a href="/docs/sdk-quickstart/" class="docs-nav-link docs-nav-link--nested">SDK Quickstart</a>
-          <a href="/docs/cli-reference/" class="docs-nav-link docs-nav-link--nested">CLI Reference</a>
-          <a href="/docs/error-codes/" class="docs-nav-link docs-nav-link--nested">Error Codes</a>
-          <a href="/docs/agent-integrations/" class="docs-nav-link docs-nav-link--nested">Agent Integrations</a>
+      <div class="docs-nav-group">Guides</div>
+      <a href="/docs/webhooks/" class="docs-nav-link docs-nav-link--nested">Webhook Signatures</a>
+      <a href="/docs/sdk-quickstart/" class="docs-nav-link docs-nav-link--nested">SDK Quickstart</a>
+      <a href="/docs/cli-reference/" class="docs-nav-link docs-nav-link--nested">CLI Reference</a>
+      <a href="/docs/error-codes/" class="docs-nav-link docs-nav-link--nested">Error Codes</a>
+      <a href="/docs/agent-integrations/" class="docs-nav-link docs-nav-link--nested">Agent Integrations</a>
 
-          <div class="docs-nav-group">Tools</div>
-          <a href="/docs/api/" class="docs-nav-link">API Explorer ↗</a>
-        </nav>
-      </div>
-    </aside>
-
+      <div class="docs-nav-group">Tools</div>
+      <a href="/docs/api/" class="docs-nav-link">API Explorer ↗</a>
+    </nav>
+  </div>
+</aside>
     <!-- Content -->
     <main id="main-content">
       <div class="docs-content-wrap">
         <div class="docs-content docs-main">
           <h1>Endpoints</h1>
           <p class="lede">Create, manage, and configure webhook endpoints. Event type routing, fan-out delivery, and custom headers.</p>
-
-          <nav class="docs-toc" aria-label="Table of contents">
-            <div class="docs-toc-label">On this page</div>
-            <ul class="docs-toc-list">
-              <li class="docs-toc-item"><a href="#endpoint-management" class="docs-toc-link">Endpoint Management</a></li>
-              <li class="docs-toc-item"><a href="#event-type-routing" class="docs-toc-link">Event Type Routing</a></li>
-              <li class="docs-toc-item"><a href="#custom-headers-warbird" class="docs-toc-link">Custom Headers (Warbird+)</a></li>
-              <li class="docs-toc-item"><a href="#endpoint-limits-by-tier" class="docs-toc-link">Endpoint Limits by Tier</a></li>
-            </ul>
-          </nav>
-
           <h2 id="endpoint-management">Endpoint Management</h2>
 <p>Endpoints are where Hookwing delivers webhooks. Each endpoint has a URL, signing secret, and optional event type filters.</p>
 <h3 id="create-an-endpoint">Create an endpoint</h3>
@@ -183,8 +165,7 @@
       </div>
     </main>
   </div>
-
-  <!-- Footer (same as homepage) -->
+  </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
       <div class="footer-grid">
@@ -197,7 +178,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -209,6 +190,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -218,9 +200,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -243,18 +225,17 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>
   </footer>
-
   <script>
-    // Mobile nav toggle
     (function(){
       const toggle=document.getElementById('nav-toggle'),mobileNav=document.getElementById('nav-mobile');
       if(toggle&&mobileNav){toggle.addEventListener('click',function(){const e=this.getAttribute('aria-expanded')==='true';this.setAttribute('aria-expanded',String(!e));mobileNav.classList.toggle('is-open',!e);mobileNav.setAttribute('aria-hidden',String(e))});document.addEventListener('click',function(e){if(mobileNav.classList.contains('is-open')&&!mobileNav.contains(e.target)&&!toggle.contains(e.target)){toggle.setAttribute('aria-expanded','false');mobileNav.classList.remove('is-open');mobileNav.setAttribute('aria-hidden','true')}});document.addEventListener('keydown',function(e){if(e.key==='Escape'&&mobileNav.classList.contains('is-open')){toggle.setAttribute('aria-expanded','false');mobileNav.classList.remove('is-open');mobileNav.setAttribute('aria-hidden','true');toggle.focus()}});mobileNav.querySelectorAll('a').forEach(function(link){link.addEventListener('click',function(){toggle.setAttribute('aria-expanded','false');mobileNav.classList.remove('is-open');mobileNav.setAttribute('aria-hidden','true')})})}
-
+      const saved=localStorage.getItem('theme'),prefersDark=window.matchMedia('(prefers-color-scheme: dark)').matches;if(saved){document.documentElement.dataset.theme=saved}else if(prefersDark){document.documentElement.dataset.theme='dark'}
+      
       // Docs sidebar toggle
       const docsHamburger = document.getElementById('docs-hamburger');
       const docsSidebar = document.getElementById('docs-sidebar');
@@ -264,7 +245,7 @@
         docsHamburger.addEventListener('click', function() {
           const isOpen = docsSidebar.classList.contains('is-open');
           docsSidebar.classList.toggle('is-open', !isOpen);
-          docsBackdrop.classList.toggle('is-open', !isOpen);
+          if (docsBackdrop) docsBackdrop.classList.toggle('is-open', !isOpen);
           docsHamburger.setAttribute('aria-expanded', String(!isOpen));
         });
 
@@ -276,12 +257,9 @@
           });
         }
       }
-
-      // Theme
-      const saved=localStorage.getItem('theme'),prefersDark=window.matchMedia('(prefers-color-scheme: dark)').matches;if(saved){document.documentElement.dataset.theme=saved}else if(prefersDark){document.documentElement.dataset.theme='dark'}
     })();
   </script>
-  <script src="/shared/feedback-widget.js" defer></script>
-  <script src="/shared/code-copy.js" defer></script>
+<script src="/shared/feedback-widget.js" defer></script>
+<script src="/shared/code-copy.js" defer></script>
 </body>
 </html>

--- a/website/docs/error-codes/index.html
+++ b/website/docs/error-codes/index.html
@@ -3,32 +3,25 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://hookwing.com; connect-src 'self' https://dev.api.hookwing.com https://api.hookwing.com; base-uri 'self'; form-action 'self';" />
   <meta name="description" content="Complete list of Hookwing API error codes, HTTP status codes, and troubleshooting guidance." />
   <link rel="canonical" href="https://dev.hookwing.com/docs/error-codes/" />
   <meta property="og:site_name" content="Hookwing" />
   <meta property="og:type" content="website" />
-  <meta property="og:image" content="https://hookwing.com/assets/og/default.png" />
   <meta property="og:title" content="Error Codes | Hookwing" />
   <meta property="og:description" content="Complete list of Hookwing API error codes, HTTP status codes, and troubleshooting guidance." />
   <meta property="og:url" content="https://dev.hookwing.com/docs/error-codes/" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Error Codes | Hookwing" />
+  <meta name="twitter:description" content="Complete list of Hookwing API error codes, HTTP status codes, and troubleshooting guidance." />
   <title>Error Codes | Hookwing</title>
-  <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-  <link rel="icon" href="/favicon-32.png" sizes="32x32" type="image/png" />
-  <link rel="manifest" href="/site.webmanifest" />
-  <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" />
-  <link rel="stylesheet" href="/styles/tokens.css" />
-  <link rel="stylesheet" href="/styles/base.css" />
-  <link rel="stylesheet" href="/styles/components.css" />
-  <link rel="stylesheet" href="/styles/patterns.css" />
+  <link rel="stylesheet" href="/styles/tokens.css?v=7" />
+  <link rel="stylesheet" href="/styles/base.css?v=7" />
+  <link rel="stylesheet" href="/styles/components.css?v=7" />
+  <link rel="stylesheet" href="/styles/patterns.css?v=8" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css" />
   <link rel="stylesheet" href="/styles/docs.css" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css" />
 </head>
 <body>
-  <!-- Navigation (same as homepage) -->
   <header>
     <nav class="nav" aria-label="Main navigation">
       <div class="container">
@@ -45,7 +38,7 @@
             <li><a href="/use-cases/" class="nav-link">Use cases</a></li>
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
-            <li><a href="/docs/" class="nav-link is-active">Documentation</a></li>
+            <li><a href="/docs/" class="nav-link">Documentation</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/signup/" class="nav-link">Start free</a></li>
           </ul>
@@ -78,7 +71,8 @@
       </div>
     </div>
   </header>
-
+  <main id="main-content">
+    
   <!-- Mobile hamburger toggle -->
   <button class="docs-hamburger" id="docs-hamburger" aria-label="Toggle documentation menu" aria-expanded="false" aria-controls="docs-sidebar">
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -92,50 +86,37 @@
   <div class="docs-sidebar-backdrop" id="docs-sidebar-backdrop"></div>
 
   <div class="docs-layout">
-    <!-- Sidebar -->
-    <aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
-      <div class="docs-sidebar-inner">
-        <nav>
-          <div class="docs-nav-group">Overview</div>
-          <a href="/docs/" class="docs-nav-link">Introduction</a>
-          <a href="/docs/getting-started/" class="docs-nav-link docs-nav-link--nested">Getting Started</a>
-          <a href="/docs/authentication/" class="docs-nav-link docs-nav-link--nested">Authentication</a>
+    
+<aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
+  <div class="docs-sidebar-inner">
+    <nav>
+      <div class="docs-nav-group">Overview</div>
+      <a href="/docs/" class="docs-nav-link">Introduction</a>
+      <a href="/docs/getting-started/" class="docs-nav-link docs-nav-link--nested">Getting Started</a>
+      <a href="/docs/authentication/" class="docs-nav-link docs-nav-link--nested">Authentication</a>
 
-          <div class="docs-nav-group">API Reference</div>
-          <a href="/docs/endpoints/" class="docs-nav-link docs-nav-link--nested">Endpoints</a>
-          <a href="/docs/event-routing/" class="docs-nav-link docs-nav-link--nested">Event Routing</a>
+      <div class="docs-nav-group">API Reference</div>
+      <a href="/docs/endpoints/" class="docs-nav-link docs-nav-link--nested">Endpoints</a>
+      <a href="/docs/event-routing/" class="docs-nav-link docs-nav-link--nested">Event Routing</a>
 
-          <div class="docs-nav-group">Guides</div>
-          <a href="/docs/webhooks/" class="docs-nav-link docs-nav-link--nested">Webhook Signatures</a>
-          <a href="/docs/sdk-quickstart/" class="docs-nav-link docs-nav-link--nested">SDK Quickstart</a>
-          <a href="/docs/cli-reference/" class="docs-nav-link docs-nav-link--nested">CLI Reference</a>
-          <a href="/docs/error-codes/" class="docs-nav-link docs-nav-link--nested is-active">Error Codes</a>
-          <a href="/docs/agent-integrations/" class="docs-nav-link docs-nav-link--nested">Agent Integrations</a>
+      <div class="docs-nav-group">Guides</div>
+      <a href="/docs/webhooks/" class="docs-nav-link docs-nav-link--nested">Webhook Signatures</a>
+      <a href="/docs/sdk-quickstart/" class="docs-nav-link docs-nav-link--nested">SDK Quickstart</a>
+      <a href="/docs/cli-reference/" class="docs-nav-link docs-nav-link--nested">CLI Reference</a>
+      <a href="/docs/error-codes/" class="docs-nav-link docs-nav-link--nested is-active">Error Codes</a>
+      <a href="/docs/agent-integrations/" class="docs-nav-link docs-nav-link--nested">Agent Integrations</a>
 
-          <div class="docs-nav-group">Tools</div>
-          <a href="/docs/api/" class="docs-nav-link">API Explorer ↗</a>
-        </nav>
-      </div>
-    </aside>
-
+      <div class="docs-nav-group">Tools</div>
+      <a href="/docs/api/" class="docs-nav-link">API Explorer ↗</a>
+    </nav>
+  </div>
+</aside>
     <!-- Content -->
     <main id="main-content">
       <div class="docs-content-wrap">
         <div class="docs-content docs-main">
           <h1>Error Codes</h1>
           <p class="lede">Complete list of Hookwing API error codes, HTTP status codes, and troubleshooting guidance.</p>
-
-          <nav class="docs-toc" aria-label="Table of contents">
-            <div class="docs-toc-label">On this page</div>
-            <ul class="docs-toc-list">
-              <li class="docs-toc-item"><a href="#error-response-format" class="docs-toc-link">Error Response Format</a></li>
-              <li class="docs-toc-item"><a href="#http-status-codes" class="docs-toc-link">HTTP Status Codes</a></li>
-              <li class="docs-toc-item"><a href="#rate-limit-headers" class="docs-toc-link">Rate Limit Headers</a></li>
-              <li class="docs-toc-item"><a href="#scope-errors" class="docs-toc-link">Scope Errors</a></li>
-              <li class="docs-toc-item"><a href="#tier-gated-feature-errors" class="docs-toc-link">Tier-Gated Feature Errors</a></li>
-            </ul>
-          </nav>
-
           <h2 id="error-response-format">Error Response Format</h2>
 <p>All API errors return a consistent JSON structure:</p>
 <pre><code class="hljs language-json"><span class="hljs-punctuation">{</span>
@@ -176,8 +157,7 @@
       </div>
     </main>
   </div>
-
-  <!-- Footer (same as homepage) -->
+  </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
       <div class="footer-grid">
@@ -190,7 +170,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -202,6 +182,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -211,9 +192,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -236,18 +217,17 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>
   </footer>
-
   <script>
-    // Mobile nav toggle
     (function(){
       const toggle=document.getElementById('nav-toggle'),mobileNav=document.getElementById('nav-mobile');
       if(toggle&&mobileNav){toggle.addEventListener('click',function(){const e=this.getAttribute('aria-expanded')==='true';this.setAttribute('aria-expanded',String(!e));mobileNav.classList.toggle('is-open',!e);mobileNav.setAttribute('aria-hidden',String(e))});document.addEventListener('click',function(e){if(mobileNav.classList.contains('is-open')&&!mobileNav.contains(e.target)&&!toggle.contains(e.target)){toggle.setAttribute('aria-expanded','false');mobileNav.classList.remove('is-open');mobileNav.setAttribute('aria-hidden','true')}});document.addEventListener('keydown',function(e){if(e.key==='Escape'&&mobileNav.classList.contains('is-open')){toggle.setAttribute('aria-expanded','false');mobileNav.classList.remove('is-open');mobileNav.setAttribute('aria-hidden','true');toggle.focus()}});mobileNav.querySelectorAll('a').forEach(function(link){link.addEventListener('click',function(){toggle.setAttribute('aria-expanded','false');mobileNav.classList.remove('is-open');mobileNav.setAttribute('aria-hidden','true')})})}
-
+      const saved=localStorage.getItem('theme'),prefersDark=window.matchMedia('(prefers-color-scheme: dark)').matches;if(saved){document.documentElement.dataset.theme=saved}else if(prefersDark){document.documentElement.dataset.theme='dark'}
+      
       // Docs sidebar toggle
       const docsHamburger = document.getElementById('docs-hamburger');
       const docsSidebar = document.getElementById('docs-sidebar');
@@ -257,7 +237,7 @@
         docsHamburger.addEventListener('click', function() {
           const isOpen = docsSidebar.classList.contains('is-open');
           docsSidebar.classList.toggle('is-open', !isOpen);
-          docsBackdrop.classList.toggle('is-open', !isOpen);
+          if (docsBackdrop) docsBackdrop.classList.toggle('is-open', !isOpen);
           docsHamburger.setAttribute('aria-expanded', String(!isOpen));
         });
 
@@ -269,12 +249,9 @@
           });
         }
       }
-
-      // Theme
-      const saved=localStorage.getItem('theme'),prefersDark=window.matchMedia('(prefers-color-scheme: dark)').matches;if(saved){document.documentElement.dataset.theme=saved}else if(prefersDark){document.documentElement.dataset.theme='dark'}
     })();
   </script>
-  <script src="/shared/feedback-widget.js" defer></script>
-  <script src="/shared/code-copy.js" defer></script>
+<script src="/shared/feedback-widget.js" defer></script>
+<script src="/shared/code-copy.js" defer></script>
 </body>
 </html>

--- a/website/docs/event-routing/index.html
+++ b/website/docs/event-routing/index.html
@@ -3,32 +3,25 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://hookwing.com; connect-src 'self' https://dev.api.hookwing.com https://api.hookwing.com; base-uri 'self'; form-action 'self';" />
   <meta name="description" content="Route, filter, and transform webhook events with conditional rules. Match by event type, payload, or headers — then deliver to specific endpoints." />
   <link rel="canonical" href="https://dev.hookwing.com/docs/event-routing/" />
   <meta property="og:site_name" content="Hookwing" />
   <meta property="og:type" content="website" />
-  <meta property="og:image" content="https://hookwing.com/assets/og/default.png" />
   <meta property="og:title" content="Event Routing | Hookwing" />
   <meta property="og:description" content="Route, filter, and transform webhook events with conditional rules. Match by event type, payload, or headers — then deliver to specific endpoints." />
   <meta property="og:url" content="https://dev.hookwing.com/docs/event-routing/" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Event Routing | Hookwing" />
+  <meta name="twitter:description" content="Route, filter, and transform webhook events with conditional rules. Match by event type, payload, or headers — then deliver to specific endpoints." />
   <title>Event Routing | Hookwing</title>
-  <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-  <link rel="icon" href="/favicon-32.png" sizes="32x32" type="image/png" />
-  <link rel="manifest" href="/site.webmanifest" />
-  <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" />
-  <link rel="stylesheet" href="/styles/tokens.css" />
-  <link rel="stylesheet" href="/styles/base.css" />
-  <link rel="stylesheet" href="/styles/components.css" />
-  <link rel="stylesheet" href="/styles/patterns.css" />
+  <link rel="stylesheet" href="/styles/tokens.css?v=7" />
+  <link rel="stylesheet" href="/styles/base.css?v=7" />
+  <link rel="stylesheet" href="/styles/components.css?v=7" />
+  <link rel="stylesheet" href="/styles/patterns.css?v=8" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css" />
   <link rel="stylesheet" href="/styles/docs.css" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css" />
 </head>
 <body>
-  <!-- Navigation (same as homepage) -->
   <header>
     <nav class="nav" aria-label="Main navigation">
       <div class="container">
@@ -45,7 +38,7 @@
             <li><a href="/use-cases/" class="nav-link">Use cases</a></li>
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
-            <li><a href="/docs/" class="nav-link is-active">Documentation</a></li>
+            <li><a href="/docs/" class="nav-link">Documentation</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/signup/" class="nav-link">Start free</a></li>
           </ul>
@@ -78,7 +71,8 @@
       </div>
     </div>
   </header>
-
+  <main id="main-content">
+    
   <!-- Mobile hamburger toggle -->
   <button class="docs-hamburger" id="docs-hamburger" aria-label="Toggle documentation menu" aria-expanded="false" aria-controls="docs-sidebar">
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -92,50 +86,37 @@
   <div class="docs-sidebar-backdrop" id="docs-sidebar-backdrop"></div>
 
   <div class="docs-layout">
-    <!-- Sidebar -->
-    <aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
-      <div class="docs-sidebar-inner">
-        <nav>
-          <div class="docs-nav-group">Overview</div>
-          <a href="/docs/" class="docs-nav-link">Introduction</a>
-          <a href="/docs/getting-started/" class="docs-nav-link docs-nav-link--nested">Getting Started</a>
-          <a href="/docs/authentication/" class="docs-nav-link docs-nav-link--nested">Authentication</a>
+    
+<aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
+  <div class="docs-sidebar-inner">
+    <nav>
+      <div class="docs-nav-group">Overview</div>
+      <a href="/docs/" class="docs-nav-link">Introduction</a>
+      <a href="/docs/getting-started/" class="docs-nav-link docs-nav-link--nested">Getting Started</a>
+      <a href="/docs/authentication/" class="docs-nav-link docs-nav-link--nested">Authentication</a>
 
-          <div class="docs-nav-group">API Reference</div>
-          <a href="/docs/endpoints/" class="docs-nav-link docs-nav-link--nested">Endpoints</a>
-          <a href="/docs/event-routing/" class="docs-nav-link docs-nav-link--nested is-active">Event Routing</a>
+      <div class="docs-nav-group">API Reference</div>
+      <a href="/docs/endpoints/" class="docs-nav-link docs-nav-link--nested">Endpoints</a>
+      <a href="/docs/event-routing/" class="docs-nav-link docs-nav-link--nested is-active">Event Routing</a>
 
-          <div class="docs-nav-group">Guides</div>
-          <a href="/docs/webhooks/" class="docs-nav-link docs-nav-link--nested">Webhook Signatures</a>
-          <a href="/docs/sdk-quickstart/" class="docs-nav-link docs-nav-link--nested">SDK Quickstart</a>
-          <a href="/docs/cli-reference/" class="docs-nav-link docs-nav-link--nested">CLI Reference</a>
-          <a href="/docs/error-codes/" class="docs-nav-link docs-nav-link--nested">Error Codes</a>
-          <a href="/docs/agent-integrations/" class="docs-nav-link docs-nav-link--nested">Agent Integrations</a>
+      <div class="docs-nav-group">Guides</div>
+      <a href="/docs/webhooks/" class="docs-nav-link docs-nav-link--nested">Webhook Signatures</a>
+      <a href="/docs/sdk-quickstart/" class="docs-nav-link docs-nav-link--nested">SDK Quickstart</a>
+      <a href="/docs/cli-reference/" class="docs-nav-link docs-nav-link--nested">CLI Reference</a>
+      <a href="/docs/error-codes/" class="docs-nav-link docs-nav-link--nested">Error Codes</a>
+      <a href="/docs/agent-integrations/" class="docs-nav-link docs-nav-link--nested">Agent Integrations</a>
 
-          <div class="docs-nav-group">Tools</div>
-          <a href="/docs/api/" class="docs-nav-link">API Explorer ↗</a>
-        </nav>
-      </div>
-    </aside>
-
+      <div class="docs-nav-group">Tools</div>
+      <a href="/docs/api/" class="docs-nav-link">API Explorer ↗</a>
+    </nav>
+  </div>
+</aside>
     <!-- Content -->
     <main id="main-content">
       <div class="docs-content-wrap">
         <div class="docs-content docs-main">
           <h1>Event Routing</h1>
           <p class="lede">Route, filter, and transform webhook events with conditional rules. Match by event type, payload, or headers — then deliver to specific endpoints.</p>
-
-          <nav class="docs-toc" aria-label="Table of contents">
-            <div class="docs-toc-label">On this page</div>
-            <ul class="docs-toc-list">
-              <li class="docs-toc-item"><a href="#overview" class="docs-toc-link">Overview</a></li>
-              <li class="docs-toc-item"><a href="#concepts" class="docs-toc-link">Concepts</a></li>
-              <li class="docs-toc-item"><a href="#api-reference" class="docs-toc-link">API Reference</a></li>
-              <li class="docs-toc-item"><a href="#examples" class="docs-toc-link">Examples</a></li>
-              <li class="docs-toc-item"><a href="#limits-by-tier" class="docs-toc-link">Limits by Tier</a></li>
-            </ul>
-          </nav>
-
           <h2 id="overview">Overview</h2>
 <p>Event routing lets you control which events reach which endpoints. Instead of delivering every event to every endpoint, you define rules: conditions that match events, optional transforms that reshape payloads, and actions that route matched events to specific endpoints — or drop them entirely.</p>
 <p>Rules are evaluated in priority order. All conditions within a rule use AND logic — every condition must match for the rule to fire.</p>
@@ -312,8 +293,7 @@
       </div>
     </main>
   </div>
-
-  <!-- Footer (same as homepage) -->
+  </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
       <div class="footer-grid">
@@ -326,7 +306,7 @@
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -338,6 +318,7 @@
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -347,9 +328,9 @@
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -372,18 +353,17 @@
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>
   </footer>
-
   <script>
-    // Mobile nav toggle
     (function(){
       const toggle=document.getElementById('nav-toggle'),mobileNav=document.getElementById('nav-mobile');
       if(toggle&&mobileNav){toggle.addEventListener('click',function(){const e=this.getAttribute('aria-expanded')==='true';this.setAttribute('aria-expanded',String(!e));mobileNav.classList.toggle('is-open',!e);mobileNav.setAttribute('aria-hidden',String(e))});document.addEventListener('click',function(e){if(mobileNav.classList.contains('is-open')&&!mobileNav.contains(e.target)&&!toggle.contains(e.target)){toggle.setAttribute('aria-expanded','false');mobileNav.classList.remove('is-open');mobileNav.setAttribute('aria-hidden','true')}});document.addEventListener('keydown',function(e){if(e.key==='Escape'&&mobileNav.classList.contains('is-open')){toggle.setAttribute('aria-expanded','false');mobileNav.classList.remove('is-open');mobileNav.setAttribute('aria-hidden','true');toggle.focus()}});mobileNav.querySelectorAll('a').forEach(function(link){link.addEventListener('click',function(){toggle.setAttribute('aria-expanded','false');mobileNav.classList.remove('is-open');mobileNav.setAttribute('aria-hidden','true')})})}
-
+      const saved=localStorage.getItem('theme'),prefersDark=window.matchMedia('(prefers-color-scheme: dark)').matches;if(saved){document.documentElement.dataset.theme=saved}else if(prefersDark){document.documentElement.dataset.theme='dark'}
+      
       // Docs sidebar toggle
       const docsHamburger = document.getElementById('docs-hamburger');
       const docsSidebar = document.getElementById('docs-sidebar');
@@ -393,7 +373,7 @@
         docsHamburger.addEventListener('click', function() {
           const isOpen = docsSidebar.classList.contains('is-open');
           docsSidebar.classList.toggle('is-open', !isOpen);
-          docsBackdrop.classList.toggle('is-open', !isOpen);
+          if (docsBackdrop) docsBackdrop.classList.toggle('is-open', !isOpen);
           docsHamburger.setAttribute('aria-expanded', String(!isOpen));
         });
 
@@ -405,12 +385,9 @@
           });
         }
       }
-
-      // Theme
-      const saved=localStorage.getItem('theme'),prefersDark=window.matchMedia('(prefers-color-scheme: dark)').matches;if(saved){document.documentElement.dataset.theme=saved}else if(prefersDark){document.documentElement.dataset.theme='dark'}
     })();
   </script>
-  <script src="/shared/feedback-widget.js" defer></script>
-  <script src="/shared/code-copy.js" defer></script>
+<script src="/shared/feedback-widget.js" defer></script>
+<script src="/shared/code-copy.js" defer></script>
 </body>
 </html>

--- a/website/docs/getting-started/index.html
+++ b/website/docs/getting-started/index.html
@@ -3,32 +3,25 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://hookwing.com; connect-src 'self' https://dev.api.hookwing.com https://api.hookwing.com; base-uri 'self'; form-action 'self';" />
   <meta name="description" content="Your first webhook in 60 seconds. Create an account, set up an endpoint, and start receiving events." />
   <link rel="canonical" href="https://dev.hookwing.com/docs/getting-started/" />
   <meta property="og:site_name" content="Hookwing" />
   <meta property="og:type" content="website" />
-  <meta property="og:image" content="https://hookwing.com/assets/og/default.png" />
   <meta property="og:title" content="Getting Started | Hookwing" />
   <meta property="og:description" content="Your first webhook in 60 seconds. Create an account, set up an endpoint, and start receiving events." />
   <meta property="og:url" content="https://dev.hookwing.com/docs/getting-started/" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Getting Started | Hookwing" />
+  <meta name="twitter:description" content="Your first webhook in 60 seconds. Create an account, set up an endpoint, and start receiving events." />
   <title>Getting Started | Hookwing</title>
-  <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-  <link rel="icon" href="/favicon-32.png" sizes="32x32" type="image/png" />
-  <link rel="manifest" href="/site.webmanifest" />
-  <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" />
-  <link rel="stylesheet" href="/styles/tokens.css" />
-  <link rel="stylesheet" href="/styles/base.css" />
-  <link rel="stylesheet" href="/styles/components.css" />
-  <link rel="stylesheet" href="/styles/patterns.css" />
+  <link rel="stylesheet" href="/styles/tokens.css?v=7" />
+  <link rel="stylesheet" href="/styles/base.css?v=7" />
+  <link rel="stylesheet" href="/styles/components.css?v=7" />
+  <link rel="stylesheet" href="/styles/patterns.css?v=8" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css" />
   <link rel="stylesheet" href="/styles/docs.css" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css" />
 </head>
 <body>
-  <!-- Navigation (same as homepage) -->
   <header>
     <nav class="nav" aria-label="Main navigation">
       <div class="container">
@@ -45,7 +38,7 @@
             <li><a href="/use-cases/" class="nav-link">Use cases</a></li>
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
-            <li><a href="/docs/" class="nav-link is-active">Documentation</a></li>
+            <li><a href="/docs/" class="nav-link">Documentation</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/signup/" class="nav-link">Start free</a></li>
           </ul>
@@ -78,7 +71,8 @@
       </div>
     </div>
   </header>
-
+  <main id="main-content">
+    
   <!-- Mobile hamburger toggle -->
   <button class="docs-hamburger" id="docs-hamburger" aria-label="Toggle documentation menu" aria-expanded="false" aria-controls="docs-sidebar">
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -92,47 +86,37 @@
   <div class="docs-sidebar-backdrop" id="docs-sidebar-backdrop"></div>
 
   <div class="docs-layout">
-    <!-- Sidebar -->
-    <aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
-      <div class="docs-sidebar-inner">
-        <nav>
-          <div class="docs-nav-group">Overview</div>
-          <a href="/docs/" class="docs-nav-link">Introduction</a>
-          <a href="/docs/getting-started/" class="docs-nav-link docs-nav-link--nested is-active">Getting Started</a>
-          <a href="/docs/authentication/" class="docs-nav-link docs-nav-link--nested">Authentication</a>
+    
+<aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
+  <div class="docs-sidebar-inner">
+    <nav>
+      <div class="docs-nav-group">Overview</div>
+      <a href="/docs/" class="docs-nav-link">Introduction</a>
+      <a href="/docs/getting-started/" class="docs-nav-link docs-nav-link--nested is-active">Getting Started</a>
+      <a href="/docs/authentication/" class="docs-nav-link docs-nav-link--nested">Authentication</a>
 
-          <div class="docs-nav-group">API Reference</div>
-          <a href="/docs/endpoints/" class="docs-nav-link docs-nav-link--nested">Endpoints</a>
-          <a href="/docs/event-routing/" class="docs-nav-link docs-nav-link--nested">Event Routing</a>
+      <div class="docs-nav-group">API Reference</div>
+      <a href="/docs/endpoints/" class="docs-nav-link docs-nav-link--nested">Endpoints</a>
+      <a href="/docs/event-routing/" class="docs-nav-link docs-nav-link--nested">Event Routing</a>
 
-          <div class="docs-nav-group">Guides</div>
-          <a href="/docs/webhooks/" class="docs-nav-link docs-nav-link--nested">Webhook Signatures</a>
-          <a href="/docs/sdk-quickstart/" class="docs-nav-link docs-nav-link--nested">SDK Quickstart</a>
-          <a href="/docs/cli-reference/" class="docs-nav-link docs-nav-link--nested">CLI Reference</a>
-          <a href="/docs/error-codes/" class="docs-nav-link docs-nav-link--nested">Error Codes</a>
-          <a href="/docs/agent-integrations/" class="docs-nav-link docs-nav-link--nested">Agent Integrations</a>
+      <div class="docs-nav-group">Guides</div>
+      <a href="/docs/webhooks/" class="docs-nav-link docs-nav-link--nested">Webhook Signatures</a>
+      <a href="/docs/sdk-quickstart/" class="docs-nav-link docs-nav-link--nested">SDK Quickstart</a>
+      <a href="/docs/cli-reference/" class="docs-nav-link docs-nav-link--nested">CLI Reference</a>
+      <a href="/docs/error-codes/" class="docs-nav-link docs-nav-link--nested">Error Codes</a>
+      <a href="/docs/agent-integrations/" class="docs-nav-link docs-nav-link--nested">Agent Integrations</a>
 
-          <div class="docs-nav-group">Tools</div>
-          <a href="/docs/api/" class="docs-nav-link">API Explorer ↗</a>
-        </nav>
-      </div>
-    </aside>
-
+      <div class="docs-nav-group">Tools</div>
+      <a href="/docs/api/" class="docs-nav-link">API Explorer ↗</a>
+    </nav>
+  </div>
+</aside>
     <!-- Content -->
     <main id="main-content">
       <div class="docs-content-wrap">
         <div class="docs-content docs-main">
           <h1>Getting Started</h1>
           <p class="lede">Your first webhook in 60 seconds. Create an account, set up an endpoint, and start receiving events.</p>
-
-          <nav class="docs-toc" aria-label="Table of contents">
-            <div class="docs-toc-label">On this page</div>
-            <ul class="docs-toc-list">
-              <li class="docs-toc-item"><a href="#your-first-webhook-in-60-seconds" class="docs-toc-link">Your first webhook in 60 seconds</a></li>
-              <li class="docs-toc-item"><a href="#what-s-next" class="docs-toc-link">What&apos;s next?</a></li>
-            </ul>
-          </nav>
-
           <h2 id="your-first-webhook-in-60-seconds">Your first webhook in 60 seconds</h2>
 <p>Hookwing receives webhooks, verifies signatures, retries on failure, and delivers to your endpoints. Here&#39;s how to get started.</p>
 <h3 id="1-create-an-account">1. Create an account</h3>
@@ -235,8 +219,7 @@ event, err := wh.Verify([]byte(payload), req.Header)</code></pre>
       </div>
     </main>
   </div>
-
-  <!-- Footer (same as homepage) -->
+  </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
       <div class="footer-grid">
@@ -249,7 +232,7 @@ event, err := wh.Verify([]byte(payload), req.Header)</code></pre>
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -261,6 +244,7 @@ event, err := wh.Verify([]byte(payload), req.Header)</code></pre>
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -270,9 +254,9 @@ event, err := wh.Verify([]byte(payload), req.Header)</code></pre>
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -295,18 +279,17 @@ event, err := wh.Verify([]byte(payload), req.Header)</code></pre>
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>
   </footer>
-
   <script>
-    // Mobile nav toggle
     (function(){
       const toggle=document.getElementById('nav-toggle'),mobileNav=document.getElementById('nav-mobile');
       if(toggle&&mobileNav){toggle.addEventListener('click',function(){const e=this.getAttribute('aria-expanded')==='true';this.setAttribute('aria-expanded',String(!e));mobileNav.classList.toggle('is-open',!e);mobileNav.setAttribute('aria-hidden',String(e))});document.addEventListener('click',function(e){if(mobileNav.classList.contains('is-open')&&!mobileNav.contains(e.target)&&!toggle.contains(e.target)){toggle.setAttribute('aria-expanded','false');mobileNav.classList.remove('is-open');mobileNav.setAttribute('aria-hidden','true')}});document.addEventListener('keydown',function(e){if(e.key==='Escape'&&mobileNav.classList.contains('is-open')){toggle.setAttribute('aria-expanded','false');mobileNav.classList.remove('is-open');mobileNav.setAttribute('aria-hidden','true');toggle.focus()}});mobileNav.querySelectorAll('a').forEach(function(link){link.addEventListener('click',function(){toggle.setAttribute('aria-expanded','false');mobileNav.classList.remove('is-open');mobileNav.setAttribute('aria-hidden','true')})})}
-
+      const saved=localStorage.getItem('theme'),prefersDark=window.matchMedia('(prefers-color-scheme: dark)').matches;if(saved){document.documentElement.dataset.theme=saved}else if(prefersDark){document.documentElement.dataset.theme='dark'}
+      
       // Docs sidebar toggle
       const docsHamburger = document.getElementById('docs-hamburger');
       const docsSidebar = document.getElementById('docs-sidebar');
@@ -316,7 +299,7 @@ event, err := wh.Verify([]byte(payload), req.Header)</code></pre>
         docsHamburger.addEventListener('click', function() {
           const isOpen = docsSidebar.classList.contains('is-open');
           docsSidebar.classList.toggle('is-open', !isOpen);
-          docsBackdrop.classList.toggle('is-open', !isOpen);
+          if (docsBackdrop) docsBackdrop.classList.toggle('is-open', !isOpen);
           docsHamburger.setAttribute('aria-expanded', String(!isOpen));
         });
 
@@ -328,12 +311,9 @@ event, err := wh.Verify([]byte(payload), req.Header)</code></pre>
           });
         }
       }
-
-      // Theme
-      const saved=localStorage.getItem('theme'),prefersDark=window.matchMedia('(prefers-color-scheme: dark)').matches;if(saved){document.documentElement.dataset.theme=saved}else if(prefersDark){document.documentElement.dataset.theme='dark'}
     })();
   </script>
-  <script src="/shared/feedback-widget.js" defer></script>
-  <script src="/shared/code-copy.js" defer></script>
+<script src="/shared/feedback-widget.js" defer></script>
+<script src="/shared/code-copy.js" defer></script>
 </body>
 </html>

--- a/website/docs/sdk-quickstart/index.html
+++ b/website/docs/sdk-quickstart/index.html
@@ -3,32 +3,25 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://hookwing.com; connect-src 'self' https://dev.api.hookwing.com https://api.hookwing.com; base-uri 'self'; form-action 'self';" />
   <meta name="description" content="Get started with the Hookwing SDK in Node.js, Python, Go, or Ruby. Verify webhook signatures in under 5 minutes." />
   <link rel="canonical" href="https://dev.hookwing.com/docs/sdk-quickstart/" />
   <meta property="og:site_name" content="Hookwing" />
   <meta property="og:type" content="website" />
-  <meta property="og:image" content="https://hookwing.com/assets/og/default.png" />
   <meta property="og:title" content="SDK Quickstart | Hookwing" />
   <meta property="og:description" content="Get started with the Hookwing SDK in Node.js, Python, Go, or Ruby. Verify webhook signatures in under 5 minutes." />
   <meta property="og:url" content="https://dev.hookwing.com/docs/sdk-quickstart/" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="SDK Quickstart | Hookwing" />
+  <meta name="twitter:description" content="Get started with the Hookwing SDK in Node.js, Python, Go, or Ruby. Verify webhook signatures in under 5 minutes." />
   <title>SDK Quickstart | Hookwing</title>
-  <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-  <link rel="icon" href="/favicon-32.png" sizes="32x32" type="image/png" />
-  <link rel="manifest" href="/site.webmanifest" />
-  <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" />
-  <link rel="stylesheet" href="/styles/tokens.css" />
-  <link rel="stylesheet" href="/styles/base.css" />
-  <link rel="stylesheet" href="/styles/components.css" />
-  <link rel="stylesheet" href="/styles/patterns.css" />
+  <link rel="stylesheet" href="/styles/tokens.css?v=7" />
+  <link rel="stylesheet" href="/styles/base.css?v=7" />
+  <link rel="stylesheet" href="/styles/components.css?v=7" />
+  <link rel="stylesheet" href="/styles/patterns.css?v=8" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css" />
   <link rel="stylesheet" href="/styles/docs.css" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css" />
 </head>
 <body>
-  <!-- Navigation (same as homepage) -->
   <header>
     <nav class="nav" aria-label="Main navigation">
       <div class="container">
@@ -45,7 +38,7 @@
             <li><a href="/use-cases/" class="nav-link">Use cases</a></li>
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
-            <li><a href="/docs/" class="nav-link is-active">Documentation</a></li>
+            <li><a href="/docs/" class="nav-link">Documentation</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/signup/" class="nav-link">Start free</a></li>
           </ul>
@@ -78,7 +71,8 @@
       </div>
     </div>
   </header>
-
+  <main id="main-content">
+    
   <!-- Mobile hamburger toggle -->
   <button class="docs-hamburger" id="docs-hamburger" aria-label="Toggle documentation menu" aria-expanded="false" aria-controls="docs-sidebar">
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -92,52 +86,37 @@
   <div class="docs-sidebar-backdrop" id="docs-sidebar-backdrop"></div>
 
   <div class="docs-layout">
-    <!-- Sidebar -->
-    <aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
-      <div class="docs-sidebar-inner">
-        <nav>
-          <div class="docs-nav-group">Overview</div>
-          <a href="/docs/" class="docs-nav-link">Introduction</a>
-          <a href="/docs/getting-started/" class="docs-nav-link docs-nav-link--nested">Getting Started</a>
-          <a href="/docs/authentication/" class="docs-nav-link docs-nav-link--nested">Authentication</a>
+    
+<aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
+  <div class="docs-sidebar-inner">
+    <nav>
+      <div class="docs-nav-group">Overview</div>
+      <a href="/docs/" class="docs-nav-link">Introduction</a>
+      <a href="/docs/getting-started/" class="docs-nav-link docs-nav-link--nested">Getting Started</a>
+      <a href="/docs/authentication/" class="docs-nav-link docs-nav-link--nested">Authentication</a>
 
-          <div class="docs-nav-group">API Reference</div>
-          <a href="/docs/endpoints/" class="docs-nav-link docs-nav-link--nested">Endpoints</a>
-          <a href="/docs/event-routing/" class="docs-nav-link docs-nav-link--nested">Event Routing</a>
+      <div class="docs-nav-group">API Reference</div>
+      <a href="/docs/endpoints/" class="docs-nav-link docs-nav-link--nested">Endpoints</a>
+      <a href="/docs/event-routing/" class="docs-nav-link docs-nav-link--nested">Event Routing</a>
 
-          <div class="docs-nav-group">Guides</div>
-          <a href="/docs/webhooks/" class="docs-nav-link docs-nav-link--nested">Webhook Signatures</a>
-          <a href="/docs/sdk-quickstart/" class="docs-nav-link docs-nav-link--nested is-active">SDK Quickstart</a>
-          <a href="/docs/cli-reference/" class="docs-nav-link docs-nav-link--nested">CLI Reference</a>
-          <a href="/docs/error-codes/" class="docs-nav-link docs-nav-link--nested">Error Codes</a>
-          <a href="/docs/agent-integrations/" class="docs-nav-link docs-nav-link--nested">Agent Integrations</a>
+      <div class="docs-nav-group">Guides</div>
+      <a href="/docs/webhooks/" class="docs-nav-link docs-nav-link--nested">Webhook Signatures</a>
+      <a href="/docs/sdk-quickstart/" class="docs-nav-link docs-nav-link--nested is-active">SDK Quickstart</a>
+      <a href="/docs/cli-reference/" class="docs-nav-link docs-nav-link--nested">CLI Reference</a>
+      <a href="/docs/error-codes/" class="docs-nav-link docs-nav-link--nested">Error Codes</a>
+      <a href="/docs/agent-integrations/" class="docs-nav-link docs-nav-link--nested">Agent Integrations</a>
 
-          <div class="docs-nav-group">Tools</div>
-          <a href="/docs/api/" class="docs-nav-link">API Explorer ↗</a>
-        </nav>
-      </div>
-    </aside>
-
+      <div class="docs-nav-group">Tools</div>
+      <a href="/docs/api/" class="docs-nav-link">API Explorer ↗</a>
+    </nav>
+  </div>
+</aside>
     <!-- Content -->
     <main id="main-content">
       <div class="docs-content-wrap">
         <div class="docs-content docs-main">
           <h1>SDK Quickstart</h1>
           <p class="lede">Get started with the Hookwing SDK in Node.js, Python, Go, or Ruby. Verify webhook signatures in under 5 minutes.</p>
-
-          <nav class="docs-toc" aria-label="Table of contents">
-            <div class="docs-toc-label">On this page</div>
-            <ul class="docs-toc-list">
-              <li class="docs-toc-item"><a href="#choose-your-language" class="docs-toc-link">Choose Your Language</a></li>
-              <li class="docs-toc-item"><a href="#node-js-typescript" class="docs-toc-link">Node.js / TypeScript</a></li>
-              <li class="docs-toc-item"><a href="#python" class="docs-toc-link">Python</a></li>
-              <li class="docs-toc-item"><a href="#go" class="docs-toc-link">Go</a></li>
-              <li class="docs-toc-item"><a href="#ruby" class="docs-toc-link">Ruby</a></li>
-              <li class="docs-toc-item"><a href="#signature-headers" class="docs-toc-link">Signature Headers</a></li>
-              <li class="docs-toc-item"><a href="#next-steps" class="docs-toc-link">Next Steps</a></li>
-            </ul>
-          </nav>
-
           <h2 id="choose-your-language">Choose Your Language</h2>
 <p>Hookwing has official SDKs for 4 languages. Each handles HMAC-SHA256 signature verification with constant-time comparison.</p>
 <h2 id="node-js-typescript">Node.js / TypeScript</h2>
@@ -289,8 +268,7 @@ end</code></pre>
       </div>
     </main>
   </div>
-
-  <!-- Footer (same as homepage) -->
+  </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
       <div class="footer-grid">
@@ -303,7 +281,7 @@ end</code></pre>
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -315,6 +293,7 @@ end</code></pre>
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -324,9 +303,9 @@ end</code></pre>
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -349,18 +328,17 @@ end</code></pre>
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>
   </footer>
-
   <script>
-    // Mobile nav toggle
     (function(){
       const toggle=document.getElementById('nav-toggle'),mobileNav=document.getElementById('nav-mobile');
       if(toggle&&mobileNav){toggle.addEventListener('click',function(){const e=this.getAttribute('aria-expanded')==='true';this.setAttribute('aria-expanded',String(!e));mobileNav.classList.toggle('is-open',!e);mobileNav.setAttribute('aria-hidden',String(e))});document.addEventListener('click',function(e){if(mobileNav.classList.contains('is-open')&&!mobileNav.contains(e.target)&&!toggle.contains(e.target)){toggle.setAttribute('aria-expanded','false');mobileNav.classList.remove('is-open');mobileNav.setAttribute('aria-hidden','true')}});document.addEventListener('keydown',function(e){if(e.key==='Escape'&&mobileNav.classList.contains('is-open')){toggle.setAttribute('aria-expanded','false');mobileNav.classList.remove('is-open');mobileNav.setAttribute('aria-hidden','true');toggle.focus()}});mobileNav.querySelectorAll('a').forEach(function(link){link.addEventListener('click',function(){toggle.setAttribute('aria-expanded','false');mobileNav.classList.remove('is-open');mobileNav.setAttribute('aria-hidden','true')})})}
-
+      const saved=localStorage.getItem('theme'),prefersDark=window.matchMedia('(prefers-color-scheme: dark)').matches;if(saved){document.documentElement.dataset.theme=saved}else if(prefersDark){document.documentElement.dataset.theme='dark'}
+      
       // Docs sidebar toggle
       const docsHamburger = document.getElementById('docs-hamburger');
       const docsSidebar = document.getElementById('docs-sidebar');
@@ -370,7 +348,7 @@ end</code></pre>
         docsHamburger.addEventListener('click', function() {
           const isOpen = docsSidebar.classList.contains('is-open');
           docsSidebar.classList.toggle('is-open', !isOpen);
-          docsBackdrop.classList.toggle('is-open', !isOpen);
+          if (docsBackdrop) docsBackdrop.classList.toggle('is-open', !isOpen);
           docsHamburger.setAttribute('aria-expanded', String(!isOpen));
         });
 
@@ -382,12 +360,9 @@ end</code></pre>
           });
         }
       }
-
-      // Theme
-      const saved=localStorage.getItem('theme'),prefersDark=window.matchMedia('(prefers-color-scheme: dark)').matches;if(saved){document.documentElement.dataset.theme=saved}else if(prefersDark){document.documentElement.dataset.theme='dark'}
     })();
   </script>
-  <script src="/shared/feedback-widget.js" defer></script>
-  <script src="/shared/code-copy.js" defer></script>
+<script src="/shared/feedback-widget.js" defer></script>
+<script src="/shared/code-copy.js" defer></script>
 </body>
 </html>

--- a/website/docs/webhooks/index.html
+++ b/website/docs/webhooks/index.html
@@ -3,32 +3,25 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://hookwing.com; connect-src 'self' https://dev.api.hookwing.com https://api.hookwing.com; base-uri 'self'; form-action 'self';" />
   <meta name="description" content="How Hookwing signs deliveries and how to verify them in your application." />
   <link rel="canonical" href="https://dev.hookwing.com/docs/webhooks/" />
   <meta property="og:site_name" content="Hookwing" />
   <meta property="og:type" content="website" />
-  <meta property="og:image" content="https://hookwing.com/assets/og/default.png" />
   <meta property="og:title" content="Webhook Signatures | Hookwing" />
   <meta property="og:description" content="How Hookwing signs deliveries and how to verify them in your application." />
   <meta property="og:url" content="https://dev.hookwing.com/docs/webhooks/" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Webhook Signatures | Hookwing" />
+  <meta name="twitter:description" content="How Hookwing signs deliveries and how to verify them in your application." />
   <title>Webhook Signatures | Hookwing</title>
-  <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-  <link rel="icon" href="/favicon-32.png" sizes="32x32" type="image/png" />
-  <link rel="manifest" href="/site.webmanifest" />
-  <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" />
-  <link rel="stylesheet" href="/styles/tokens.css" />
-  <link rel="stylesheet" href="/styles/base.css" />
-  <link rel="stylesheet" href="/styles/components.css" />
-  <link rel="stylesheet" href="/styles/patterns.css" />
+  <link rel="stylesheet" href="/styles/tokens.css?v=7" />
+  <link rel="stylesheet" href="/styles/base.css?v=7" />
+  <link rel="stylesheet" href="/styles/components.css?v=7" />
+  <link rel="stylesheet" href="/styles/patterns.css?v=8" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css" />
   <link rel="stylesheet" href="/styles/docs.css" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css" />
 </head>
 <body>
-  <!-- Navigation (same as homepage) -->
   <header>
     <nav class="nav" aria-label="Main navigation">
       <div class="container">
@@ -45,7 +38,7 @@
             <li><a href="/use-cases/" class="nav-link">Use cases</a></li>
             <li><a href="/playground/" class="nav-link">Playground</a></li>
             <li><a href="/pricing/" class="nav-link">Pricing</a></li>
-            <li><a href="/docs/" class="nav-link is-active">Documentation</a></li>
+            <li><a href="/docs/" class="nav-link">Documentation</a></li>
             <li><a href="/blog/" class="nav-link">Blog</a></li>
             <li><a href="/signup/" class="nav-link">Start free</a></li>
           </ul>
@@ -78,7 +71,8 @@
       </div>
     </div>
   </header>
-
+  <main id="main-content">
+    
   <!-- Mobile hamburger toggle -->
   <button class="docs-hamburger" id="docs-hamburger" aria-label="Toggle documentation menu" aria-expanded="false" aria-controls="docs-sidebar">
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -92,48 +86,37 @@
   <div class="docs-sidebar-backdrop" id="docs-sidebar-backdrop"></div>
 
   <div class="docs-layout">
-    <!-- Sidebar -->
-    <aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
-      <div class="docs-sidebar-inner">
-        <nav>
-          <div class="docs-nav-group">Overview</div>
-          <a href="/docs/" class="docs-nav-link">Introduction</a>
-          <a href="/docs/getting-started/" class="docs-nav-link docs-nav-link--nested">Getting Started</a>
-          <a href="/docs/authentication/" class="docs-nav-link docs-nav-link--nested">Authentication</a>
+    
+<aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
+  <div class="docs-sidebar-inner">
+    <nav>
+      <div class="docs-nav-group">Overview</div>
+      <a href="/docs/" class="docs-nav-link">Introduction</a>
+      <a href="/docs/getting-started/" class="docs-nav-link docs-nav-link--nested">Getting Started</a>
+      <a href="/docs/authentication/" class="docs-nav-link docs-nav-link--nested">Authentication</a>
 
-          <div class="docs-nav-group">API Reference</div>
-          <a href="/docs/endpoints/" class="docs-nav-link docs-nav-link--nested">Endpoints</a>
-          <a href="/docs/event-routing/" class="docs-nav-link docs-nav-link--nested">Event Routing</a>
+      <div class="docs-nav-group">API Reference</div>
+      <a href="/docs/endpoints/" class="docs-nav-link docs-nav-link--nested">Endpoints</a>
+      <a href="/docs/event-routing/" class="docs-nav-link docs-nav-link--nested">Event Routing</a>
 
-          <div class="docs-nav-group">Guides</div>
-          <a href="/docs/webhooks/" class="docs-nav-link docs-nav-link--nested is-active">Webhook Signatures</a>
-          <a href="/docs/sdk-quickstart/" class="docs-nav-link docs-nav-link--nested">SDK Quickstart</a>
-          <a href="/docs/cli-reference/" class="docs-nav-link docs-nav-link--nested">CLI Reference</a>
-          <a href="/docs/error-codes/" class="docs-nav-link docs-nav-link--nested">Error Codes</a>
-          <a href="/docs/agent-integrations/" class="docs-nav-link docs-nav-link--nested">Agent Integrations</a>
+      <div class="docs-nav-group">Guides</div>
+      <a href="/docs/webhooks/" class="docs-nav-link docs-nav-link--nested is-active">Webhook Signatures</a>
+      <a href="/docs/sdk-quickstart/" class="docs-nav-link docs-nav-link--nested">SDK Quickstart</a>
+      <a href="/docs/cli-reference/" class="docs-nav-link docs-nav-link--nested">CLI Reference</a>
+      <a href="/docs/error-codes/" class="docs-nav-link docs-nav-link--nested">Error Codes</a>
+      <a href="/docs/agent-integrations/" class="docs-nav-link docs-nav-link--nested">Agent Integrations</a>
 
-          <div class="docs-nav-group">Tools</div>
-          <a href="/docs/api/" class="docs-nav-link">API Explorer ↗</a>
-        </nav>
-      </div>
-    </aside>
-
+      <div class="docs-nav-group">Tools</div>
+      <a href="/docs/api/" class="docs-nav-link">API Explorer ↗</a>
+    </nav>
+  </div>
+</aside>
     <!-- Content -->
     <main id="main-content">
       <div class="docs-content-wrap">
         <div class="docs-content docs-main">
           <h1>Webhook Signatures</h1>
           <p class="lede">How Hookwing signs deliveries and how to verify them in your application.</p>
-
-          <nav class="docs-toc" aria-label="Table of contents">
-            <div class="docs-toc-label">On this page</div>
-            <ul class="docs-toc-list">
-              <li class="docs-toc-item"><a href="#how-hookwing-signs-deliveries" class="docs-toc-link">How Hookwing Signs Deliveries</a></li>
-              <li class="docs-toc-item"><a href="#delivery-retries" class="docs-toc-link">Delivery Retries</a></li>
-              <li class="docs-toc-item"><a href="#event-replay" class="docs-toc-link">Event Replay</a></li>
-            </ul>
-          </nav>
-
           <h2 id="how-hookwing-signs-deliveries">How Hookwing Signs Deliveries</h2>
 <p>Every webhook delivery includes two verification headers:</p>
 <table><thead><tr><th>Header</th><th>Value</th></tr></thead><tbody><tr><td><code>X-Hookwing-Signature</code></td><td><code>sha256=&amp;lt;hex-encoded HMAC-SHA256&amp;gt;</code></td></tr><tr><td><code>X-Hookwing-Timestamp</code></td><td>Unix timestamp in milliseconds</td></tr></tbody></table>
@@ -201,9 +184,9 @@ post <span class="hljs-string">&#x27;/webhooks&#x27;</span> <span class="hljs-ke
   event = wh.<span class="hljs-title function_">verify</span>(request.<span class="hljs-property">body</span>.<span class="hljs-property">read</span>, request.<span class="hljs-property">env</span>)
   puts <span class="hljs-string">&quot;Verified: #{event[:type]}&quot;</span>
   status <span class="hljs-number">200</span>
-rescue <span class="hljs-title class_">Hookwing</span>::<span class="function"><span class="hljs-params">VerificationError</span> =&gt;</span> e
+rescue <span class="hljs-title class_">Hookwing</span>::<span class="hljs-function"><span class="hljs-params">VerificationError</span> =&gt;</span> e
   status <span class="hljs-number">401</span>
-  body e.<span class="hljs-property">message
+  body e.<span class="hljs-property">message</span>
 end</code></pre>
 <h2 id="delivery-retries">Delivery Retries</h2>
 <p>If your endpoint returns a non-2xx status code, Hookwing retries with exponential backoff:</p>
@@ -218,8 +201,7 @@ curl -X POST https://api.hookwing.com/v1/events/evt_abc/replay \
       </div>
     </main>
   </div>
-
-  <!-- Footer (same as homepage) -->
+  </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
       <div class="footer-grid">
@@ -232,7 +214,7 @@ curl -X POST https://api.hookwing.com/v1/events/evt_abc/replay \
             Hookwing
           </a>
           <p class="footer-brand-desc">
-            Webhook infrastructure built for agents and developers.
+            Webhook infrastructure, built for agents.
             Test free. Ship with confidence.
           </p>
           <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
@@ -244,6 +226,7 @@ curl -X POST https://api.hookwing.com/v1/events/evt_abc/replay \
           <p class="footer-col-heading">Product</p>
           <ul class="footer-links" role="list" aria-label="Product navigation">
             <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/agent-experience/" class="footer-link">Agent experience</a></li>
             <li><a href="/playground/" class="footer-link">Playground</a></li>
             <li><a href="/pricing/" class="footer-link">Pricing</a></li>
             <li><a href="/docs/" class="footer-link">Docs</a></li>
@@ -253,9 +236,9 @@ curl -X POST https://api.hookwing.com/v1/events/evt_abc/replay \
         <div>
           <p class="footer-col-heading">Developers</p>
           <ul class="footer-links" role="list">
-            <li><a href="/getting-started/" class="footer-link">API reference</a></li>
+            <li><a href="/docs/" class="footer-link">API reference</a></li>
             <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
-            <li><a href="/docs/" class="footer-link">OpenAPI spec</a></li>
+            <li><a href="/openapi.json" class="footer-link">OpenAPI spec</a></li>
             <li><a href="/status/" class="footer-link">Status page</a></li>
           </ul>
         </div>
@@ -278,18 +261,17 @@ curl -X POST https://api.hookwing.com/v1/events/evt_abc/replay \
           &copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.
         </p>
         <p class="footer-copy" style="color:rgba(255,255,255,.25);">
-          Built for developers and AI agents.
+          Built for agents.
         </p>
       </div>
     </div>
   </footer>
-
   <script>
-    // Mobile nav toggle
     (function(){
       const toggle=document.getElementById('nav-toggle'),mobileNav=document.getElementById('nav-mobile');
       if(toggle&&mobileNav){toggle.addEventListener('click',function(){const e=this.getAttribute('aria-expanded')==='true';this.setAttribute('aria-expanded',String(!e));mobileNav.classList.toggle('is-open',!e);mobileNav.setAttribute('aria-hidden',String(e))});document.addEventListener('click',function(e){if(mobileNav.classList.contains('is-open')&&!mobileNav.contains(e.target)&&!toggle.contains(e.target)){toggle.setAttribute('aria-expanded','false');mobileNav.classList.remove('is-open');mobileNav.setAttribute('aria-hidden','true')}});document.addEventListener('keydown',function(e){if(e.key==='Escape'&&mobileNav.classList.contains('is-open')){toggle.setAttribute('aria-expanded','false');mobileNav.classList.remove('is-open');mobileNav.setAttribute('aria-hidden','true');toggle.focus()}});mobileNav.querySelectorAll('a').forEach(function(link){link.addEventListener('click',function(){toggle.setAttribute('aria-expanded','false');mobileNav.classList.remove('is-open');mobileNav.setAttribute('aria-hidden','true')})})}
-
+      const saved=localStorage.getItem('theme'),prefersDark=window.matchMedia('(prefers-color-scheme: dark)').matches;if(saved){document.documentElement.dataset.theme=saved}else if(prefersDark){document.documentElement.dataset.theme='dark'}
+      
       // Docs sidebar toggle
       const docsHamburger = document.getElementById('docs-hamburger');
       const docsSidebar = document.getElementById('docs-sidebar');
@@ -299,7 +281,7 @@ curl -X POST https://api.hookwing.com/v1/events/evt_abc/replay \
         docsHamburger.addEventListener('click', function() {
           const isOpen = docsSidebar.classList.contains('is-open');
           docsSidebar.classList.toggle('is-open', !isOpen);
-          docsBackdrop.classList.toggle('is-open', !isOpen);
+          if (docsBackdrop) docsBackdrop.classList.toggle('is-open', !isOpen);
           docsHamburger.setAttribute('aria-expanded', String(!isOpen));
         });
 
@@ -311,12 +293,9 @@ curl -X POST https://api.hookwing.com/v1/events/evt_abc/replay \
           });
         }
       }
-
-      // Theme
-      const saved=localStorage.getItem('theme'),prefersDark=window.matchMedia('(prefers-color-scheme: dark)').matches;if(saved){document.documentElement.dataset.theme=saved}else if(prefersDark){document.documentElement.dataset.theme='dark'}
     })();
   </script>
-  <script src="/shared/feedback-widget.js" defer></script>
-  <script src="/shared/code-copy.js" defer></script>
+<script src="/shared/feedback-widget.js" defer></script>
+<script src="/shared/code-copy.js" defer></script>
 </body>
 </html>

--- a/website/scripts/build-content.mjs
+++ b/website/scripts/build-content.mjs
@@ -624,7 +624,9 @@ function renderLayout({ title, description, content, routePath, nav = "", ogImag
   <link rel="stylesheet" href="/styles/components.css?v=7" />
   <link rel="stylesheet" href="/styles/patterns.css?v=8" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css" />
-  <link rel="stylesheet" href="/styles/pages/blog.css?v=9" />
+  ${isDocs
+    ? `<link rel="stylesheet" href="/styles/docs.css" />`
+    : `<link rel="stylesheet" href="/styles/pages/blog.css?v=9" />`}
 </head>
 <body>
   <header>
@@ -677,9 +679,7 @@ function renderLayout({ title, description, content, routePath, nav = "", ogImag
     </div>
   </header>
   <main id="main-content">
-    <div class="shell">
-      ${content}
-    </div>
+    ${isDocs ? content : `<div class="shell">${content}</div>`}
   </main>
   <footer class="footer" aria-label="Site footer">
     <div class="container">
@@ -750,7 +750,28 @@ function renderLayout({ title, description, content, routePath, nav = "", ogImag
       const toggle=document.getElementById('nav-toggle'),mobileNav=document.getElementById('nav-mobile');
       if(toggle&&mobileNav){toggle.addEventListener('click',function(){const e=this.getAttribute('aria-expanded')==='true';this.setAttribute('aria-expanded',String(!e));mobileNav.classList.toggle('is-open',!e);mobileNav.setAttribute('aria-hidden',String(e))});document.addEventListener('click',function(e){if(mobileNav.classList.contains('is-open')&&!mobileNav.contains(e.target)&&!toggle.contains(e.target)){toggle.setAttribute('aria-expanded','false');mobileNav.classList.remove('is-open');mobileNav.setAttribute('aria-hidden','true')}});document.addEventListener('keydown',function(e){if(e.key==='Escape'&&mobileNav.classList.contains('is-open')){toggle.setAttribute('aria-expanded','false');mobileNav.classList.remove('is-open');mobileNav.setAttribute('aria-hidden','true');toggle.focus()}});mobileNav.querySelectorAll('a').forEach(function(link){link.addEventListener('click',function(){toggle.setAttribute('aria-expanded','false');mobileNav.classList.remove('is-open');mobileNav.setAttribute('aria-hidden','true')})})}
       const saved=localStorage.getItem('theme'),prefersDark=window.matchMedia('(prefers-color-scheme: dark)').matches;if(saved){document.documentElement.dataset.theme=saved}else if(prefersDark){document.documentElement.dataset.theme='dark'}
-      
+      ${isDocs ? `
+      // Docs sidebar toggle
+      const docsHamburger = document.getElementById('docs-hamburger');
+      const docsSidebar = document.getElementById('docs-sidebar');
+      const docsBackdrop = document.getElementById('docs-sidebar-backdrop');
+
+      if (docsHamburger && docsSidebar) {
+        docsHamburger.addEventListener('click', function() {
+          const isOpen = docsSidebar.classList.contains('is-open');
+          docsSidebar.classList.toggle('is-open', !isOpen);
+          if (docsBackdrop) docsBackdrop.classList.toggle('is-open', !isOpen);
+          docsHamburger.setAttribute('aria-expanded', String(!isOpen));
+        });
+
+        if (docsBackdrop) {
+          docsBackdrop.addEventListener('click', function() {
+            docsSidebar.classList.remove('is-open');
+            docsBackdrop.classList.remove('is-open');
+            docsHamburger.setAttribute('aria-expanded', 'false');
+          });
+        }
+      }` : ''}
     })();
   </script>
 <script src="/shared/feedback-widget.js" defer></script>
@@ -1004,21 +1025,30 @@ function renderDocsIndex(docs) {
   });
 }
 
-const docsNavHtml = `
-<aside class="docs-sidebar" style="position:sticky;top:24px;align-self:start;">
-  <nav style="border-right:1px solid var(--color-border);padding-right:16px;">
-    <a href="/docs/" style="display:block;padding:4px 0;font-size:.875rem;font-weight:600;color:var(--color-ink-strong);text-decoration:none;margin-bottom:8px;">← All Docs</a>
-    <a href="/docs/getting-started/" style="display:block;padding:4px 0;font-size:.875rem;color:var(--color-ink-muted);text-decoration:none;">Getting Started</a>
-    <a href="/docs/authentication/" style="display:block;padding:4px 0;font-size:.875rem;color:var(--color-ink-muted);text-decoration:none;">Authentication</a>
-    <a href="/docs/endpoints/" style="display:block;padding:4px 0;font-size:.875rem;color:var(--color-ink-muted);text-decoration:none;">Endpoints</a>
-    <a href="/docs/event-routing/" style="display:block;padding:4px 0;font-size:.875rem;color:var(--color-ink-muted);text-decoration:none;">Event Routing</a>
-    <a href="/docs/webhooks/" style="display:block;padding:4px 0;font-size:.875rem;color:var(--color-ink-muted);text-decoration:none;">Webhook Signatures</a>
-    <a href="/docs/sdk-quickstart/" style="display:block;padding:4px 0;font-size:.875rem;color:var(--color-ink-muted);text-decoration:none;">SDK Quickstart</a>
-    <a href="/docs/cli-reference/" style="display:block;padding:4px 0;font-size:.875rem;color:var(--color-ink-muted);text-decoration:none;">CLI Reference</a>
-    <a href="/docs/error-codes/" style="display:block;padding:4px 0;font-size:.875rem;color:var(--color-ink-muted);text-decoration:none;">Error Codes</a>
-    <a href="/docs/agent-integrations/" style="display:block;padding:4px 0;font-size:.875rem;color:var(--color-ink-muted);text-decoration:none;">Agent Integrations</a>
-    <a href="/docs/api/" style="display:block;padding:4px 0;font-size:.875rem;color:var(--color-brand-action);text-decoration:none;">API Explorer ↗</a>
-  </nav>
+const docsNavHtml = (activeSlug) => `
+<aside class="docs-sidebar" id="docs-sidebar" aria-label="Documentation navigation">
+  <div class="docs-sidebar-inner">
+    <nav>
+      <div class="docs-nav-group">Overview</div>
+      <a href="/docs/" class="docs-nav-link${activeSlug === 'index' ? ' is-active' : ''}">Introduction</a>
+      <a href="/docs/getting-started/" class="docs-nav-link docs-nav-link--nested${activeSlug === 'getting-started' ? ' is-active' : ''}">Getting Started</a>
+      <a href="/docs/authentication/" class="docs-nav-link docs-nav-link--nested${activeSlug === 'authentication' ? ' is-active' : ''}">Authentication</a>
+
+      <div class="docs-nav-group">API Reference</div>
+      <a href="/docs/endpoints/" class="docs-nav-link docs-nav-link--nested${activeSlug === 'endpoints' ? ' is-active' : ''}">Endpoints</a>
+      <a href="/docs/event-routing/" class="docs-nav-link docs-nav-link--nested${activeSlug === 'event-routing' ? ' is-active' : ''}">Event Routing</a>
+
+      <div class="docs-nav-group">Guides</div>
+      <a href="/docs/webhooks/" class="docs-nav-link docs-nav-link--nested${activeSlug === 'webhooks' ? ' is-active' : ''}">Webhook Signatures</a>
+      <a href="/docs/sdk-quickstart/" class="docs-nav-link docs-nav-link--nested${activeSlug === 'sdk-quickstart' ? ' is-active' : ''}">SDK Quickstart</a>
+      <a href="/docs/cli-reference/" class="docs-nav-link docs-nav-link--nested${activeSlug === 'cli-reference' ? ' is-active' : ''}">CLI Reference</a>
+      <a href="/docs/error-codes/" class="docs-nav-link docs-nav-link--nested${activeSlug === 'error-codes' ? ' is-active' : ''}">Error Codes</a>
+      <a href="/docs/agent-integrations/" class="docs-nav-link docs-nav-link--nested${activeSlug === 'agent-integrations' ? ' is-active' : ''}">Agent Integrations</a>
+
+      <div class="docs-nav-group">Tools</div>
+      <a href="/docs/api/" class="docs-nav-link">API Explorer ↗</a>
+    </nav>
+  </div>
 </aside>`;
 
 function renderDocsArticle(doc) {
@@ -1027,15 +1057,32 @@ function renderDocsArticle(doc) {
     description: doc.summary,
     routePath: `/docs/${doc.slug}/`,
     nav: `<a href="/docs/">Docs home</a>`,
-    content: `<div style="display:grid;grid-template-columns:220px 1fr;gap:32px;max-width:1100px;margin:0 auto;padding:24px 20px;">
-      ${docsNavHtml}
-      <article style="min-width:0;">
-        <h1>${escapeHtml(doc.title)}</h1>
-        <div class="meta"><span>Updated ${escapeHtml(formatDate(doc.updatedAt))}</span></div>
-        <p class="lede">${escapeHtml(doc.summary)}</p>
-        ${doc.bodyHtml}
-      </article>
-    </div>`,
+    content: `
+  <!-- Mobile hamburger toggle -->
+  <button class="docs-hamburger" id="docs-hamburger" aria-label="Toggle documentation menu" aria-expanded="false" aria-controls="docs-sidebar">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <line x1="3" y1="6" x2="21" y2="6"></line>
+      <line x1="3" y1="12" x2="21" y2="12"></line>
+      <line x1="3" y1="18" x2="21" y2="18"></line>
+    </svg>
+  </button>
+
+  <!-- Backdrop for mobile sidebar -->
+  <div class="docs-sidebar-backdrop" id="docs-sidebar-backdrop"></div>
+
+  <div class="docs-layout">
+    ${docsNavHtml(doc.slug)}
+    <!-- Content -->
+    <main id="main-content">
+      <div class="docs-content-wrap">
+        <div class="docs-content docs-main">
+          <h1>${escapeHtml(doc.title)}</h1>
+          <p class="lede">${escapeHtml(doc.summary)}</p>
+          ${doc.bodyHtml}
+        </div>
+      </div>
+    </main>
+  </div>`,
   });
 }
 


### PR DESCRIPTION
## Summary
- Rewrite `build-content.mjs` to generate all 9 docs sub-pages using the modern `docs.css` sidebar layout (matching `docs/index.html`)
- Each page now uses: `docs.css` stylesheet, `docs-layout` / `docs-sidebar` structure, hamburger toggle for mobile, docs sidebar JS, and `is-active` nav highlighting
- Blog pages remain unchanged (still use `blog.css` and `shell` wrapper)

## Changes
- `website/scripts/build-content.mjs` — 4 modifications to `renderLayout` + `renderDocsArticle`:
  1. Conditionally load `docs.css` vs `blog.css` based on route
  2. No `shell` wrapper for docs routes (docs-layout handles padding)
  3. Add docs sidebar toggle JS for docs routes
  4. New `docsNavHtml(activeSlug)` function with proper CSS classes + active link highlighting

## Test plan
- [x] `npm run build` — all 9 docs pages generated with docs.css, docs-layout, is-active link, hamburger toggle
- [x] Blog index still uses blog.css (verified)
- [x] docs/index.html still uses docs.css (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)