### PR TITLE
feat: migration CI validation + dynamic migration runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,6 @@ jobs:
           sudo apt-get install -y sqlite3
           cat migrations/*.sql | sqlite3 /tmp/test.db
           TABLES=$(sqlite3 /tmp/test.db ".tables")
-          for t in workspaces api_keys endpoints events deliveries dead_letter_items feedback routing_rules password_reset_tokens idempotency_keys custom_domains; do
+          for t in workspaces api_keys endpoints events deliveries dead_letter_items feedback routing_rules password_reset_tokens idempotency_keys custom_domains oauth_accounts; do
             echo "$TABLES" | grep -q "$t" && echo "✅ $t" || { echo "❌ Missing: $t"; exit 1; }
           done

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -110,17 +110,28 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Setup infrastructure and deploy API
+      - name: Create infrastructure
+        run: |
+          wrangler queues create webhook-delivery-dev 2>&1 || true
+          wrangler d1 create hookwing-dev 2>&1 || true
+        working-directory: packages/api
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+      - name: Run database migrations
+        run: |
+          for f in $(ls ../../migrations/*.sql | sort); do
+            echo "Applying $(basename $f)..."
+            npx wrangler d1 execute hookwing-dev --remote --file="$f"
+          done
+        working-directory: packages/api
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+      - name: Deploy API to Workers
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: packages/api
-          preCommands: |
-            wrangler queues create webhook-delivery-dev 2>&1 || true
-            wrangler d1 create hookwing-dev 2>&1 || true
-            for f in $(ls ../../migrations/*.sql | sort); do
-              echo "Applying $(basename $f)..."
-              npx wrangler d1 execute hookwing-dev --remote --file="$f"
-            done
           command: deploy

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -116,7 +116,7 @@ jobs:
         run: |
           for f in $(ls ../../migrations/*.sql | sort); do
             echo "Applying $(basename $f)..."
-            npx wrangler d1 execute hookwing-prod --remote --file="$f"
+            npx wrangler d1 execute hookwing-prod --remote --env production --file="$f"
           done
         working-directory: packages/api
 

--- a/migrations/0018_add_oauth_accounts.sql
+++ b/migrations/0018_add_oauth_accounts.sql
@@ -1,0 +1,15 @@
+-- OAuth Accounts - social login identities
+-- Added to support GitHub/Google OAuth authentication
+
+CREATE TABLE IF NOT EXISTS oauth_accounts (
+  id TEXT PRIMARY KEY NOT NULL,
+  workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  provider TEXT NOT NULL,
+  provider_account_id TEXT NOT NULL,
+  email TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS oauth_accounts_workspace_id_idx ON oauth_accounts(workspace_id);
+CREATE UNIQUE INDEX IF NOT EXISTS oauth_accounts_provider_account_idx ON oauth_accounts(provider, provider_account_id);


### PR DESCRIPTION
## Summary
- Add `oauth_accounts` to CI table validation check
- Fix `deploy-prod.yml` to use `--env production` flag for wrangler d1 execute
- Split `deploy-dev.yml` migration step from preCommands into separate step with explicit env

## Test plan
- [x] CI passes migration validation with oauth_accounts table
- [x] Deploy-dev runs migrations in dedicated step with CLOUDFLARE_API_TOKEN env
- [x] Deploy-prod uses `--env production` flag for wrangler d1

🤖 Generated with [Claude Code](https://claude.com/claude-code)