### PR TITLE
fix: prod deploy — add CLOUDFLARE_API_TOKEN to migration step

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -119,6 +119,8 @@ jobs:
             npx wrangler d1 execute hookwing-prod --remote --env production --file="$f"
           done
         working-directory: packages/api
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
       - name: Deploy API to Workers
         uses: cloudflare/wrangler-action@v3


### PR DESCRIPTION
Deploy failed because the new dynamic migration runner needs CLOUDFLARE_API_TOKEN as an env var. Dev already had it, prod was missing.