### PR TITLE
fix(api-explorer): fix broken page — CSP, local spec, clear Playground distinction

### DIFF
--- a/website/pricing/index.html
+++ b/website/pricing/index.html
@@ -86,7 +86,7 @@
           "name": "Can agents sign up and pay via API?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "Yes. Hookwing is designed for this. No 2FA or CAPTCHA by default. Agents can create accounts, provision endpoints, and manage billing entirely via API. Machine-readable pricing is available at /api/pricing."
+            "text": "Yes. Hookwing is designed for this. No 2FA or CAPTCHA by default. Agents can create accounts, provision endpoints, and manage billing entirely via API. Machine-readable pricing is available at https://api.hookwing.com/api/pricing."
           }
         },
         {
@@ -539,7 +539,7 @@
 
         <p style="text-align:center; margin-top:var(--space-6); font-size:14px; color:var(--color-ink-muted);">
           Machine-readable pricing at
-          <a href="/api/pricing" style="font-family:var(--font-mono); font-size:13px;">/api/pricing</a>
+          <a href="https://api.hookwing.com/api/pricing" style="font-family:var(--font-mono); font-size:13px;">/api/pricing</a>
           . Agents can query our pricing before they sign up. No scraping. No parsing. Just JSON.
         </p>
 
@@ -622,7 +622,7 @@
               </tr>
 
               <tr>
-                <td scope="row">Machine-readable pricing (/api/pricing)</td>
+                <td scope="row">Machine-readable pricing (<a href="https://api.hookwing.com/api/pricing" style="font-family:var(--font-mono);">/api/pricing</a>)</td>
                 <td><span class="tbl-check">✓</span></td>
                 <td><span class="tbl-check">✓</span></td>
                 <td class="col-featured"><span class="tbl-check">✓</span></td>
@@ -1048,7 +1048,7 @@
               <div class="faq-answer-inner">
                 Yes, this is a first-class use case, not a workaround. Hookwing was designed for agents to operate without any human in the loop. No 2FA or CAPTCHA by default. API-key auth. No browser flows.
                 Agents can create accounts, provision endpoints, send events, inspect delivery, and upgrade plans, entirely via HTTP.
-                Machine-readable pricing at <a href="/api/pricing"><code>/api/pricing</code></a> so agents can evaluate tiers before committing.
+                Machine-readable pricing at <a href="https://api.hookwing.com/api/pricing"><code>/api/pricing</code></a> so agents can evaluate tiers before committing.
               </div>
             </div>
           </div>


### PR DESCRIPTION
## What's broken

`/docs/api/` — the API Explorer — was completely blank. Swagger UI was silently failing to load.

## Root causes

1. **CSP blocked CDN resources** — `script-src` and `style-src` did not include `https://cdn.jsdelivr.net`, so the browser rejected both the Swagger UI JavaScript bundle and its CSS. The `#swagger-ui` div rendered empty with no error visible to users.

2. **Spec URL pointed to dev API** — `https://dev.api.hookwing.com/openapi.json` is unreliable (dev environment, potential CORS issues) and caused Swagger UI to fail even if the bundle had loaded.

3. **Canonical/OG URLs pointed to dev subdomain** — `https://dev.hookwing.com/docs/api/` instead of production.

## Changes

| File | What changed |
|------|-------------|
| `website/docs/api/index.html` | Fix CSP to allow CDN; use local spec URL; fix canonical/og:url; add Playground callout |
| `website/docs/api/openapi.yaml` | Copy of `packages/api/openapi.yaml` — served statically, no external fetch needed |

## Visual changes

**Before:** Page loads, `#swagger-ui` div is empty, no content visible.

**After:**
- Full Swagger UI renders with all API endpoints (Health, Auth, Endpoints, Events, Deliveries, Analytics, Ingest)
- "Try it out" enabled by default
- Callout below the heading: _"Looking to test webhook delivery without an account? Use the [Playground] instead."_ — clearly separates the two tools

## Playground vs API Explorer distinction

| | Playground `/playground/` | API Explorer `/docs/api/` |
|---|---|---|
| **Purpose** | Test webhook delivery interactively | Browse API reference, run authenticated requests |
| **Account needed** | No | Yes (for live requests) |
| **What it shows** | Live events, delivery timeline | Full endpoint/schema docs |

Nav already separates them ("Playground" top-nav, "API Explorer" in docs sidebar). The new inline callout reinforces this for anyone who lands on the wrong page.

## Test plan

- [ ] Visit `/docs/api/` — Swagger UI renders with full endpoint list
- [ ] Expand an endpoint — schema and parameters display correctly  
- [ ] Check browser DevTools console — no CSP violations
- [ ] "Try it out" button works on unauthenticated endpoints (e.g. `GET /health`)
- [ ] `/playground/` still works independently — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)