### PR TITLE
feat: Hookwing CLI with dual human/agent mode (#122)

### DIFF
--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -51,6 +51,22 @@ export interface PlaygroundSession {
   createdAt: string;
 }
 
+export interface WhoAmI {
+  id: string;
+  email: string;
+  name: string;
+  workspaceId: string;
+  workspaceName: string;
+}
+
+export interface StreamEvent {
+  id: string;
+  type: string;
+  payload: Record<string, unknown>;
+  receivedAt: string;
+  headers?: Record<string, string>;
+}
+
 export class HookwingClient {
   private apiKey: string;
   private baseUrl: string;
@@ -178,5 +194,78 @@ export class HookwingClient {
 
   async deletePlaygroundSession(sessionId: string): Promise<void> {
     await this.request<void>('DELETE', `/v1/playground/sessions/${sessionId}`);
+  }
+
+  async whoami(): Promise<WhoAmI> {
+    return this.request<WhoAmI>('GET', '/v1/auth/me');
+  }
+
+  /**
+   * Connect to the Hookwing event stream via SSE.
+   * Calls onEvent for each received event; calls onError on stream errors.
+   * Returns an AbortController so the caller can stop the stream.
+   */
+  connectStream(
+    onEvent: (event: StreamEvent) => void,
+    onError: (err: Error) => void,
+  ): AbortController {
+    const controller = new AbortController();
+    const url = `${this.baseUrl}/v1/stream`;
+
+    const run = async () => {
+      try {
+        const response = await fetch(url, {
+          headers: {
+            Authorization: `Bearer ${this.apiKey}`,
+            Accept: 'text/event-stream',
+          },
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          const text = await response.text();
+          throw new Error(`Stream error (${response.status}): ${text || response.statusText}`);
+        }
+
+        if (!response.body) {
+          throw new Error('No response body from stream endpoint');
+        }
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split('\n');
+          buffer = lines.pop() ?? '';
+
+          let eventData = '';
+          for (const line of lines) {
+            if (line.startsWith('data: ')) {
+              eventData = line.slice(6).trim();
+            } else if (line === '' && eventData) {
+              try {
+                const parsed = JSON.parse(eventData) as StreamEvent;
+                onEvent(parsed);
+              } catch {
+                // skip malformed SSE data
+              }
+              eventData = '';
+            }
+          }
+        }
+      } catch (err) {
+        if ((err as Error).name !== 'AbortError') {
+          onError(err as Error);
+        }
+      }
+    };
+
+    run();
+    return controller;
   }
 }

--- a/packages/cli/src/commands/listen.ts
+++ b/packages/cli/src/commands/listen.ts
@@ -1,0 +1,144 @@
+import chalk from 'chalk';
+import type { Command } from 'commander';
+import { HookwingClient, type StreamEvent } from '../client.js';
+import { getApiKey, isAgentMode, loadConfig } from '../config.js';
+import { createSpinner, printError } from '../output.js';
+
+export function createListenCommand(program: Command, getFormat: () => 'json' | 'table'): void {
+  program
+    .command('listen')
+    .description('Forward incoming webhooks to a local URL')
+    .option('--port <port>', 'Local port to forward webhooks to', '3000')
+    .option('--path <path>', 'Local path prefix to forward to', '/')
+    .option('--agent', 'Agent/script mode: emit JSON lines, no interactive UI')
+    .action(async (options) => {
+      const config = await loadConfig();
+      const apiKey = getApiKey(config);
+
+      if (!apiKey) {
+        const agent = options.agent || isAgentMode(config);
+        printError("Not authenticated. Run 'hookwing auth login'", agent);
+        process.exit(1);
+      }
+
+      const agentMode = options.agent || isAgentMode(config) || getFormat() === 'json';
+      const port = Number.parseInt(options.port, 10);
+      const basePath = options.path === '/' ? '' : options.path;
+      const localBase = `http://localhost:${port}`;
+
+      if (!agentMode) {
+        console.log(chalk.bold('Hookwing Listen'));
+        console.log(
+          `Forwarding webhooks → ${chalk.cyan(`${localBase}${basePath || '/'}`)}`,
+        );
+        console.log(chalk.dim('Press Ctrl+C to stop\n'));
+      } else {
+        process.stdout.write(
+          JSON.stringify({ status: 'connected', forwardTo: `${localBase}${basePath || '/'}` }) + '\n',
+        );
+      }
+
+      const client = new HookwingClient(apiKey, config.baseUrl);
+
+      const handleEvent = async (event: StreamEvent) => {
+        const targetPath = `${basePath}/${event.type.replace(/\./g, '/')}`.replace(/\/+/g, '/');
+        const targetUrl = `${localBase}${targetPath}`;
+
+        if (!agentMode) {
+          const spinner = createSpinner(
+            `${chalk.cyan(event.type)} → ${targetUrl}`,
+            agentMode,
+          );
+          try {
+            const res = await fetch(targetUrl, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'X-Hookwing-Event': event.type,
+                'X-Hookwing-Event-Id': event.id,
+                ...(event.headers ?? {}),
+              },
+              body: JSON.stringify(event.payload),
+            });
+            spinner.succeed(
+              `${chalk.cyan(event.type)}  ${chalk.green(String(res.status))}  ${chalk.dim(event.id)}`,
+            );
+          } catch (err) {
+            spinner.fail(
+              `${chalk.cyan(event.type)}  ${chalk.red('connection refused')}  ${chalk.dim(event.id)}`,
+            );
+          }
+        } else {
+          // Agent mode: emit a JSON line before forwarding, then another after
+          process.stdout.write(
+            JSON.stringify({
+              event: 'received',
+              id: event.id,
+              type: event.type,
+              receivedAt: event.receivedAt,
+              forwardTo: targetUrl,
+            }) + '\n',
+          );
+
+          try {
+            const res = await fetch(targetUrl, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'X-Hookwing-Event': event.type,
+                'X-Hookwing-Event-Id': event.id,
+                ...(event.headers ?? {}),
+              },
+              body: JSON.stringify(event.payload),
+            });
+            process.stdout.write(
+              JSON.stringify({
+                event: 'forwarded',
+                id: event.id,
+                type: event.type,
+                status: res.status,
+                ok: res.ok,
+              }) + '\n',
+            );
+          } catch (err) {
+            process.stdout.write(
+              JSON.stringify({
+                event: 'forward_error',
+                id: event.id,
+                type: event.type,
+                error: (err as Error).message,
+              }) + '\n',
+            );
+          }
+        }
+      };
+
+      const controller = client.connectStream(
+        (event) => {
+          handleEvent(event).catch(() => {});
+        },
+        (err) => {
+          if (!agentMode) {
+            console.error(chalk.red(`\nStream error: ${err.message}`));
+          } else {
+            process.stderr.write(JSON.stringify({ error: err.message }) + '\n');
+          }
+          process.exit(1);
+        },
+      );
+
+      // Graceful shutdown
+      const shutdown = () => {
+        controller.abort();
+        if (!agentMode) {
+          console.log(chalk.dim('\nStopped.'));
+        } else {
+          process.stdout.write(JSON.stringify({ status: 'disconnected' }) + '\n');
+        }
+        process.exit(0);
+      };
+
+      process.on('SIGINT', shutdown);
+      process.on('SIGTERM', shutdown);
+    });
+}

--- a/packages/cli/src/commands/workspace.ts
+++ b/packages/cli/src/commands/workspace.ts
@@ -1,0 +1,45 @@
+import chalk from 'chalk';
+import type { Command } from 'commander';
+import { HookwingClient } from '../client.js';
+import { getApiKey, isAgentMode, loadConfig } from '../config.js';
+import { createSpinner, formatJson, printError } from '../output.js';
+
+export function createWorkspaceCommands(program: Command, getFormat: () => 'json' | 'table'): void {
+  program
+    .command('whoami')
+    .description('Show current authenticated user and workspace')
+    .action(async () => {
+      const config = await loadConfig();
+      const apiKey = getApiKey(config);
+      const agentMode = isAgentMode(config) || getFormat() === 'json';
+
+      if (!apiKey) {
+        printError("Not authenticated. Run 'hookwing auth login'", agentMode);
+        process.exit(1);
+      }
+
+      const client = new HookwingClient(apiKey, config.baseUrl);
+      const spinner = createSpinner('Loading user info...', agentMode);
+
+      try {
+        const user = await client.whoami();
+        spinner.stop();
+
+        if (agentMode) {
+          console.log(formatJson(user));
+        } else {
+          console.log(chalk.bold('Authenticated as'));
+          console.log(`  Name:       ${chalk.cyan(user.name)}`);
+          console.log(`  Email:      ${chalk.cyan(user.email)}`);
+          console.log(`  Workspace:  ${chalk.cyan(user.workspaceName)} ${chalk.dim(`(${user.workspaceId})`)}`);
+        }
+      } catch (err) {
+        spinner.fail('Failed to fetch user info');
+        printError((err as Error).message, agentMode);
+        process.exit(1);
+      }
+    });
+}
+
+// Re-export formatJson so listen.ts can use it cleanly
+export { formatJson } from '../output.js';

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -61,3 +61,9 @@ export function getApiKey(config: Config): string | undefined {
   }
   return config.apiKey || undefined;
 }
+
+export function isAgentMode(config: Config): boolean {
+  if (process.env.HOOKWING_AGENT === '1') return true;
+  if (process.env.HOOKWING_JSON === '1') return true;
+  return config.format === 'json';
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,9 @@ import { createDeliveriesCommands } from './commands/deliveries.js';
 import { createEndpointsCommands } from './commands/endpoints.js';
 import { createEventsCommands } from './commands/events.js';
 import { createKeysCommands } from './commands/keys.js';
+import { createListenCommand } from './commands/listen.js';
 import { createPlaygroundCommands } from './commands/playground.js';
+import { createWorkspaceCommands } from './commands/workspace.js';
 import { loadConfig } from './config.js';
 
 const program = new Command();
@@ -16,26 +18,39 @@ function getFormat(): 'json' | 'table' {
   return outputFormat;
 }
 
+// Detect agent/JSON mode from env vars early so all commands see it
+if (process.env.HOOKWING_AGENT === '1' || process.env.HOOKWING_JSON === '1') {
+  outputFormat = 'json';
+}
+
 program
   .name('hookwing')
-  .version('0.0.1')
-  .description('Hookwing CLI - Manage webhooks from the terminal')
-  .option('--json', 'Output in JSON format')
+  .version('0.1.0')
+  .description('Hookwing CLI — Manage webhooks from the terminal or scripts')
+  .option('--json', 'Output in JSON format (alias for --agent)')
+  .option('--agent', 'Agent/script mode: structured JSON output, no interactive UI')
   .hook('preAction', async () => {
     const config = await loadConfig();
-    outputFormat = config.format;
+    if (outputFormat !== 'json') {
+      outputFormat = config.format;
+    }
   });
 
-// Global --json flag
 program.on('option:json', () => {
   outputFormat = 'json';
 });
 
+program.on('option:agent', () => {
+  outputFormat = 'json';
+});
+
 createAuthCommands(program);
+createListenCommand(program, getFormat);
 createEndpointsCommands(program, getFormat);
 createEventsCommands(program, getFormat);
 createDeliveriesCommands(program, getFormat);
 createKeysCommands(program, getFormat);
 createPlaygroundCommands(program, getFormat);
+createWorkspaceCommands(program, getFormat);
 
 program.parse();

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -1,3 +1,6 @@
+import chalk from 'chalk';
+import ora from 'ora';
+
 export function formatTable(headers: string[], rows: string[][]): string {
   const columnWidths = headers.map((header, colIndex) => {
     const dataWidths = rows.map((row) => (row[colIndex] ?? '').length);
@@ -16,4 +19,24 @@ export function formatTable(headers: string[], rows: string[][]): string {
 
 export function formatJson(data: unknown): string {
   return JSON.stringify(data, null, 2);
+}
+
+export function createSpinner(text: string, agentMode: boolean) {
+  if (agentMode) {
+    return {
+      stop: () => {},
+      succeed: (_msg?: string) => {},
+      fail: (_msg?: string) => {},
+      text: '',
+    };
+  }
+  return ora(text).start();
+}
+
+export function printError(message: string, agentMode: boolean): void {
+  if (agentMode) {
+    process.stderr.write(JSON.stringify({ error: message }) + '\n');
+  } else {
+    console.error(chalk.red(`Error: ${message}`));
+  }
 }


### PR DESCRIPTION
## Summary

- Closes #122, PROD-238
- Adds `hookwing listen` — connects to Hookwing SSE stream and forwards events to `localhost:<port>`
  - **Human mode** (default): live spinner output with colored status per event
  - **Agent mode** (`--agent` / `HOOKWING_AGENT=1`): newline-delimited JSON lines, no interactive UI
- Adds `hookwing whoami` — shows authenticated user name, email, and workspace
- Adds `isAgentMode()` to config (checks `HOOKWING_AGENT=1`, `HOOKWING_JSON=1`, or stored format)
- Adds `createSpinner()` / `printError()` to output helpers (noop/JSON in agent mode)
- Extends `HookwingClient` with `whoami()` and `connectStream()` (SSE via fetch streaming)
- Adds global `--agent` flag to CLI root (alias for `--json`)

## Test plan

- [x] Typecheck passes (`tsc --noEmit`)
- [x] All 20 existing unit tests pass (`vitest run`)
- [ ] Manual: `hookwing listen --port 3000` shows live forwarding UI
- [ ] Manual: `HOOKWING_AGENT=1 hookwing listen --port 3000` emits JSON lines
- [ ] Manual: `hookwing whoami` shows user info; `hookwing whoami --agent` emits JSON
- [ ] Manual: `hookwing listen --agent` emits `{"status":"connected",...}` then per-event JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)