### PR TITLE
fix: use api.hookwing.com as placeholder in playground static HTML

### DIFF
--- a/website/playground/index.html
+++ b/website/playground/index.html
@@ -115,7 +115,7 @@
           <div class="playground-header">
             <div class="endpoint-info">
               <span class="endpoint-label">Endpoint URL:</span>
-              <span id="endpoint-url" class="endpoint-url">https://dev.api.hookwing.com/v1/ingest/...</span>
+              <span id="endpoint-url" class="endpoint-url">https://api.hookwing.com/v1/ingest/...</span>
               <button class="copy-url-btn" id="copy-url-btn" aria-label="Copy webhook URL" data-tooltip="Copy">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                   <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
@@ -176,7 +176,7 @@
 
                   <div class="curl-section">
                     <div class="curl-command">
-                      <pre id="curl-command">curl -X POST https://dev.api.hookwing.com/v1/ingest/... \
+                      <pre id="curl-command">curl -X POST https://api.hookwing.com/v1/ingest/... \
   -H "Content-Type: application/json" \
   -H "X-Event-Type: payment_intent.succeeded" \
   -d '{"id": "pi_123"}'</pre>


### PR DESCRIPTION
## What

The static HTML placeholder text in `/playground/` showed `dev.api.hookwing.com` — the development subdomain — to users before JavaScript replaced it with the correct URL.

## Why it matters

- Users who land on the page with JS loading experience a flash of `dev.api.hookwing.com` in the visible endpoint URL and curl example
- Scrapers, SEO crawlers, and no-JS environments see the wrong domain
- First impressions matter — showing a dev subdomain on a production page looks unpolished

## Change

`website/playground/index.html`:
- Line 118: `endpoint-url` span placeholder updated to `https://api.hookwing.com/v1/ingest/...`
- Line 179: `curl-command` pre placeholder updated to `https://api.hookwing.com/v1/ingest/...`

CSP header unchanged (`dev.api.hookwing.com` still whitelisted for local development).

## Testing

1. Open `/playground/` — endpoint URL and curl command should show `api.hookwing.com` immediately on load
2. JS replacement flow still works correctly (no functional change)

## Type

- [x] Bug fix (no breaking change)

---
_Auto-fix by daily UX regression check — 2026-04-04_