### PR TITLE
feat(#122): hookwing CLI — login, listen tunnel, endpoints, events, replay

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -17,20 +17,23 @@ npx @hookwing/cli
 Before using the CLI, you need to authenticate with your API key:
 
 ```bash
-# Interactive login
+# Save API key directly (recommended)
+hookwing login --api-key hk_live_...
+
+# Or interactive login
 hookwing auth login
 
 # Or set via environment variable
 export HOOKWING_API_KEY=your_api_key
-
-# Or use --api-key flag with any command
-hookwing endpoints list --api-key your_api_key
 ```
 
 ### Auth Commands
 
 ```bash
-# Check authentication status
+# Check authentication status and API health
+hookwing status
+
+# Full auth status (same as above)
 hookwing auth status
 
 # Logout (remove API key)
@@ -101,11 +104,37 @@ hookwing events get <event-id> --json
 ### Replay Event
 
 ```bash
+# Top-level shorthand
+hookwing replay <event-id>
+
+# Or via events subcommand
 hookwing events replay <event-id>
 
 # Replay multiple events
 hookwing events replay --bulk event-id-1,event-id-2,event-id-3
 ```
+
+## Listen (WebSocket Tunnel)
+
+Forward incoming webhooks to your local development server in real-time.
+
+```bash
+# Forward all events to a local URL
+hookwing listen --forward-to http://localhost:3000/webhooks
+
+# Filter to a specific endpoint
+hookwing listen --endpoint ep_abc123 --forward-to http://localhost:3000/webhooks
+
+# Legacy port+path mode (routes by event type, e.g. event.foo → /event/foo)
+hookwing listen --port 3000 --path /webhooks
+
+# Agent/script mode (JSON lines output)
+hookwing listen --forward-to http://localhost:3000/webhooks --agent
+```
+
+When `--forward-to` is used, all events are POSTed to that exact URL with headers:
+- `X-Hookwing-Event` — event type
+- `X-Hookwing-Event-Id` — event ID
 
 ## Deliveries
 

--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -204,13 +204,18 @@ export class HookwingClient {
    * Connect to the Hookwing event stream via SSE.
    * Calls onEvent for each received event; calls onError on stream errors.
    * Returns an AbortController so the caller can stop the stream.
+   * @param onEvent - callback for each received event
+   * @param onError - callback for stream errors
+   * @param endpointId - optional endpoint ID to filter events
    */
   connectStream(
     onEvent: (event: StreamEvent) => void,
     onError: (err: Error) => void,
+    endpointId?: string,
   ): AbortController {
     const controller = new AbortController();
-    const url = `${this.baseUrl}/v1/stream`;
+    const params = endpointId ? `?endpointId=${encodeURIComponent(endpointId)}` : '';
+    const url = `${this.baseUrl}/v1/stream${params}`;
 
     const run = async () => {
       try {

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -8,28 +8,34 @@ export function createAuthCommands(program: Command): void {
   auth
     .command('login')
     .description('Login with your API key')
-    .action(async () => {
+    .option('--api-key <key>', 'API key to save (skips interactive prompt)')
+    .action(async (options) => {
       const config = await loadConfig();
 
-      // Prompt for API key (using simple approach since no inquirer)
-      const readline = await import('node:readline');
-      const rl = readline.createInterface({
-        input: process.stdin,
-        output: process.stdout,
-      });
+      let apiKey: string;
+      if (options.apiKey) {
+        apiKey = options.apiKey.trim();
+      } else {
+        // Prompt for API key (using simple approach since no inquirer)
+        const readline = await import('node:readline');
+        const rl = readline.createInterface({
+          input: process.stdin,
+          output: process.stdout,
+        });
 
-      const question = (query: string): Promise<string> =>
-        new Promise((resolve) => rl.question(query, resolve));
+        const question = (query: string): Promise<string> =>
+          new Promise((resolve) => rl.question(query, resolve));
 
-      const apiKey = await question('Enter your API key: ');
-      rl.close();
+        apiKey = (await question('Enter your API key: ')).trim();
+        rl.close();
+      }
 
-      if (!apiKey.trim()) {
+      if (!apiKey) {
         console.error(chalk.red('Error: API key is required'));
         process.exit(1);
       }
 
-      config.apiKey = apiKey.trim();
+      config.apiKey = apiKey;
       await saveConfig(config);
 
       console.log(chalk.green('API key saved successfully'));

--- a/packages/cli/src/commands/listen.ts
+++ b/packages/cli/src/commands/listen.ts
@@ -8,8 +8,21 @@ export function createListenCommand(program: Command, getFormat: () => 'json' | 
   program
     .command('listen')
     .description('Forward incoming webhooks to a local URL')
-    .option('--port <port>', 'Local port to forward webhooks to', '3000')
-    .option('--path <path>', 'Local path prefix to forward to', '/')
+    .option('--endpoint <id>', 'Endpoint ID to listen on (filters stream to this endpoint)')
+    .option(
+      '--forward-to <url>',
+      'Full URL to forward webhooks to (e.g. http://localhost:3000/webhooks)',
+    )
+    .option(
+      '--port <port>',
+      'Local port to forward webhooks to (used when --forward-to is not set)',
+      '3000',
+    )
+    .option(
+      '--path <path>',
+      'Local path prefix to forward to (used when --forward-to is not set)',
+      '/',
+    )
     .option('--agent', 'Agent/script mode: emit JSON lines, no interactive UI')
     .action(async (options) => {
       const config = await loadConfig();
@@ -17,30 +30,48 @@ export function createListenCommand(program: Command, getFormat: () => 'json' | 
 
       if (!apiKey) {
         const agent = options.agent || isAgentMode(config);
-        printError("Not authenticated. Run 'hookwing auth login'", agent);
+        printError("Not authenticated. Run 'hookwing login --api-key <key>'", agent);
         process.exit(1);
       }
 
       const agentMode = options.agent || isAgentMode(config) || getFormat() === 'json';
-      const port = Number.parseInt(options.port, 10);
-      const basePath = options.path === '/' ? '' : options.path;
-      const localBase = `http://localhost:${port}`;
+
+      // Resolve the base forward URL
+      let forwardBase: string;
+      let usePathRouting: boolean;
+      if (options.forwardTo) {
+        forwardBase = options.forwardTo.replace(/\/$/, '');
+        usePathRouting = false;
+      } else {
+        const port = Number.parseInt(options.port, 10);
+        const basePath = options.path === '/' ? '' : options.path;
+        forwardBase = `http://localhost:${port}${basePath}`;
+        usePathRouting = true;
+      }
 
       if (!agentMode) {
         console.log(chalk.bold('Hookwing Listen'));
-        console.log(`Forwarding webhooks → ${chalk.cyan(`${localBase}${basePath || '/'}`)}`);
+        if (options.endpoint) {
+          console.log(`Endpoint:  ${chalk.cyan(options.endpoint)}`);
+        }
+        console.log(`Forwarding webhooks → ${chalk.cyan(forwardBase)}`);
         console.log(chalk.dim('Press Ctrl+C to stop\n'));
       } else {
         process.stdout.write(
-          `${JSON.stringify({ status: 'connected', forwardTo: `${localBase}${basePath || '/'}` })}\n`,
+          `${JSON.stringify({ status: 'connected', endpointId: options.endpoint ?? null, forwardTo: forwardBase })}\n`,
         );
       }
 
       const client = new HookwingClient(apiKey, config.baseUrl);
 
       const handleEvent = async (event: StreamEvent) => {
-        const targetPath = `${basePath}/${event.type.replace(/\./g, '/')}`.replace(/\/+/g, '/');
-        const targetUrl = `${localBase}${targetPath}`;
+        let targetUrl: string;
+        if (usePathRouting) {
+          const eventPath = `/${event.type.replace(/\./g, '/')}`.replace(/\/+/g, '/');
+          targetUrl = `${forwardBase}${eventPath}`;
+        } else {
+          targetUrl = forwardBase;
+        }
 
         if (!agentMode) {
           const spinner = createSpinner(`${chalk.cyan(event.type)} → ${targetUrl}`, agentMode);
@@ -120,6 +151,7 @@ export function createListenCommand(program: Command, getFormat: () => 'json' | 
           }
           process.exit(1);
         },
+        options.endpoint,
       );
 
       // Graceful shutdown

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
+import chalk from 'chalk';
 import { Command } from 'commander';
+import { HookwingClient } from './client.js';
 import { createAuthCommands } from './commands/auth.js';
 import { createDeliveriesCommands } from './commands/deliveries.js';
 import { createEndpointsCommands } from './commands/endpoints.js';
@@ -9,7 +11,7 @@ import { createKeysCommands } from './commands/keys.js';
 import { createListenCommand } from './commands/listen.js';
 import { createPlaygroundCommands } from './commands/playground.js';
 import { createWorkspaceCommands } from './commands/workspace.js';
-import { loadConfig } from './config.js';
+import { getApiKey, loadConfig, saveConfig } from './config.js';
 
 const program = new Command();
 let outputFormat: 'json' | 'table' = 'table';
@@ -52,5 +54,67 @@ createDeliveriesCommands(program, getFormat);
 createKeysCommands(program, getFormat);
 createPlaygroundCommands(program, getFormat);
 createWorkspaceCommands(program, getFormat);
+
+// Top-level convenience aliases
+program
+  .command('login')
+  .description('Save your API key (alias for: auth login --api-key)')
+  .requiredOption('--api-key <key>', 'API key to save')
+  .action(async (options) => {
+    const config = await loadConfig();
+    config.apiKey = options.apiKey.trim();
+    await saveConfig(config);
+    console.log(chalk.green('API key saved successfully'));
+  });
+
+program
+  .command('status')
+  .description('Quick API health check and auth status (alias for: auth status)')
+  .action(async () => {
+    const config = await loadConfig();
+    const apiKey = getApiKey(config);
+
+    if (apiKey) {
+      const masked = `${apiKey.substring(0, 7)}...${apiKey.substring(apiKey.length - 4)}`;
+      console.log(chalk.green('Authenticated'));
+      console.log(`API Key: ${chalk.cyan(masked)}`);
+    } else {
+      console.log(chalk.yellow('Not authenticated'));
+      console.log(`Run ${chalk.cyan('hookwing login --api-key <key>')} to authenticate`);
+    }
+
+    console.log(`Base URL: ${chalk.cyan(config.baseUrl)}`);
+
+    if (apiKey) {
+      try {
+        const client = new HookwingClient(apiKey, config.baseUrl);
+        await client.whoami();
+        console.log(chalk.green('API reachable'));
+      } catch {
+        console.log(chalk.red('API unreachable or key invalid'));
+      }
+    }
+  });
+
+program
+  .command('replay <event-id>')
+  .description('Replay an event (alias for: events replay)')
+  .action(async (eventId: string) => {
+    const config = await loadConfig();
+    const apiKey = getApiKey(config);
+    if (!apiKey) {
+      console.error(chalk.red("Error: Not authenticated. Run 'hookwing login --api-key <key>'"));
+      process.exit(1);
+    }
+
+    const client = new HookwingClient(apiKey, config.baseUrl);
+    try {
+      await client.replayEvent(eventId);
+      console.log(chalk.green(`Event ${eventId} replayed successfully`));
+    } catch (err) {
+      console.error(chalk.red((err as Error).message));
+      process.exit(1);
+    }
+  });
 
 program.parse();


### PR DESCRIPTION
## CLI Enhancement (#122)

New top-level commands:
- `hookwing login --api-key hk_live_...` — saves to ~/.hookwing/config.json
- `hookwing status` — health check + auth status
- `hookwing replay <event-id>` — shorthand for event replay
- `hookwing listen --endpoint ep_abc --forward-to http://localhost:3000/webhooks` — event tunnel with endpoint filter

All 20 tests pass, typecheck clean, biome clean.