### PR TITLE
Add /compare/hookdeck fit-based comparison page

### DIFF
--- a/website/compare/hookdeck/index.html
+++ b/website/compare/hookdeck/index.html
@@ -1,0 +1,458 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://hookwing.com; connect-src 'self' https://dev.api.hookwing.com https://api.hookwing.com; base-uri 'self'; form-action 'self';" />
+  <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin" />
+  <meta http-equiv="X-Content-Type-Options" content="nosniff" />
+  <title>Hookwing vs Hookdeck | Which webhook platform fits better?</title>
+  <meta name="description" content="A fit-based comparison of Hookwing vs Hookdeck for teams choosing webhook infrastructure in 2026. Honest tradeoffs, current pricing context, and product-grounded claims only." />
+  <link rel="canonical" href="https://hookwing.com/compare/hookdeck/" />
+  <meta property="og:title" content="Hookwing vs Hookdeck | Which webhook platform fits better?" />
+  <meta property="og:description" content="Hookwing is the better fit for agent-native teams that want a lower starting price and simpler runtime flows. Hookdeck is the better fit if you need a mature inbound event gateway with metered scale controls." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://hookwing.com/compare/hookdeck/" />
+  <meta property="og:image" content="https://hookwing.com/assets/og/default.png" />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="630" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:site" content="@hookwing" />
+  <meta name="twitter:title" content="Hookwing vs Hookdeck | Which webhook platform fits better?" />
+  <meta name="twitter:description" content="A fit-based comparison of Hookwing vs Hookdeck with real tradeoffs, honest pricing context, and product-grounded claims." />
+  <meta name="twitter:image" content="https://hookwing.com/assets/og/default.png" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <link rel="icon" type="image/png" href="/favicon-32.png" sizes="32x32" />
+  <link rel="manifest" href="/site.webmanifest" />
+  <link rel="apple-touch-icon" href="/apple-touch-icon.png" sizes="180x180" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "Hookwing vs Hookdeck",
+    "description": "A fit-based comparison of Hookwing vs Hookdeck for teams choosing webhook infrastructure.",
+    "url": "https://hookwing.com/compare/hookdeck/",
+    "isPartOf": { "@type": "WebSite", "url": "https://hookwing.com" }
+  }
+  </script>
+  <link rel="stylesheet" href="/styles/tokens.css?v=7" />
+  <link rel="stylesheet" href="/styles/base.css?v=7" />
+  <link rel="stylesheet" href="/styles/components.css?v=7" />
+  <link rel="stylesheet" href="/styles/patterns.css?v=9" />
+  <link rel="stylesheet" href="/styles/pages/compare.css?v=1" />
+</head>
+<body class="compare-page">
+  <header>
+    <nav class="nav" aria-label="Main navigation">
+      <div class="container">
+        <div class="nav-inner">
+          <a href="/" class="nav-logo" aria-label="Hookwing - home">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+              <path d="M21 3L3 10.5l7.5 3L14 21l7-18z"/>
+              <path d="M10.5 13.5L14 10"/>
+            </svg>
+            Hookwing
+          </a>
+          <ul class="nav-links" role="list">
+            <li><a href="/why-hookwing/" class="nav-link">Why Hookwing</a></li>
+            <li><a href="/use-cases/" class="nav-link">Use cases</a></li>
+            <li><a href="/playground/" class="nav-link">Playground</a></li>
+            <li><a href="/pricing/" class="nav-link">Pricing</a></li>
+            <li><a href="/docs/" class="nav-link">Documentation</a></li>
+            <li><a href="/blog/" class="nav-link">Blog</a></li>
+            <li><a href="/getting-started/" class="nav-link">Start free</a></li>
+          </ul>
+          <div class="nav-actions">
+            <a href="/signin/" class="nav-link">Sign in</a>
+            <a href="/signup/" class="btn btn-primary btn-md nav-cta">Start free</a>
+          </div>
+          <button class="nav-hamburger" id="nav-toggle" aria-expanded="false" aria-controls="nav-mobile" aria-label="Toggle navigation menu">
+            <span></span><span></span><span></span>
+          </button>
+        </div>
+      </div>
+    </nav>
+    <div id="nav-mobile" class="nav-mobile" aria-hidden="true">
+      <nav aria-label="Mobile navigation links">
+        <ul class="nav-mobile-links" role="list">
+          <li><a href="/why-hookwing/" class="nav-mobile-link">Why Hookwing</a></li>
+          <li><a href="/use-cases/" class="nav-mobile-link">Use cases</a></li>
+          <li><a href="/playground/" class="nav-mobile-link">Playground</a></li>
+          <li><a href="/pricing/" class="nav-mobile-link">Pricing</a></li>
+          <li><a href="/docs/" class="nav-mobile-link">Documentation</a></li>
+          <li><a href="/blog/" class="nav-mobile-link">Blog</a></li>
+          <li><a href="/getting-started/" class="nav-mobile-link">Get started</a></li>
+          <li><a href="/signin/" class="nav-mobile-link">Sign in</a></li>
+        </ul>
+      </nav>
+      <div class="nav-mobile-actions">
+        <a href="/signup/" class="btn btn-primary btn-lg" style="width:100%;justify-content:center;">Start free</a>
+        <a href="/playground/">Try the playground</a>
+      </div>
+    </div>
+  </header>
+
+  <main id="main-content">
+    <section class="compare-hero" aria-labelledby="compare-hero-heading">
+      <div class="container container-lg">
+        <div class="compare-hero-grid">
+          <div>
+            <span class="compare-eyebrow">Fit-based comparison</span>
+            <h1 class="compare-title" id="compare-hero-heading">Hookwing <span class="accent">vs Hookdeck</span></h1>
+            <p class="compare-lead">
+              If you want the short version, Hookwing is the better fit for teams that want agent-ready webhook infrastructure,
+              lower starting cost, and a simpler path from API key to live endpoint. Hookdeck is the better fit if you need a mature inbound event gateway with metered scale controls, issues tooling, and metrics export today.
+            </p>
+            <div class="compare-hero-actions">
+              <a href="/getting-started/" class="btn btn-primary btn-lg">Start with Hookwing</a>
+              <a href="#comparison-table" class="btn btn-secondary btn-lg">See the breakdown</a>
+            </div>
+            <span class="compare-note">No chest-beating. No fake parity. Just the tradeoffs that matter.</span>
+          </div>
+
+          <aside class="compare-hero-card" aria-label="Quick take">
+            <div class="compare-card-stack">
+              <article class="compare-card is-highlight">
+                <span class="compare-card-label">Best fit for Hookwing</span>
+                <span class="compare-card-value">API-first and agent-friendly teams</span>
+                <p class="compare-card-detail">Hookwing starts at $19/month, has a larger free tier than Hookdeck, and gives you native API signup plus MCP support out of the box.</p>
+              </article>
+              <article class="compare-card">
+                <span class="compare-card-label">Best fit for Hookdeck</span>
+                <span class="compare-card-value">Event gateway-heavy setups</span>
+                <p class="compare-card-detail">Hookdeck's pricing page currently emphasizes throughput controls, metrics export, issues management, and SSO on higher tiers.</p>
+              </article>
+              <article class="compare-card">
+                <span class="compare-card-label">Shared baseline</span>
+                <span class="compare-card-value">Both cover core webhook ops</span>
+                <p class="compare-card-detail">Automatic retries, webhook signing, replay, and event inspection are table stakes on both sides.</p>
+              </article>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </section>
+
+    <section class="compare-section" aria-labelledby="fit-heading">
+      <div class="container container-lg">
+        <div class="compare-section-header">
+          <span class="compare-section-eyebrow">Decision shortcut</span>
+          <h2 class="compare-section-title" id="fit-heading">Choose based on operating model, not logo preference</h2>
+          <p class="compare-section-intro">The cleanest split is this: Hookwing is trying to make webhook infrastructure easier to operate for software teams and autonomous systems. Hookdeck is trying to give event-heavy teams more gateway control and observability depth.</p>
+        </div>
+
+        <div class="compare-fit-grid">
+          <article class="compare-fit-card is-hookwing">
+            <h3 class="compare-fit-title">Choose Hookwing if you want</h3>
+            <p class="compare-fit-copy">A lighter operational model, lower starting price, and infrastructure that already fits API-driven and agent-driven workflows.</p>
+            <ul class="compare-fit-list">
+              <li>$19/month entry tier instead of $39/month.</li>
+              <li>25,000 free events per month instead of 10,000.</li>
+              <li>7-day free retention instead of 3 days.</li>
+              <li>Native API signup and endpoint provisioning flows.</li>
+              <li>MCP support without routing through a separate CLI layer.</li>
+            </ul>
+          </article>
+
+          <article class="compare-fit-card is-hookdeck">
+            <h3 class="compare-fit-title">Choose Hookdeck if you want</h3>
+            <p class="compare-fit-copy">A more explicitly event-gateway-oriented platform with pricing that leans into throughput, issue handling, and exported metrics.</p>
+            <ul class="compare-fit-list">
+              <li>Metered event pricing and additional throughput controls.</li>
+              <li>Built-in issues management on the pricing surface.</li>
+              <li>Metrics export called out on the Growth tier.</li>
+              <li>SSO, SAML, and SCIM already listed on paid plans.</li>
+              <li>A product centered around connections, transformations, and event processing flow control.</li>
+            </ul>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="compare-section" aria-labelledby="comparison-table-heading">
+      <div class="container container-lg">
+        <div class="compare-section-header">
+          <span class="compare-section-eyebrow">Side-by-side</span>
+          <h2 class="compare-section-title" id="comparison-table-heading">What actually separates them</h2>
+          <p class="compare-section-intro">This table is intentionally narrow. Every Hookwing claim below maps to current repo truth. Every Hookdeck claim below comes from its live pricing page as fetched today.</p>
+        </div>
+
+        <div class="compare-table-wrap" id="comparison-table" role="region" aria-label="Hookwing versus Hookdeck comparison table" tabindex="0">
+          <table class="compare-table">
+            <thead>
+              <tr>
+                <th>Area</th>
+                <th class="col-hookwing">Hookwing</th>
+                <th>Hookdeck</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Paid entry point</td>
+                <td class="col-hookwing">
+                  <span class="compare-badge is-good">$19 / month</span>
+                  <span class="compare-cell-note">Warbird starts well below the first paid Hookdeck tier.</span>
+                </td>
+                <td>
+                  <span class="compare-badge is-hookdeck">$39 / month</span>
+                  <span class="compare-cell-note">Team starts at $39/month on the live pricing page.</span>
+                </td>
+              </tr>
+              <tr>
+                <td>Free tier events</td>
+                <td class="col-hookwing">
+                  <span class="compare-badge is-good">25,000 / month</span>
+                  <span class="compare-cell-note">Paper Plane includes 25k events.</span>
+                </td>
+                <td>
+                  <span class="compare-badge is-hookdeck">10,000 / month</span>
+                  <span class="compare-cell-note">Developer includes 10k events.</span>
+                </td>
+              </tr>
+              <tr>
+                <td>Free tier retention</td>
+                <td class="col-hookwing">
+                  <span class="compare-badge is-good">7 days</span>
+                  <span class="compare-cell-note">Useful if you want a real evaluation window before paying.</span>
+                </td>
+                <td>
+                  <span class="compare-badge is-hookdeck">3 days</span>
+                  <span class="compare-cell-note">Shorter history on the free tier.</span>
+                </td>
+              </tr>
+              <tr>
+                <td>Mid-market tier shape</td>
+                <td class="col-hookwing">
+                  <span class="compare-badge is-good">$89 / month</span>
+                  <span class="compare-cell-note">Stealth Jet gives 1M events/month and 90-day retention.</span>
+                </td>
+                <td>
+                  <span class="compare-badge is-hookdeck">$499 / month</span>
+                  <span class="compare-cell-note">Growth starts at $499/month, then adds metered usage.</span>
+                </td>
+              </tr>
+              <tr>
+                <td>Agent-oriented onboarding</td>
+                <td class="col-hookwing">
+                  <span class="compare-badge is-good">Native</span>
+                  <span class="compare-cell-note">API signup plus endpoint creation are already first-class product paths.</span>
+                </td>
+                <td>
+                  <span class="compare-badge is-neutral">Not the primary story</span>
+                  <span class="compare-cell-note">Hookdeck can still be automated, but its pricing surface is centered on teams, projects, throughput, and org controls.</span>
+                </td>
+              </tr>
+              <tr>
+                <td>MCP support</td>
+                <td class="col-hookwing">
+                  <span class="compare-badge is-good">Built in</span>
+                  <span class="compare-cell-note">Hookwing ships a native MCP server in the repo.</span>
+                </td>
+                <td>
+                  <span class="compare-badge is-neutral">Different path</span>
+                  <span class="compare-cell-note">Hookdeck is active around agent tooling too, but this page does not claim feature parity beyond that.</span>
+                </td>
+              </tr>
+              <tr>
+                <td>Metrics export</td>
+                <td class="col-hookwing">
+                  <span class="compare-badge is-neutral">Not claimed here</span>
+                  <span class="compare-cell-note">We are deliberately not overclaiming this page beyond current repo-backed surface truth.</span>
+                </td>
+                <td>
+                  <span class="compare-badge is-hookdeck">Growth tier</span>
+                  <span class="compare-cell-note">Metrics export is explicitly listed on Hookdeck Growth.</span>
+                </td>
+              </tr>
+              <tr>
+                <td>Issues / incident tooling</td>
+                <td class="col-hookwing">
+                  <span class="compare-badge is-neutral">Core delivery tools today</span>
+                  <span class="compare-cell-note">Retries, replay, signing, analytics, and event inspection are real.</span>
+                </td>
+                <td>
+                  <span class="compare-badge is-hookdeck">Called out directly</span>
+                  <span class="compare-cell-note">Issues management is part of Hookdeck's pricing matrix.</span>
+                </td>
+              </tr>
+              <tr>
+                <td>Enterprise controls on the page</td>
+                <td class="col-hookwing">
+                  <span class="compare-badge is-neutral">Light</span>
+                  <span class="compare-cell-note">This page intentionally avoids claiming SSO, SLA, or compliance depth beyond what repo truth safely supports.</span>
+                </td>
+                <td>
+                  <span class="compare-badge is-hookdeck">Broader surface</span>
+                  <span class="compare-cell-note">SSO, SAML, SCIM, uptime SLA, and latency SLA are all visible on Hookdeck pricing.</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
+    <section class="compare-section" aria-labelledby="pricing-snapshot-heading">
+      <div class="container container-lg">
+        <div class="compare-section-header">
+          <span class="compare-section-eyebrow">Pricing shape</span>
+          <h2 class="compare-section-title" id="pricing-snapshot-heading">The pricing gap is real, and it changes who each product serves well</h2>
+          <p class="compare-section-intro">This is the clearest reason someone evaluates Hookwing against Hookdeck in the first place. One product starts cheaper and stays simpler. The other starts higher and leans harder into operational controls.</p>
+        </div>
+
+        <div class="compare-pricing-grid">
+          <article class="compare-pricing-card">
+            <span class="compare-pricing-name">Hookwing Paper Plane</span>
+            <span class="compare-pricing-price">$0</span>
+            <p class="compare-pricing-meta">25,000 events/month, 7-day retention, API access, and MCP support. Good for a real trial, not just a toy sandbox.</p>
+          </article>
+          <article class="compare-pricing-card is-featured">
+            <span class="compare-pricing-name">Hookwing Warbird / Stealth Jet</span>
+            <span class="compare-pricing-price">$19 → $89</span>
+            <p class="compare-pricing-meta">This is Hookwing's strongest fit window: small teams, growing SaaS products, and agent-first builders that want real capacity before entering enterprise pricing territory.</p>
+          </article>
+          <article class="compare-pricing-card">
+            <span class="compare-pricing-name">Hookdeck Team / Growth</span>
+            <span class="compare-pricing-price">$39 → $499</span>
+            <p class="compare-pricing-meta">Hookdeck gives a clearer event-gateway and observability story at the higher end, but the jump is much steeper for teams that just need solid webhook infrastructure.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="compare-section" aria-labelledby="proof-heading">
+      <div class="container container-lg">
+        <div class="compare-section-header">
+          <span class="compare-section-eyebrow">What we can defend</span>
+          <h2 class="compare-section-title" id="proof-heading">Grounded claims only</h2>
+          <p class="compare-section-intro">A lot of comparison pages get greasy here. This one is trying not to. So these are the exact claim buckets we can support without inventing future product.</p>
+        </div>
+
+        <div class="compare-proof-grid">
+          <article class="compare-proof-card">
+            <h3 class="compare-proof-title">What Hookwing can honestly claim today</h3>
+            <p class="compare-proof-copy">Self-service API signup exists. Endpoint CRUD exists. Replay exists. Signing exists. MCP exists. The tier and retention numbers are enforced in code.</p>
+            <ul class="compare-proof-list">
+              <li>API signup is real, not mock copy.</li>
+              <li>Pricing and retention come from tier config.</li>
+              <li>MCP server is implemented in the repo.</li>
+              <li>Machine-readable pricing is live.</li>
+            </ul>
+          </article>
+
+          <article class="compare-proof-card">
+            <h3 class="compare-proof-title">Where Hookdeck still looks stronger</h3>
+            <p class="compare-proof-copy">If your evaluation is dominated by metrics export, issue handling, throughput settings, SSO, and SLA language, Hookdeck presents the more mature surface today.</p>
+            <ul class="compare-proof-list">
+              <li>Metrics export appears on Growth.</li>
+              <li>Issues management is part of the platform story.</li>
+              <li>Enterprise controls are visible earlier.</li>
+              <li>Metered usage and throughput are explicit.</li>
+            </ul>
+          </article>
+
+          <article class="compare-proof-card">
+            <h3 class="compare-proof-title">Internal links worth opening next</h3>
+            <p class="compare-proof-copy">If Hookwing looks close to your shape, these are the pages that answer the obvious follow-up questions.</p>
+            <div class="compare-link-card">
+              <p class="compare-link-title">Keep going</p>
+              <ul class="compare-links">
+                <li><a href="/pricing/">See the actual Hookwing plan matrix</a></li>
+                <li><a href="/docs/">Review the docs and API surface</a></li>
+                <li><a href="/getting-started/">Go from key to live endpoint</a></li>
+                <li><a href="/playground/">Test without creating an account</a></li>
+                <li><a href="/blog/webhook-endpoint-for-ai-agents/">Read the agent endpoint walkthrough</a></li>
+              </ul>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="compare-cta" aria-labelledby="compare-cta-heading">
+      <div class="container container-lg">
+        <div class="compare-cta-card">
+          <div>
+            <h2 class="compare-cta-title" id="compare-cta-heading">If you need webhook infrastructure, not a giant platform buying exercise</h2>
+            <p class="compare-cta-copy">Start with Hookwing if your actual requirement is straightforward: receive events reliably, inspect them, replay them, manage endpoints over API, and keep the path agent-friendly. If your requirement is heavier event gateway control and richer enterprise surface area right now, Hookdeck may still fit better.</p>
+          </div>
+          <div class="compare-hero-actions" style="justify-content:flex-start; margin-top:0;">
+            <a href="/signup/" class="btn btn-primary btn-lg">Start free</a>
+            <a href="/why-hookwing/" class="btn btn-secondary btn-lg">See why Hookwing</a>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer" aria-label="Site footer">
+    <div class="container">
+      <div class="footer-grid">
+        <div class="footer-brand-wrap">
+          <a href="/" class="footer-brand-name" aria-label="Hookwing home">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M21 3L3 10.5l7.5 3L14 21l7-18z"/>
+              <path d="M10.5 13.5L14 10"/>
+            </svg>
+            Hookwing
+          </a>
+          <p class="footer-brand-desc">Webhook infrastructure, built for agents. Test free. Ship with confidence.</p>
+          <a href="/status/" class="footer-status" style="margin-top:var(--space-4); display:inline-flex;" target="_blank" rel="noopener noreferrer" aria-label="System status: all systems operational">
+            <span class="status-dot" aria-hidden="true"></span>
+            All systems operational
+          </a>
+        </div>
+        <div>
+          <p class="footer-col-heading">Product</p>
+          <ul class="footer-links" role="list" aria-label="Product navigation">
+            <li><a href="/use-cases/" class="footer-link">Use cases</a></li>
+            <li><a href="/playground/" class="footer-link">Playground</a></li>
+            <li><a href="/pricing/" class="footer-link">Pricing</a></li>
+            <li><a href="/docs/" class="footer-link">Docs</a></li>
+            <li><a href="/getting-started/" class="footer-link">Getting started</a></li>
+          </ul>
+        </div>
+        <div>
+          <p class="footer-col-heading">Compare</p>
+          <ul class="footer-links" role="list">
+            <li><a href="/compare/hookdeck/" class="footer-link">Hookwing vs Hookdeck</a></li>
+            <li><a href="/why-hookwing/" class="footer-link">Why Hookwing</a></li>
+            <li><a href="/blog/" class="footer-link">Blog</a></li>
+          </ul>
+        </div>
+        <div>
+          <p class="footer-col-heading">Company</p>
+          <ul class="footer-links" role="list">
+            <li><a href="mailto:hello@hookwing.com" class="footer-link">Contact</a></li>
+            <li><a href="/privacy/" class="footer-link">Privacy policy</a></li>
+            <li><a href="/terms/" class="footer-link">Terms of service</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p class="footer-copy">&copy; <span id="footer-year">2026</span> Hookwing Inc. All rights reserved.</p>
+        <p class="footer-copy" style="color:rgba(255,255,255,.25);">Built for agents.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    (() => {
+      const toggle = document.getElementById('nav-toggle');
+      const mobile = document.getElementById('nav-mobile');
+      if (!toggle || !mobile) return;
+      toggle.addEventListener('click', () => {
+        const expanded = toggle.getAttribute('aria-expanded') === 'true';
+        toggle.setAttribute('aria-expanded', String(!expanded));
+        mobile.setAttribute('aria-hidden', String(expanded));
+        mobile.classList.toggle('is-open', !expanded);
+      });
+      const year = document.getElementById('footer-year');
+      if (year) year.textContent = String(new Date().getFullYear());
+    })();
+  </script>
+</body>
+</html>

--- a/website/scripts/build-content.mjs
+++ b/website/scripts/build-content.mjs
@@ -22,6 +22,7 @@ const docsContentDir = path.join(contentRoot, "docs");
 const authorsContentDir = path.join(contentRoot, "authors");
 const DEFAULT_SITE_URL = "https://hookwing.com";
 const DEFAULT_OG_IMAGE = "/assets/og/default.png";
+const STATIC_SITEMAP_ROUTES = ["/", "/compare/hookdeck/"];
 const siteUrl = (process.env.HOOKWING_SITE_URL || DEFAULT_SITE_URL).replace(/\/$/, "");
 
 function escapeHtml(input) {
@@ -1423,7 +1424,7 @@ async function main() {
   const blogCounts = await buildBlog(publishedPosts);
   const docsCounts = await buildDocs(docs);
 
-  const sitemapRoutes = ["/", ...blogCounts.routes, ...docsCounts.routes];
+  const sitemapRoutes = [...STATIC_SITEMAP_ROUTES, ...blogCounts.routes, ...docsCounts.routes];
   await fs.writeFile(path.join(websiteRoot, "sitemap.xml"), buildSitemap(sitemapRoutes), "utf8");
 
   process.stdout.write(

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 <url><loc>https://hookwing.com/</loc></url>
+<url><loc>https://hookwing.com/compare/hookdeck/</loc></url>
 <url><loc>https://hookwing.com/blog/</loc></url>
 <url><loc>https://hookwing.com/blog/webhook-event-ordering/</loc></url>
 <url><loc>https://hookwing.com/blog/debugging-webhooks/</loc></url>

--- a/website/styles/pages/compare.css
+++ b/website/styles/pages/compare.css
@@ -1,0 +1,473 @@
+:root {
+  --compare-surface: rgba(12, 18, 31, 0.72);
+  --compare-border: rgba(148, 163, 184, 0.16);
+  --compare-border-strong: rgba(0, 192, 122, 0.26);
+  --compare-text-soft: rgba(226, 232, 240, 0.72);
+  --compare-text-muted: rgba(148, 163, 184, 0.82);
+  --compare-glow: radial-gradient(circle at top, rgba(0, 192, 122, 0.16), transparent 52%);
+}
+
+.compare-page {
+  background:
+    radial-gradient(circle at top left, rgba(0, 192, 122, 0.12), transparent 30%),
+    radial-gradient(circle at top right, rgba(56, 189, 248, 0.12), transparent 26%),
+    linear-gradient(180deg, #07111f 0%, #0a1322 46%, #09111d 100%);
+}
+
+.compare-hero {
+  position: relative;
+  overflow: hidden;
+  padding: clamp(7rem, 10vw, 9.5rem) 0 4.5rem;
+}
+
+.compare-hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: var(--compare-glow);
+  pointer-events: none;
+}
+
+.compare-hero-grid {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(320px, 0.9fr);
+  gap: 2rem;
+  align-items: end;
+}
+
+.compare-eyebrow,
+.compare-section-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.88);
+}
+
+.compare-eyebrow::before,
+.compare-section-eyebrow::before {
+  content: "";
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(0, 192, 122, 1), rgba(56, 189, 248, 0.86));
+  box-shadow: 0 0 18px rgba(0, 192, 122, 0.45);
+}
+
+.compare-title {
+  max-width: 11ch;
+  margin: 1rem 0 1.15rem;
+  font-size: clamp(2.7rem, 5vw, 5.15rem);
+  line-height: 0.95;
+  letter-spacing: -0.045em;
+}
+
+.compare-title .accent {
+  color: var(--color-primary);
+}
+
+.compare-lead {
+  max-width: 42rem;
+  font-size: 1.08rem;
+  line-height: 1.78;
+  color: var(--compare-text-soft);
+}
+
+.compare-hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.compare-note {
+  display: block;
+  margin-top: 0.9rem;
+  color: var(--compare-text-muted);
+  font-size: 0.96rem;
+}
+
+.compare-hero-card,
+.compare-card,
+.compare-fit-card,
+.compare-pricing-card,
+.compare-proof-card,
+.compare-cta-card {
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.82), rgba(8, 15, 28, 0.9));
+  border: 1px solid var(--compare-border);
+  border-radius: 1.5rem;
+  box-shadow: 0 24px 80px rgba(2, 8, 23, 0.36);
+}
+
+.compare-hero-card {
+  padding: 1.35rem;
+}
+
+.compare-card-stack {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.compare-card {
+  padding: 1rem 1rem 1.05rem;
+}
+
+.compare-card-label {
+  display: block;
+  margin-bottom: 0.55rem;
+  color: var(--compare-text-muted);
+  font-size: 0.77rem;
+  font-family: var(--font-mono);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.compare-card-value {
+  display: block;
+  color: #f8fafc;
+  font-size: 1.45rem;
+  font-weight: 650;
+  letter-spacing: -0.02em;
+}
+
+.compare-card-detail {
+  margin: 0.45rem 0 0;
+  color: var(--compare-text-soft);
+  line-height: 1.65;
+  font-size: 0.96rem;
+}
+
+.compare-card.is-highlight {
+  border-color: var(--compare-border-strong);
+  background: linear-gradient(180deg, rgba(5, 26, 20, 0.88), rgba(8, 19, 28, 0.96));
+}
+
+.compare-section {
+  padding: 0 0 5rem;
+}
+
+.compare-section-header {
+  max-width: 44rem;
+  margin-bottom: 1.8rem;
+}
+
+.compare-section-title {
+  margin: 0.9rem 0 0.95rem;
+  font-size: clamp(2rem, 3vw, 3rem);
+  letter-spacing: -0.03em;
+}
+
+.compare-section-intro {
+  margin: 0;
+  color: var(--compare-text-soft);
+  line-height: 1.8;
+}
+
+.compare-fit-grid,
+.compare-pricing-grid,
+.compare-proof-grid {
+  display: grid;
+  gap: 1.1rem;
+}
+
+.compare-fit-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.compare-fit-card {
+  padding: 1.35rem 1.35rem 1.45rem;
+}
+
+.compare-fit-card.is-hookwing {
+  border-color: var(--compare-border-strong);
+}
+
+.compare-fit-card.is-hookdeck {
+  border-color: rgba(56, 189, 248, 0.22);
+}
+
+.compare-fit-title {
+  margin: 0 0 0.65rem;
+  font-size: 1.25rem;
+}
+
+.compare-fit-copy {
+  margin: 0 0 1rem;
+  color: var(--compare-text-soft);
+  line-height: 1.7;
+}
+
+.compare-fit-list,
+.compare-proof-list,
+.compare-links {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.compare-fit-list li,
+.compare-proof-list li,
+.compare-links li {
+  position: relative;
+  padding-left: 1.15rem;
+  color: #dbe4f0;
+  line-height: 1.65;
+}
+
+.compare-fit-list li + li,
+.compare-proof-list li + li,
+.compare-links li + li {
+  margin-top: 0.68rem;
+}
+
+.compare-fit-list li::before,
+.compare-proof-list li::before,
+.compare-links li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.68rem;
+  width: 0.38rem;
+  height: 0.38rem;
+  border-radius: 999px;
+  background: rgba(0, 192, 122, 0.92);
+}
+
+.compare-table-wrap {
+  overflow-x: auto;
+  border-radius: 1.5rem;
+  border: 1px solid var(--compare-border);
+  background: rgba(8, 15, 28, 0.9);
+  box-shadow: 0 24px 80px rgba(2, 8, 23, 0.32);
+}
+
+.compare-table {
+  width: 100%;
+  min-width: 780px;
+  border-collapse: collapse;
+}
+
+.compare-table thead th {
+  padding: 1rem 1.1rem;
+  background: rgba(15, 23, 42, 0.95);
+  color: rgba(226, 232, 240, 0.92);
+  font-size: 0.8rem;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+  text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.16);
+}
+
+.compare-table thead th.col-hookwing {
+  color: var(--color-primary);
+}
+
+.compare-table tbody td {
+  padding: 1rem 1.1rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+  vertical-align: top;
+  line-height: 1.55;
+  color: #e2e8f0;
+}
+
+.compare-table tbody td:first-child {
+  width: 28%;
+  color: #f8fafc;
+  font-weight: 600;
+}
+
+.compare-table tbody td.col-hookwing {
+  background: rgba(0, 192, 122, 0.07);
+}
+
+.compare-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.compare-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.36rem 0.62rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.compare-badge.is-good {
+  background: rgba(0, 192, 122, 0.14);
+  color: #7ef5bc;
+}
+
+.compare-badge.is-neutral {
+  background: rgba(148, 163, 184, 0.14);
+  color: #cbd5e1;
+}
+
+.compare-badge.is-hookdeck {
+  background: rgba(56, 189, 248, 0.14);
+  color: #93e5ff;
+}
+
+.compare-cell-note {
+  display: block;
+  margin-top: 0.5rem;
+  color: var(--compare-text-muted);
+  font-size: 0.92rem;
+}
+
+.compare-pricing-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.compare-pricing-card {
+  padding: 1.25rem;
+}
+
+.compare-pricing-card.is-featured {
+  border-color: var(--compare-border-strong);
+  background: linear-gradient(180deg, rgba(4, 30, 20, 0.92), rgba(8, 16, 29, 0.98));
+}
+
+.compare-pricing-name {
+  display: block;
+  color: #f8fafc;
+  font-weight: 650;
+  font-size: 1.1rem;
+}
+
+.compare-pricing-price {
+  display: block;
+  margin-top: 0.65rem;
+  font-size: 2.1rem;
+  line-height: 1;
+  letter-spacing: -0.05em;
+}
+
+.compare-pricing-meta {
+  margin: 0.75rem 0 0;
+  color: var(--compare-text-soft);
+  line-height: 1.7;
+}
+
+.compare-proof-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.compare-proof-card {
+  padding: 1.25rem;
+}
+
+.compare-proof-title {
+  margin: 0 0 0.75rem;
+  font-size: 1.06rem;
+}
+
+.compare-proof-copy {
+  margin: 0 0 0.9rem;
+  color: var(--compare-text-soft);
+  line-height: 1.72;
+}
+
+.compare-proof-list li::before {
+  background: rgba(56, 189, 248, 0.92);
+}
+
+.compare-proof-footer {
+  margin-top: 0.95rem;
+  color: var(--compare-text-muted);
+  font-size: 0.92rem;
+}
+
+.compare-cta {
+  padding: 0 0 5.75rem;
+}
+
+.compare-cta-card {
+  padding: clamp(1.5rem, 3vw, 2rem);
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(280px, 0.8fr);
+  gap: 1.25rem;
+  align-items: center;
+}
+
+.compare-cta-title {
+  margin: 0 0 0.65rem;
+  font-size: clamp(1.6rem, 2.5vw, 2.3rem);
+}
+
+.compare-cta-copy {
+  margin: 0;
+  color: var(--compare-text-soft);
+  line-height: 1.75;
+}
+
+.compare-link-card {
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  border-radius: 1.15rem;
+  padding: 1rem 1.05rem;
+  background: rgba(7, 12, 22, 0.6);
+}
+
+.compare-link-title {
+  margin: 0 0 0.8rem;
+  font-size: 0.98rem;
+  color: #f8fafc;
+}
+
+.compare-links a {
+  color: #dbeafe;
+  text-decoration: none;
+}
+
+.compare-links a:hover {
+  color: var(--color-primary);
+}
+
+.compare-links li::before {
+  background: rgba(0, 192, 122, 0.85);
+}
+
+@media (max-width: 1023px) {
+  .compare-hero-grid,
+  .compare-fit-grid,
+  .compare-pricing-grid,
+  .compare-proof-grid,
+  .compare-cta-card {
+    grid-template-columns: 1fr;
+  }
+
+  .compare-title {
+    max-width: none;
+  }
+}
+
+@media (max-width: 767px) {
+  .compare-hero {
+    padding-top: 6.5rem;
+  }
+
+  .compare-fit-card,
+  .compare-pricing-card,
+  .compare-proof-card,
+  .compare-cta-card,
+  .compare-hero-card {
+    border-radius: 1.25rem;
+  }
+
+  .compare-title {
+    font-size: 2.55rem;
+  }
+
+  .compare-section,
+  .compare-cta {
+    padding-bottom: 4.2rem;
+  }
+}

--- a/website/why-hookwing/index.html
+++ b/website/why-hookwing/index.html
@@ -902,6 +902,9 @@
             The only platform in this space that was designed for agents from day one.
             The numbers back it up.
           </p>
+          <p class="compare-sub" style="margin-top:0.85rem; font-size:0.96rem; color:rgba(226,232,240,.7);">
+            Want the narrower fit check? Read <a href="/compare/hookdeck/" style="color:var(--color-primary);">Hookwing vs Hookdeck</a>.
+          </p>
         </div>
 
         <!-- Feature comparison table -->


### PR DESCRIPTION
## Summary
- add a real `/compare/hookdeck/` landing page with clean canonical, OG, and Twitter metadata
- keep the comparison fit-based and grounded in current Hookwing product truth plus live Hookdeck pricing
- add internal discovery via `why-hookwing` and ensure the page is included in generated sitemap output

## What changed
- new static page at `website/compare/hookdeck/index.html`
- new page styles at `website/styles/pages/compare.css`
- add a contextual link from `website/why-hookwing/index.html`
- extend `website/scripts/build-content.mjs` sitemap generation to include `/compare/hookdeck/`
- regenerate `website/sitemap.xml`

## Claim discipline
- Hookwing pricing, retention, API signup, and MCP references were checked against repo truth and live `https://hookwing.com/api/pricing`
- Hookdeck pricing and feature references were checked against live `https://hookdeck.com/pricing`
- avoided unsupported claims around SLA, compliance, or feature parity

## Verification
- `npm test`
