### PR TITLE
fix: harden prod endpoint creation and auth smoke contract

### DIFF
--- a/packages/api/src/__tests__/auth-login.test.ts
+++ b/packages/api/src/__tests__/auth-login.test.ts
@@ -54,6 +54,19 @@ describe('GET /v1/auth/me', () => {
     expect(res.status).toBe(401);
   });
 
+  it('should require Authorization Bearer instead of x-api-key', async () => {
+    const app = new Hono().route('/v1/auth', authRoutes);
+    const res = await app.request('/v1/auth/me', {
+      headers: {
+        'x-api-key': 'hk_live_testkey1234567890abcdef',
+      },
+    });
+
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.message).toBe('Missing Authorization header');
+  });
+
   it('should return 401 with invalid API key format', async () => {
     const app = new Hono().route('/v1/auth', authRoutes);
     const res = await app.request('/v1/auth/me', {

--- a/packages/api/src/__tests__/endpoint-create-regression.test.ts
+++ b/packages/api/src/__tests__/endpoint-create-regression.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { buildEndpointInsertValues } from '../routes/endpoints';
+
+describe('buildEndpointInsertValues', () => {
+  it('omits optional endpoint columns when they are not provided', () => {
+    const values = buildEndpointInsertValues({
+      endpointId: 'ep_test_123',
+      workspaceId: 'ws_test_123',
+      url: 'https://example.com/webhook',
+      signingSecret: 'whsec_test_123',
+      now: 1234567890,
+    });
+
+    expect(values).toEqual({
+      id: 'ep_test_123',
+      workspaceId: 'ws_test_123',
+      url: 'https://example.com/webhook',
+      description: null,
+      secret: 'whsec_test_123',
+      isActive: 1,
+      createdAt: 1234567890,
+      updatedAt: 1234567890,
+    });
+
+    expect(values).not.toHaveProperty('fanoutEnabled');
+    expect(values).not.toHaveProperty('eventTypes');
+    expect(values).not.toHaveProperty('metadata');
+    expect(values).not.toHaveProperty('customHeaders');
+    expect(values).not.toHaveProperty('ipWhitelist');
+  });
+
+  it('includes optional columns only when explicitly used', () => {
+    const values = buildEndpointInsertValues({
+      endpointId: 'ep_test_123',
+      workspaceId: 'ws_test_123',
+      url: 'https://example.com/webhook',
+      description: 'Primary endpoint',
+      signingSecret: 'whsec_test_123',
+      eventTypes: ['invoice.paid'],
+      fanoutEnabled: false,
+      metadata: { env: 'prod' },
+      customHeaders: { 'X-Test': '1' },
+      ipWhitelist: ['203.0.113.10'],
+      now: 1234567890,
+    });
+
+    expect(values).toMatchObject({
+      id: 'ep_test_123',
+      workspaceId: 'ws_test_123',
+      url: 'https://example.com/webhook',
+      description: 'Primary endpoint',
+      secret: 'whsec_test_123',
+      isActive: 1,
+      fanoutEnabled: 0,
+      createdAt: 1234567890,
+      updatedAt: 1234567890,
+    });
+    expect(values.eventTypes).toBe('["invoice.paid"]');
+    expect(values.metadata).toBe('{"env":"prod"}');
+    expect(values.customHeaders).toBe('{"X-Test":"1"}');
+    expect(values.ipWhitelist).toBe('["203.0.113.10"]');
+  });
+});

--- a/packages/api/src/routes/endpoints.ts
+++ b/packages/api/src/routes/endpoints.ts
@@ -115,6 +115,55 @@ endpointRoutes.use(
   }),
 );
 
+type EndpointInsertValues = typeof endpoints.$inferInsert;
+
+export function buildEndpointInsertValues(input: {
+  endpointId: string;
+  workspaceId: string;
+  url: string;
+  description?: string | undefined;
+  signingSecret: string;
+  eventTypes?: string[] | undefined;
+  fanoutEnabled?: boolean | undefined;
+  metadata?: Record<string, string> | undefined;
+  customHeaders?: Record<string, string> | undefined;
+  ipWhitelist?: string[] | undefined;
+  now: number;
+}): EndpointInsertValues {
+  const values: EndpointInsertValues = {
+    id: input.endpointId,
+    workspaceId: input.workspaceId,
+    url: input.url,
+    description: input.description ?? null,
+    secret: input.signingSecret,
+    isActive: 1,
+    createdAt: input.now,
+    updatedAt: input.now,
+  };
+
+  if (input.eventTypes && input.eventTypes.length > 0) {
+    values.eventTypes = JSON.stringify(input.eventTypes);
+  }
+
+  if (input.fanoutEnabled === false) {
+    values.fanoutEnabled = 0;
+  }
+
+  if (input.metadata && Object.keys(input.metadata).length > 0) {
+    values.metadata = JSON.stringify(input.metadata);
+  }
+
+  if (input.customHeaders && Object.keys(input.customHeaders).length > 0) {
+    values.customHeaders = JSON.stringify(input.customHeaders);
+  }
+
+  if (input.ipWhitelist && input.ipWhitelist.length > 0) {
+    values.ipWhitelist = JSON.stringify(input.ipWhitelist);
+  }
+
+  return values;
+}
+
 // ============================================================================
 // POST /v1/endpoints — Create endpoint
 // ============================================================================
@@ -152,7 +201,8 @@ endpointRoutes.post('/', requireApiKeyScopes(['endpoints:write']), async (c) => 
     }
   }
 
-  const { url, description, eventTypes, fanoutEnabled, metadata, customHeaders } = parsed.data;
+  const { url, description, eventTypes, fanoutEnabled, metadata, customHeaders, ipWhitelist } =
+    parsed.data;
 
   // Tier-gate custom headers
   if (customHeaders && Object.keys(customHeaders).length > 0) {
@@ -184,21 +234,21 @@ endpointRoutes.post('/', requireApiKeyScopes(['endpoints:write']), async (c) => 
 
   const endpointId = generateId('ep');
 
-  await db.insert(endpoints).values({
-    id: endpointId,
-    workspaceId: workspace.id,
-    url,
-    description: description ?? null,
-    secret: signingSecret,
-    eventTypes: eventTypes ? JSON.stringify(eventTypes) : null,
-    isActive: 1,
-    fanoutEnabled: fanoutEnabled !== false ? 1 : 0,
-    rateLimitPerSecond: null,
-    metadata: metadata ? JSON.stringify(metadata) : null,
-    customHeaders: customHeaders ? JSON.stringify(customHeaders) : null,
-    createdAt: now,
-    updatedAt: now,
-  });
+  await db.insert(endpoints).values(
+    buildEndpointInsertValues({
+      endpointId,
+      workspaceId: workspace.id,
+      url,
+      description,
+      signingSecret,
+      eventTypes,
+      fanoutEnabled,
+      metadata,
+      customHeaders,
+      ipWhitelist,
+      now,
+    }),
+  );
 
   return c.json(
     {
@@ -213,6 +263,7 @@ endpointRoutes.post('/', requireApiKeyScopes(['endpoints:write']), async (c) => 
       rateLimitPerSecond: null,
       metadata: metadata ?? null,
       customHeaders: customHeaders ?? null,
+      ipWhitelist: ipWhitelist ?? null,
       createdAt: now,
       updatedAt: now,
     },


### PR DESCRIPTION
## Summary
- harden `POST /v1/endpoints` inserts so optional columns are only written when actually used
- codify that `/v1/auth/me` requires `Authorization: Bearer <key>` rather than `x-api-key`
- add regression coverage for bearer-auth contract and endpoint creation payloads

## Root cause
`POST /v1/endpoints` was unconditionally writing optional endpoint columns (`fanout_enabled`, `metadata`, `custom_headers`, and related fields) even when the request did not use them. That makes endpoint creation fragile against production schema drift, and it matches the observed prod-only failure pattern where auth succeeds but endpoint creation 500s.

## Testing
- npm test -- --run src/__tests__/auth-login.test.ts src/__tests__/endpoint-create-regression.test.ts
- npm test -- --run src/__tests__/endpoints.test.ts src/__tests__/error-response-shape.test.ts
- npm run typecheck

## Notes
- I did not touch the deploy workflow indent bug here. That remains the immediate next tiny follow-up PR.