### PR TITLE
fix(playground): remove dev.api.hookwing.com regression (3rd occurrence)

### DIFF
--- a/website/playground/index.html
+++ b/website/playground/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self' https://dev.api.hookwing.com https://api.hookwing.com https://api.hookwing.com; base-uri 'self'; form-action 'self';" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self' https://api.hookwing.com; base-uri 'self'; form-action 'self';" />
   <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <title>Playground — Hookwing</title>
@@ -115,7 +115,7 @@
           <div class="playground-header">
             <div class="endpoint-info">
               <span class="endpoint-label">Endpoint URL:</span>
-              <span id="endpoint-url" class="endpoint-url">https://dev.api.hookwing.com/v1/ingest/...</span>
+              <span id="endpoint-url" class="endpoint-url">https://api.hookwing.com/v1/ingest/...</span>
               <button class="copy-url-btn" id="copy-url-btn" aria-label="Copy webhook URL">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                   <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
@@ -176,7 +176,7 @@
 
                   <div class="curl-section">
                     <div class="curl-command">
-                      <pre id="curl-command">curl -X POST https://dev.api.hookwing.com/v1/ingest/... \
+                      <pre id="curl-command">curl -X POST https://api.hookwing.com/v1/ingest/... \
   -H "Content-Type: application/json" \
   -H "X-Event-Type: payment_intent.succeeded" \
   -d '{"id": "pi_123"}'</pre>


### PR DESCRIPTION
## Summary

- Removes `dev.api.hookwing.com` from playground static HTML — third occurrence of this regression
- Endpoint URL placeholder (line 118): `dev.api.hookwing.com` → `api.hookwing.com`
- curl example placeholder (line 179): `dev.api.hookwing.com` → `api.hookwing.com`
- CSP `connect-src` (line 6): removed `dev.api.hookwing.com` and deduplicated `api.hookwing.com`

## Root cause

This regression has now appeared three times (PR #192, 2026-04-12 session, now today 2026-04-14). The static HTML placeholder is being reset on merges from `dev` into `main`. Likely caused by a playground template/scaffold that still holds the dev domain — recommend searching for the source template.

## Test plan

- [ ] Fetch `https://hookwing.com/playground/` and verify no `dev.api.hookwing.com` in source HTML
- [ ] Confirm endpoint URL placeholder shows `api.hookwing.com/v1/ingest/...`
- [ ] Confirm curl example shows `api.hookwing.com/v1/ingest/...`
- [ ] CSP header: only `api.hookwing.com` in `connect-src`, no duplicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)