### PR TITLE
fix: changelog redirect + terms governing law placeholders

### DIFF
--- a/website/_redirects
+++ b/website/_redirects
@@ -2,3 +2,5 @@
 /api/pricing/   /api/pricing/index.json  200
 /app/*  https://dev.app.hookwing.com/:splat  301
 /app    https://dev.app.hookwing.com/        301
+/changelog      /blog/                        301
+/changelog/     /blog/                        301

--- a/website/terms/index.html
+++ b/website/terms/index.html
@@ -273,7 +273,7 @@
         <section>
           <h2>12. Governing Law and Dispute Resolution</h2>
           <h3>12.1 Governing Law</h3>
-          <p>These Terms shall be governed by and construed in accordance with the laws of <mark>[JURISDICTION]</mark>, specifically the laws of <mark>[GOVERNING_LAW]</mark>, without regard to conflict of law principles.</p>
+          <p>These Terms shall be governed by and construed in accordance with the laws of <mark>British Columbia, Canada</mark>, specifically the laws of <mark>the Province of British Columbia and the federal laws of Canada applicable therein</mark>, without regard to conflict of law principles.</p>
           <h3>12.2 Dispute Resolution</h3>
           <p>Any dispute, claim, or controversy arising out of or relating to these Terms, or the breach, termination, or validity thereof, shall be resolved as follows:</p>
           <p><strong>Negotiation:</strong> The parties shall first attempt to resolve any dispute through good-faith negotiation for a period of 30 days.</p>


### PR DESCRIPTION
## Summary

- `/changelog/` redirect to `/blog/` has regressed again (3rd time) — re-added both `/changelog` and `/changelog/` → `/blog/` 301 rules to `_redirects`
- `website/terms/index.html` Section 12.1 had two live placeholder brackets (`[JURISDICTION]`, `[GOVERNING_LAW]`) visible to users; filled with British Columbia, Canada governing law (consistent with Section 12.2 arbitration clause)

## Root Cause Note

The `/changelog/` redirect regression appears to be caused by commits that touch `_redirects` without carrying forward the changelog rule. Worth adding a CI check that asserts `/changelog/` returns a 3xx.

## Test plan
- [ ] Verify `https://hookwing.com/changelog/` redirects to `/blog/` after deploy
- [ ] Verify Section 12.1 of `/terms/` no longer shows bracket placeholders
- [ ] Confirm governing law wording is legally acceptable (BC, Canada — matches arbitration clause in 12.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)