### PR TITLE
fix: add /docs/mcp/ redirect to agent-integrations

### DIFF
--- a/website/_redirects
+++ b/website/_redirects
@@ -4,3 +4,5 @@
 /app    https://dev.app.hookwing.com/        301
 /changelog      /blog/                        301
 /changelog/     /blog/                        301
+/docs/mcp       /docs/agent-integrations/     301
+/docs/mcp/      /docs/agent-integrations/     301


### PR DESCRIPTION
## Summary
- `/docs/mcp/` had no page and was falling through to homepage content (same pattern as the `/changelog/` regression)
- Link originates from `/agent-experience/` Principle 5 (MCP-native section): `Read more: MCP integration docs`
- `/docs/agent-integrations/` already covers MCP comprehensively (MCP server, tools, self-provisioning)
- Added 301 redirects for both `/docs/mcp` and `/docs/mcp/` to `/docs/agent-integrations/`

## Root cause
No `docs/mcp/index.html` or `content/docs/mcp.md` exists. Route falls through to SPA default → homepage.

## Test plan
- [ ] Verify `https://hookwing.com/docs/mcp/` redirects to `https://hookwing.com/docs/agent-integrations/`
- [ ] Verify `https://hookwing.com/docs/mcp` (no trailing slash) also redirects
- [ ] Confirm `/agent-experience/` MCP link now resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)