### PR TITLE
fix(website): correct dev API URL in docs OpenAPI button + dedupe CSP

### DIFF
--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -142,7 +142,7 @@
           </p>
 
           <div style="display: flex; gap: var(--space-3); margin-bottom: var(--space-8); flex-wrap: wrap;">
-            <a href="https://dev.api.hookwing.com/openapi.json" class="btn btn-secondary btn-sm" target="_blank" rel="noopener">
+            <a href="https://api.hookwing.com/openapi.json" class="btn btn-secondary btn-sm" target="_blank" rel="noopener">
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
               OpenAPI Spec (JSON)
             </a>

--- a/website/src/partials/head.html
+++ b/website/src/partials/head.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <!-- Security meta tags -->
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://hookwing.com; connect-src 'self' https://dev.api.hookwing.com https://api.hookwing.com https://dev.api.hookwing.com; base-uri 'self'; form-action 'self';" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://hookwing.com; connect-src 'self' https://dev.api.hookwing.com https://api.hookwing.com; base-uri 'self'; form-action 'self';" />
   <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <title>{{TITLE}} | Hookwing</title>


### PR DESCRIPTION
## Summary

- **docs/index.html**: \"OpenAPI Spec (JSON)\" button linked to `https://dev.api.hookwing.com/openapi.json` instead of `https://api.hookwing.com/openapi.json` — 4th recurrence of this regression (playground history: PR #192, #206, now docs)
- **src/partials/head.html**: `https://dev.api.hookwing.com` was listed twice in the CSP `connect-src` directive (duplicate entry)

## Root cause note

The dev API URL regression has now appeared in: playground (3×), docs (1×). Recommend a CI grep check: `grep -r 'dev.api.hookwing.com' website --include='*.html'` to catch this on every PR. Tracked in ux-check-state.json notes.

## Test plan
- [ ] Verify docs page OpenAPI button resolves to `https://api.hookwing.com/openapi.json`
- [ ] Confirm no `dev.api.hookwing.com` appears as a clickable href anywhere in website/

🤖 UX regression check — Dex / 2026-04-20