### PR TITLE
fix: docs webhook encoding bug + stale billing tier limits

### DIFF
--- a/website/docs/billing/index.html
+++ b/website/docs/billing/index.html
@@ -120,11 +120,11 @@
 </aside>
       <article style="min-width:0;">
         <h1>Billing &amp; Tiers</h1>
-        <div class="meta"><span>Updated 2026-04-03</span></div>
+        <div class="meta"><span>Updated 2026-04-21</span></div>
         <p class="lede">Manage your subscription, upgrade or downgrade tiers, and query pricing programmatically.</p>
         <h2 id="tiers">Tiers</h2>
 <p>Hookwing offers three tiers:</p>
-<table><thead><tr><th>Feature</th><th>Paper Plane (Free)</th><th>Warbird ($19/mo)</th><th>Stealth Jet ($89/mo)</th></tr></thead><tbody><tr><td>Events/month</td><td>10,000</td><td>500,000</td><td>Unlimited</td></tr><tr><td>Endpoints</td><td>3</td><td>10</td><td>Unlimited</td></tr><tr><td>Payload size</td><td>64 KB</td><td>64 KB</td><td>256 KB</td></tr><tr><td>Rate limit</td><td>10 req/s</td><td>50 req/s</td><td>100 req/s</td></tr><tr><td>Retention</td><td>7 days</td><td>30 days</td><td>90 days</td></tr><tr><td>Event routing</td><td>—</td><td>✓ (extract transforms)</td><td>✓ (all transforms)</td></tr><tr><td>Dead letter queue</td><td>—</td><td>✓</td><td>✓</td></tr><tr><td>Custom headers</td><td>—</td><td>✓</td><td>✓</td></tr><tr><td>Custom domains</td><td>—</td><td>—</td><td>✓</td></tr><tr><td>Priority delivery</td><td>—</td><td>—</td><td>✓</td></tr><tr><td>Team members</td><td>—</td><td>✓</td><td>✓</td></tr><tr><td>Analytics</td><td>Basic</td><td>30-day</td><td>90-day</td></tr></tbody></table>
+<table><thead><tr><th>Feature</th><th>Paper Plane (Free)</th><th>Warbird ($19/mo)</th><th>Stealth Jet ($89/mo)</th></tr></thead><tbody><tr><td>Events/month</td><td>25,000</td><td>100,000</td><td>1,000,000</td></tr><tr><td>Endpoints</td><td>3</td><td>10</td><td>Unlimited</td></tr><tr><td>Payload size</td><td>64 KB</td><td>256 KB</td><td>1 MB</td></tr><tr><td>Rate limit</td><td>10 req/s</td><td>50 req/s</td><td>100 req/s</td></tr><tr><td>Retention</td><td>7 days</td><td>30 days</td><td>90 days</td></tr><tr><td>Event routing</td><td>—</td><td>✓ (extract transforms)</td><td>✓ (all transforms)</td></tr><tr><td>Dead letter queue</td><td>—</td><td>✓</td><td>✓</td></tr><tr><td>Custom headers</td><td>—</td><td>✓</td><td>✓</td></tr><tr><td>Custom domains</td><td>—</td><td>—</td><td>✓</td></tr><tr><td>Priority delivery</td><td>—</td><td>—</td><td>✓</td></tr><tr><td>Team members</td><td>—</td><td>✓</td><td>✓</td></tr><tr><td>Analytics</td><td>Basic</td><td>30-day</td><td>90-day</td></tr></tbody></table>
 <h2 id="query-pricing-public">Query Pricing (Public)</h2>
 <p>Get machine-readable pricing without authentication:</p>
 <pre><code class="hljs language-bash">curl https://api.hookwing.com/api/pricing</code></pre>

--- a/website/docs/webhooks/index.html
+++ b/website/docs/webhooks/index.html
@@ -124,7 +124,7 @@
         <p class="lede">How Hookwing signs deliveries and how to verify them in your application.</p>
         <h2 id="how-hookwing-signs-deliveries">How Hookwing Signs Deliveries</h2>
 <p>Every webhook delivery includes two verification headers:</p>
-<table><thead><tr><th>Header</th><th>Value</th></tr></thead><tbody><tr><td><code>X-Hookwing-Signature</code></td><td><code>sha256=&amp;lt;hex-encoded HMAC-SHA256&amp;gt;</code></td></tr><tr><td><code>X-Hookwing-Timestamp</code></td><td>Unix timestamp in milliseconds</td></tr></tbody></table>
+<table><thead><tr><th>Header</th><th>Value</th></tr></thead><tbody><tr><td><code>X-Hookwing-Signature</code></td><td><code>sha256=&lt;hex-encoded HMAC-SHA256&gt;</code></td></tr><tr><td><code>X-Hookwing-Timestamp</code></td><td>Unix timestamp in milliseconds</td></tr></tbody></table>
 <p>The signature is computed over the raw request body using your endpoint&#39;s signing secret.</p>
 <h3 id="verification-steps">Verification Steps</h3>
 <ol>


### PR DESCRIPTION
## Summary

- **`/docs/webhooks/`** — Double-encoded HTML entities in the signature header table: `&amp;lt;` was rendering as literal text `&lt;hex-encoded HMAC-SHA256&gt;` instead of `<hex-encoded HMAC-SHA256>`. Simple `&amp;lt;` → `&lt;` fix.

- **`/docs/billing/`** — Tier limits were stale vs the pricing page (diverged since the Apr 3 update). Fixed to match `/pricing/`:
  - Events/month: 10k/500k/unlimited → **25k/100k/1M**
  - Payload size: 64KB/64KB/256KB → **64KB/256KB/1MB**
  - Updated "last updated" date to 2026-04-21

## Found by

Daily UX regression check (2026-04-21) — deep check rotation: `/docs/authentication/`, `/docs/endpoints/`, `/docs/webhooks/`

## Test plan

- [ ] `/docs/webhooks/` — verify signature header table shows `sha256=<hex-encoded HMAC-SHA256>` in browser
- [ ] `/docs/billing/` — verify tier table numbers match `/pricing/` page
- [ ] No other pages affected (isolated to these two files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)