### PR TITLE
fix(ux): remove broken theme toggle script from use-cases page

### DIFF
--- a/website/use-cases/index.html
+++ b/website/use-cases/index.html
@@ -642,7 +642,6 @@ agent.process(event.payload)</code></pre>
     </div>
   </footer>
 
-  <!-- Theme toggle -->
 <!-- Mobile nav script -->
   <script>
     (function() {
@@ -656,15 +655,6 @@ agent.process(event.payload)</code></pre>
           document.body.style.overflow = expanded ? '' : 'hidden';
         });
       }
-    })();
-  </script>
-
-  <!-- Theme toggle script -->
-  <script>
-    (function() {
-      const html = document.documentElement;
-      if (btn) {
-
     })();
   </script>
 


### PR DESCRIPTION
## Summary
- `/use-cases/index.html` had a dead script block that referenced `btn` without declaring it, throwing `ReferenceError: btn is not defined` in the browser console on every page load
- The script was a stale leftover from a partially-removed theme toggle feature — `const html` declared but unused, `if (btn)` body empty
- No other page was affected (confirmed via repo-wide grep)

## Root cause
Partial cleanup of a theme toggle feature — the `<script>` block was hollowed out but not fully removed.

## Fix
Removed the 9-line dead script block and its accompanying stale comment.

## Test plan
- [ ] Load `/use-cases/` in browser — no JS console errors
- [ ] Confirm page renders identically (no visible change — script was dead)
- [ ] Run grep: `grep -r "if (btn)" website --include="*.html"` → 0 matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)